### PR TITLE
Fix: Configure secure session cookie via environment variable

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/RODA.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/RODA.java
@@ -233,11 +233,13 @@ public class RODA {
 
   @Bean
   public ServletContextInitializer servletContextInitializer() {
-    return new ServletContextInitializer() {
+    String secureString = System.getenv("ETERNA_SESSION_COOKIE_SECURE");
+    Boolean secure = secureString != null ? Boolean.parseBoolean(secureString) : true;
 
+    return new ServletContextInitializer() {
       @Override
       public void onStartup(ServletContext servletContext) throws ServletException {
-        servletContext.getSessionCookieConfig().setSecure(true);
+        servletContext.getSessionCookieConfig().setSecure(secure);
         servletContext.getSessionCookieConfig().setHttpOnly(true);
       }
     };


### PR DESCRIPTION
The session cookie's secure flag can now be configured using the `ETERNA_SESSION_COOKIE_SECURE` environment variable. If the variable is not set, the cookie defaults to secure (HTTPS only). The HTTPOnly flag is always enabled.