### PR TITLE
fix: Align browser tab titles with view content and refine navigation

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
@@ -89,7 +89,7 @@ public class DisposalConfirmationActions extends AbstractActionable<DisposalConf
     ActionableGroup<DisposalConfirmation> actionsGroup = new ActionableGroup<>(messages.sidebarActionsTitle());
 
     actionsGroup.addButton(messages.newDisposalConfirmationButton(), DisposalConfirmationAction.NEW,
-      ActionImpact.UPDATED, "btn-plus-circle");
+      ActionImpact.UPDATED);
 
     confirmationActionableBundle.addGroup(actionsGroup);
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionButton.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionButton.java
@@ -41,18 +41,23 @@ public class ActionButton<T extends IsIndexed> extends Composite implements HasE
     addStyleDependentName(actionButton.getImpact().toString().toLowerCase());
     setEnabled(true);
 
-    String iconClass = "fa fa-question-circle";
+    String iconClass = null;
     for (String possibleIcon : actionButton.getExtraCssClasses()) {
       if (possibleIcon.startsWith("btn-")) {
         iconClass = possibleIcon.replaceFirst("btn-", "fa fa-");
+        break;
       } else if (possibleIcon.startsWith("fas fa-") || possibleIcon.startsWith("far fa-")
         || possibleIcon.startsWith("fal fa-")) {
         iconClass = possibleIcon;
+        break;
       }
     }
-    HTMLPanel icon = new HTMLPanel(SafeHtmlUtils.fromSafeConstant("<i class='" + iconClass + "'></i>"));
-    icon.addStyleName("actionable-button-icon");
-    button.add(icon);
+
+    if (iconClass != null) { // Only add an icon if one was specified
+      HTMLPanel icon = new HTMLPanel(SafeHtmlUtils.fromSafeConstant("<i class='" + iconClass + "'></i>"));
+      icon.addStyleName("actionable-button-icon");
+      button.add(icon);
+    }
 
     label = new Label(actionButton.getText());
     label.addStyleName("actionable-button-label");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/Disposal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/Disposal.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.disposal.association.DisposalPolicyAssociationPanel;
+import org.roda.wui.client.disposal.confirmations.CreateDisposalConfirmation;
 import org.roda.wui.client.disposal.policy.DisposalPolicy;
 import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.HistoryUtils;
@@ -33,8 +34,9 @@ public class Disposal {
 
     @Override
     public void isCurrentUserPermitted(AsyncCallback<Boolean> callback) {
-      UserLogin.getInstance().checkRoles(new HistoryResolver[] {DisposalPolicy.RESOLVER, DisposalConfirmations.RESOLVER,
-        DisposalDestroyedRecords.RESOLVER}, false, callback);
+      UserLogin.getInstance()
+          .checkRoles(new HistoryResolver[] { DisposalPolicy.RESOLVER, DisposalConfirmations.RESOLVER,
+              DisposalDestroyedRecords.RESOLVER }, false, callback);
 
     }
 
@@ -78,6 +80,8 @@ public class Disposal {
       DisposalPolicy.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
     } else if (historyTokens.get(0).equals(DisposalConfirmations.RESOLVER.getHistoryToken())) {
       DisposalConfirmations.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
+    } else if (historyTokens.get(0).equals(CreateDisposalConfirmation.RESOLVER.getHistoryToken())) {
+      CreateDisposalConfirmation.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
     } else if (historyTokens.get(0).equals(DisposalDestroyedRecords.RESOLVER.getHistoryToken())) {
       DisposalDestroyedRecords.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
     } else if (historyTokens.get(0).equals(DisposalPolicyAssociationPanel.RESOLVER.getHistoryToken())) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
@@ -132,8 +132,6 @@ public class DisposalConfirmations extends Composite {
       String basePage = historyTokens.remove(0);
       if (ShowDisposalConfirmation.RESOLVER.getHistoryToken().equals(basePage)) {
         ShowDisposalConfirmation.RESOLVER.resolve(historyTokens, callback);
-      } else if (CreateDisposalConfirmation.RESOLVER.getHistoryToken().equals(basePage)) {
-        CreateDisposalConfirmation.RESOLVER.resolve(historyTokens, callback);
       }
     }
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
@@ -29,7 +29,7 @@ import org.roda.wui.client.common.lists.utils.AsyncTableCellOptions;
 import org.roda.wui.client.common.lists.utils.ConfigurableAsyncTableCell;
 import org.roda.wui.client.common.lists.utils.ListBuilder;
 import org.roda.wui.client.common.search.SearchWrapper;
-import org.roda.wui.client.disposal.DisposalConfirmations;
+import org.roda.wui.client.disposal.Disposal;
 import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.ListUtils;
 import org.roda.wui.common.client.widgets.HTMLWidgetWrapper;
@@ -85,12 +85,12 @@ public class CreateDisposalConfirmation extends Composite {
 
     @Override
     public List<String> getHistoryPath() {
-      return ListUtils.concat(DisposalConfirmations.RESOLVER.getHistoryPath(), getHistoryToken());
+      return ListUtils.concat(Disposal.RESOLVER.getHistoryPath(), getHistoryToken());
     }
 
     @Override
     public String getHistoryToken() {
-      return "create_confirmation";
+      return "overdue_records";
     }
   };
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Menu.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Menu.java
@@ -215,7 +215,7 @@ public class Menu extends Composite {
     disposalConfirmation = disposalMenu.addItem(messages.title("disposal_confirmations"),
       createCommand(DisposalConfirmations.RESOLVER.getHistoryPath()));
     disposalConfirmation.addStyleName("disposal_confirmation_item");
-    overdueActions = disposalMenu.addItem(messages.title("overdue_actions"),
+    overdueActions = disposalMenu.addItem(messages.title("disposal_overdue_actions"),
       createCommand(CreateDisposalConfirmation.RESOLVER.getHistoryPath()));
     overdueActions.addStyleName("overdue_actions_item");
     disposalDestroyedRecords = disposalMenu.addItem(messages.title("disposal_destroyed_records"),

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1481,7 +1481,7 @@ permanentlyDeleteFromBinButton:Permanently delete
 reExecuteDisposalDestroyActionButton:Re-execute destruction
 recoverDisposalConfirmationExecutionFailedButton:Recover AIPs
 restoreFromBinButton:Restore
-newDisposalConfirmationButton:New confirmation
+newDisposalConfirmationButton:Go to Overdue records
 disassociateDisposalScheduleButton:Disassociate schedule
 disassociateDisposalHoldButton:Disassociate hold
 associateDisposalScheduleButton:Associate disposal schedule

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1001,7 +1001,7 @@ title[disposal_policy]:Disposal policies
 title[disposal_policies]:Disposal policies
 title[disposal_confirmations]:Disposal confirmations
 title[disposal_overdue_records]:Overdue records
-title[overdue_actions]:Overdue records
+title[disposal_overdue_actions]:Overdue records
 title[disposal_destroyed]:Destroyed records
 title[disposal_destroyed_records]:Destroyed records
 title[planning]:Planning
@@ -1413,7 +1413,7 @@ disposalSchedulesTitle:Disposal schedules
 disposalHoldsTitle:Disposal holds
 disposalDestroyedRecordsTitle:Destroyed records
 disposalConfirmationsTitle:Disposal confirmations
-createDisposalConfirmationTitle:Create disposal confirmation
+createDisposalConfirmationTitle:Overdue records
 createDisposalConfirmationExtraInformationTitle:Disposal confirmation metadata information
 disposalScheduleTitle:Title
 disposalScheduleIdentifier:Identifier

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -960,6 +960,7 @@ output:Output
 # Menu
 title:
 title[home]:Homepage
+title[welcome]:Welcome
 title[preferences]:Preferences
 title[register]:Register
 title[verifyEmail]:Verify Email
@@ -973,6 +974,8 @@ title[search]:Search
 title[help]:Help
 title[administration]:Administration
 title[administration_actions]:Preservation actions
+title[administration_process]:Preservation actions
+title[administration_internal]:Internal actions
 title[administration_internal_actions]:Internal actions
 title[administration_disposal]:Disposal
 title[administration_user]:Users and groups
@@ -992,20 +995,30 @@ title[administration_local_instance_configuration]:Local Instance
 title[administration_access_keys]:Access Keys
 title[administration_monitoring]:Monitoring
 title[administration_market_place]:Marketplace
+title[administration_reporting]:Reporting
 title[disposal]:Disposal
+title[disposal_policy]:Disposal policies
 title[disposal_policies]:Disposal policies
 title[disposal_confirmations]:Disposal confirmations
+title[disposal_overdue_records]:Overdue records
 title[overdue_actions]:Overdue records
+title[disposal_destroyed]:Destroyed records
 title[disposal_destroyed_records]:Destroyed records
 title[planning]:Planning
 title[planning_monitoring]:Internal monitoring
 title[planning_risk]:Risk register
 title[planning_representation_information]:Representation network
+title[planning_representation_information_register]:Representation network
 title[planning_event]:Preservation events
+title[planning_events]:Preservation events
 title[planning_agent]:Preservation agents
+title[planning_agents]:Preservation agents
 title[planning_format]:Format register
+title[planning_riskregister]:Risk register
 title[ingest]:Ingest
+title[ingest_pre]:Pre-ingest
 title[ingest_preIngest]:Pre-ingest
+title[ingest_process]:Ingest process
 title[ingest_transfer]:Transfer
 title[ingest_submit]:Submit
 title[ingest_submit_upload]:Send packet
@@ -1015,6 +1028,7 @@ title[ingest_help]:Help
 title[ingest_appraisal]:Assessment
 title[settings]:Settings
 title[language]:Language
+title[profile]:Profile
 # Login Panel
 loginLogout:Logout
 loginProfile:Profile

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -998,7 +998,7 @@ title[disposal_policy]:Gallringspolicyer
 title[disposal_policies]:Gallringspolicyer
 title[disposal_confirmations]:Gallringsbekräftelser
 title[disposal_overdue_records]:Förfallna gallringar
-title[overdue_actions]:Förfallna gallringar
+title[disposal_overdue_actions]:Förfallna gallringar
 title[disposal_destroyed]:Gallrade objekt
 title[disposal_destroyed_records]:Gallrade objekt
 title[planning]:Planering

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1478,7 +1478,7 @@ permanentlyDeleteFromBinButton:Ta bort permanent
 reExecuteDisposalDestroyActionButton:Utför gallring igen
 recoverDisposalConfirmationExecutionFailedButton:Återställ AIP:er
 restoreFromBinButton:Återställ
-newDisposalConfirmationButton:Ny bekräftelse
+newDisposalConfirmationButton:Gå till Förfallna gallringar
 disassociateDisposalScheduleButton:Koppla loss schema
 disassociateDisposalHoldButton:Koppla loss stopp
 associateDisposalScheduleButton:Koppla gallringsschema

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -957,6 +957,7 @@ output:Utdata
 # Menu
 title:
 title[home]:Hemsida
+title[welcome]: Välkommen
 title[preferences]:Inställningar
 title[register]:Registrera
 title[verifyEmail]:Verifiera e-post
@@ -970,6 +971,8 @@ title[search]:Sök
 title[help]:Hjälp
 title[administration]:Administration
 title[administration_actions]:Arkivvårdsjobb
+title[administration_process]:Arkivvårdsjobb
+title[administration_internal]:Interna åtgärder
 title[administration_internal_actions]:Interna åtgärder
 title[administration_disposal]:Gallring
 title[administration_user]:Användare och grupper
@@ -989,20 +992,30 @@ title[administration_local_instance_configuration]:Lokal Instans
 title[administration_access_keys]:Åtkomstnycklar
 title[administration_monitoring]:Övervakning
 title[administration_market_place]:Marknad
+title[administration_reporting]:Rapportering
 title[disposal]:Gallring
+title[disposal_policy]:Gallringspolicyer
 title[disposal_policies]:Gallringspolicyer
 title[disposal_confirmations]:Gallringsbekräftelser
+title[disposal_overdue_records]:Förfallna gallringar
 title[overdue_actions]:Förfallna gallringar
+title[disposal_destroyed]:Gallrade objekt
 title[disposal_destroyed_records]:Gallrade objekt
 title[planning]:Planering
 title[planning_monitoring]:Intern övervakning
 title[planning_risk]:Riskregister
 title[planning_representation_information]:Representationsnätverk
+title[planning_representation_information_register]:Representationsnätverk
 title[planning_event]:Bevarandehändelser
+title[planning_events]:Händelseregister
 title[planning_agent]:Bevarandeaktör
+title[planning_agents]:Bevarandeaktör
 title[planning_format]:Formatregister
+title[planning_riskregister]:Riskregister
 title[ingest]:Leverans
+title[ingest_pre]:Leveransförberedelse
 title[ingest_preIngest]:Leveransförberedelse
+title[ingest_process]:Inleveransprocess
 title[ingest_transfer]:Inleverans
 title[ingest_submit]:Lämna in
 title[ingest_submit_upload]:Skicka paket
@@ -1012,6 +1025,7 @@ title[ingest_help]:Hjälp
 title[ingest_appraisal]:Ankomstkontroll
 title[settings]:Inställningar
 title[language]:Språk
+title[profile]:Profil
 # Login Panel
 loginLogout:Logga ut
 loginProfile:Profil


### PR DESCRIPTION
### Key Changes:

1.  **i18n Title Key Updates (Swedish & English):**
    *   **What:** Added, updated, and modified various title keys in the `i18n` properties files for both Swedish and English.
    *   **Why:** To ensure that the text displayed in the browser tab dynamically updates to match the content of the currently active view within the application. This provides better context for users, especially when working with multiple tabs.

2.  **Overdue Records Route Refinement:**
    *   **What:** The route for "overdue records" has been restructured.
        *   **Old Route:** `/disposal/confirmations/create_confirmation`
        *   **New Route:** `/disposal/overdue_records`
    *   **Why:** This simplifies the URL structure, makes it more intuitive, and contributes to the consistency of browser tab titles for this section.

3.  **Sidebar Action Button Text & Icon Handling Update:**
    *   **What:**
        *   The text on action button in the sidebar changed to better reflect the navigation target with same view title and removed icon.
        *   The underlying  `ActionButton` component included in the action sidebar was updated to gracefully handle cases where an icon class string (e.g., via an `extraCss` prop) is not provided or is `null`.
    *   **Why:**
        *   The icon handling update makes the component more robust, preventing rendering issues if an icon isn't specified.
