### PR TITLE
Feat/configurable indexing of preservation events

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
+import org.roda.core.RodaCoreFactory;
 import org.roda.core.common.iterables.CloseableIterable;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.AuthorizationDeniedException;
@@ -110,10 +111,13 @@ public class IndexModelObserver implements ModelObserver {
   private final SolrClient index;
   private final ModelService model;
 
+  private final boolean indexPreservationEvents;
+
   public IndexModelObserver(SolrClient index, ModelService model) {
     super();
     this.index = index;
     this.model = model;
+    this.indexPreservationEvents = RodaCoreFactory.getRodaConfiguration().getBoolean("core.index.preservation_event.enable", true);
   }
 
   @Override
@@ -216,6 +220,11 @@ public class IndexModelObserver implements ModelObserver {
 
   private ReturnWithExceptions<Void, ModelObserver> indexPreservationEvent(PreservationMetadata pm) {
     ReturnWithExceptions<Void, ModelObserver> ret = new ReturnWithExceptions<>(this);
+
+    if (!indexPreservationEvents) {
+      return ret;
+    }
+
     AIP aip = null;
     try {
       if (pm.getAipId() != null) {

--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -281,6 +281,8 @@ core.notification.package = org.roda.core.plugins.base.notifications
 ##########################################################################
 #core.index.fulltext_threshold_in_bytes = 104857600
 
+core.index.preservation_event.enable = true
+
 ##########################################################################
 # Plug-in/Tasks general settings
 #


### PR DESCRIPTION
This PR makes the indexing of preservation events optional and configurable with the default turned on.
Previously it was always turned on.

Background:
For every SIP ingested we noticed an average of 7 Preservation Events. In large archives this eats up a lot of SOLR index space both on disk and in RAM, up to 33% of the entire index was used by preservation events forcing earlier scale outs. This change makes it possible to disable indexing of Preservation Events, as a consequence for disabling indexing, they're no longer visible in the UI and not searchable.