### PR TITLE
Fix array out of bounds errors in URNUtils

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
@@ -162,7 +162,7 @@ public final class URNUtils {
 
   public static String extractFileIdFromId(String id) {
     String[] fields = id.split(RodaConstants.URN_SEPARATOR);
-    String fileId = fields[URN_FILE_ID_POSITION];
+    String fileId = fields.length > URN_FILE_ID_POSITION ? fields[URN_FILE_ID_POSITION] : id;
     if (fileId.toLowerCase().endsWith(".xml")) {
       fileId = fileId.substring(0, fileId.length() - 4);
     }
@@ -172,7 +172,8 @@ public final class URNUtils {
 
   public static boolean hasInstanceId(String id) {
     String[] fields = id.split(RodaConstants.URN_SEPARATOR);
-    return !fields[URN_INSTANCE_IDENTIFIER_POSITION].equals(RodaConstants.PREMIS_METADATA_TYPE);
+    return fields.length > URN_INSTANCE_IDENTIFIER_POSITION
+      && !fields[URN_INSTANCE_IDENTIFIER_POSITION].equals(RodaConstants.PREMIS_METADATA_TYPE);
   }
 
   public static boolean verifyPremisPrefix(PreservationMetadataType type, String filename) {


### PR DESCRIPTION
URNUtils.hasInstanceId would throw an ArrayIndexOutOfBoundsException When verifyPremisPrefix was called on a filename containing fewer than two (URN_INSTANCE_IDENTIFIER_POSITION) colons (RodaConstants.URN_SEPARATOR).

This PR fixes that issue.