### PR TITLE
Fix communication with SOLR over TLS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
         <swagger.version>2.2.21</swagger.version>
         <jackson.version>2.17.0</jackson.version>
         <spring.version>6.1.12</spring.version>
-        <solr.version>9.6.0</solr.version>
         <pekko.version>1.0.2</pekko.version>
         <solr.version>9.7.0</solr.version>
         <apacheds.version>2.0.0.AM27</apacheds.version>
@@ -475,6 +474,11 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
+                <version>10.0.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-client</artifactId>
                 <version>10.0.19</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Fix communication with SOLR over TLS. The reason it didn't work was that the dependencies jetty-io & jetty-alpn-java-client had different versions.