### PR TITLE
Show full node/aip path when moving an AIP or searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added missing `[one]` pluralization keys in Swedish localization file and corrected a typo
 - Replaced Unicode escapes with literal HTML tags in Swedish client messages
 
+### Improvements
+- Added a Path column to the Move/Search AIP popup to display the full hierarchy of each AIP. This helps users clearly distinguish between AIPs with identical Level and Title, reducing confusion when selecting a target AIP for move operations.
+
 ## v0.5.0 (2025-12-16)
 #### Updates
 - Added Swedish and English SVG credentials images

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1001,7 +1001,7 @@ public final class RodaConstants {
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_INTERVAL = "retentionPeriodInterval";
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_DETAILS = "retentionPeriodDetails";
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_CALCULATION = "retentionPeriodCalculation";
-
+  public static final String AIP_ANCESTORS_LIST = "allAncestorList";
   // AIP types
   public static final String AIP_TYPE_MIXED = "MIXED";
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedAIP.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedAIP.java
@@ -96,6 +96,7 @@ public class IndexedAIP implements IsIndexed, HasId, HasPermissions, HasState, H
 
   private String disposalConfirmationId = null;
 
+  private List<ParentAncestorMap> parentAncestorsList = null;
   /**
    * Constructs an empty (<strong>invalid</strong>) {@link IndexedAIP}.
    */
@@ -118,7 +119,7 @@ public class IndexedAIP implements IsIndexed, HasId, HasPermissions, HasState, H
       other.getRetentionPeriodDuration(), other.getRetentionPeriodInterval(), other.getRetentionPeriodStartDate(),
       other.getRetentionPeriodDetails(), other.getRetentionPeriodState(), other.getDisposalHoldsId(),
       other.getTransitiveDisposalHoldsId(), other.getDestroyedOn(), other.getDestroyedBy(),
-      other.getDisposalConfirmationId(), other.getScheduleAssociationType());
+      other.getDisposalConfirmationId(), other.getScheduleAssociationType(), other.getParentAncestorsList());
   }
 
   /**
@@ -140,7 +141,7 @@ public class IndexedAIP implements IsIndexed, HasId, HasPermissions, HasState, H
     String disposalScheduleName, Integer retentionPeriodDuration, RetentionPeriodIntervalCode retentionPeriodInterval,
     Date retentionPeriodStartDate, String retentionPeriodDetails, RetentionPeriodCalculation retentionPeriodCalculation,
     List<String> disposalHoldsId, List<String> transitiveDisposalHoldsId, Date destroyedOn, String destroyedBy,
-    String disposalConfirmationId, AIPDisposalScheduleAssociationType scheduleAssociationType) {
+    String disposalConfirmationId, AIPDisposalScheduleAssociationType scheduleAssociationType, List<ParentAncestorMap> parentAncestorsList) {
     super();
     this.id = id;
     this.state = state;
@@ -174,6 +175,7 @@ public class IndexedAIP implements IsIndexed, HasId, HasPermissions, HasState, H
     this.destroyedBy = destroyedBy;
     this.disposalConfirmationId = disposalConfirmationId;
     this.scheduleAssociationType = scheduleAssociationType;
+    this.parentAncestorsList = parentAncestorsList;
   }
 
   public Long getNumberOfSubmissionFiles() {
@@ -570,6 +572,14 @@ public class IndexedAIP implements IsIndexed, HasId, HasPermissions, HasState, H
 
   public void setFields(Map<String, Object> fields) {
     this.fields = fields;
+  }
+
+  public List<ParentAncestorMap> getParentAncestorsList() {
+    return parentAncestorsList;
+  }
+
+  public void setParentAncestorsList(List<ParentAncestorMap> parentAncestorsList) {
+    this.parentAncestorsList = parentAncestorsList;
   }
 
   @Override

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ParentAncestorMap.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ParentAncestorMap.java
@@ -1,0 +1,20 @@
+package org.roda.core.data.v2.ip;
+
+import java.io.Serializable;
+
+public class ParentAncestorMap implements Serializable {
+    private String ancestorId;
+    private String title;
+    public ParentAncestorMap() {}
+
+    public ParentAncestorMap(String ancestorId, String title) {
+        this.ancestorId = ancestorId;
+        this.title = title;
+    }
+
+    public String getAncestorId() { return ancestorId; }
+    public void setAncestorId(String id) { this.ancestorId = id; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexService.java
@@ -173,8 +173,12 @@ public class IndexService {
   public <T extends IsIndexed> IndexResult<T> find(Class<T> returnClass, Filter filter, Sorter sorter, Sublist sublist,
     Facets facets, User user, boolean justActive, final List<String> fieldsToReturn)
     throws GenericException, RequestNotValidException {
+    boolean includeAipFullPath = IndexedAIP.class.equals(returnClass)
+            && fieldsToReturn != null
+            && fieldsToReturn.contains(RodaConstants.AIP_ANCESTORS_LIST);
+
     return SolrUtils.find(getSolrClient(), returnClass, filter, sorter, sublist, facets, user, justActive,
-      fieldsToReturn);
+            fieldsToReturn, includeAipFullPath);
   }
 
   public <T extends IsIndexed> IterableIndexResult<T> findAll(final Class<T> returnClass, final Filter filter,

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.data.common.RodaConstants;
@@ -394,6 +395,17 @@ public class AIPCollection extends AbstractSolrCollection<IndexedAIP, AIP> {
     ret.setOnHold(disposalHoldStatus);
     ret.setDisposalConfirmationId(disposalConfirmationId);
     ret.setDisposalScheduleAssociationType(aipDisposalScheduleAssociationType);
+    if (fieldsToReturn.contains("path_docs") && doc.get("path_docs") instanceof SolrDocumentList) {
+      SolrDocumentList pathDocsList = (SolrDocumentList) doc.get("path_docs");
+      List<Map<String, Object>> serializablePathDocs = new ArrayList<>();
+      for (SolrDocument pathDoc : pathDocsList) {
+        Map<String, Object> pathDocMap = new HashMap<>();
+        pathDocMap.put("id", pathDoc.get("id"));
+        pathDocMap.put("title", pathDoc.get("title"));
+        serializablePathDocs.add(pathDocMap);
+      }      
+      ret.getFields().put("path_docs", serializablePathDocs);
+    }
 
     return ret;
   }

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
@@ -24,10 +24,7 @@ import org.roda.core.data.exceptions.AuthorizationDeniedException;
 import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
-import org.roda.core.data.v2.ip.AIP;
-import org.roda.core.data.v2.ip.AIPDisposalScheduleAssociationType;
-import org.roda.core.data.v2.ip.IndexedAIP;
-import org.roda.core.data.v2.ip.Representation;
+import org.roda.core.data.v2.ip.*;
 import org.roda.core.data.v2.ip.disposal.DisposalActionCode;
 import org.roda.core.data.v2.ip.disposal.DisposalSchedule;
 import org.roda.core.data.v2.ip.disposal.RetentionPeriodCalculation;
@@ -354,7 +351,7 @@ public class AIPCollection extends AbstractSolrCollection<IndexedAIP, AIP> {
       .objectToString(doc.get(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_DETAILS), null);
     final RetentionPeriodCalculation retentionPeriodCalculation = SolrUtils.objectToEnum(
       doc.get(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_CALCULATION), RetentionPeriodCalculation.class, null);
-
+    final List<ParentAncestorMap> parentAncestorsList;
     String level;
     if (ghost) {
       level = RodaConstants.AIP_GHOST;
@@ -395,16 +392,10 @@ public class AIPCollection extends AbstractSolrCollection<IndexedAIP, AIP> {
     ret.setOnHold(disposalHoldStatus);
     ret.setDisposalConfirmationId(disposalConfirmationId);
     ret.setDisposalScheduleAssociationType(aipDisposalScheduleAssociationType);
-    if (fieldsToReturn.contains("path_docs") && doc.get("path_docs") instanceof SolrDocumentList) {
-      SolrDocumentList pathDocsList = (SolrDocumentList) doc.get("path_docs");
-      List<Map<String, Object>> serializablePathDocs = new ArrayList<>();
-      for (SolrDocument pathDoc : pathDocsList) {
-        Map<String, Object> pathDocMap = new HashMap<>();
-        pathDocMap.put("id", pathDoc.get("id"));
-        pathDocMap.put("title", pathDoc.get("title"));
-        serializablePathDocs.add(pathDocMap);
-      }      
-      ret.getFields().put("path_docs", serializablePathDocs);
+    if (fieldsToReturn.contains(RodaConstants.AIP_ANCESTORS_LIST) && doc.get(RodaConstants.AIP_ANCESTORS_LIST) instanceof SolrDocumentList) {
+      parentAncestorsList = SolrUtils.objectToParentAncestorList((SolrDocumentList) doc.get(RodaConstants.AIP_ANCESTORS_LIST));
+      ret.setParentAncestorsList(parentAncestorsList);
+      ret.getFields().remove(RodaConstants.AIP_ANCESTORS_LIST);
     }
 
     return ret;

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -150,7 +150,6 @@ public class SolrUtils {
     RodaConstants.AIP_LEVEL, RodaConstants.AIP_DATE_INITIAL, RodaConstants.AIP_DATE_FINAL));
 
   private static Map<String, List<String>> liteFieldsForEachClass = new HashMap<>();
-
   public static final String COMMON = "common";
   public static final String CONF = "conf";
   public static final String SCHEMA = "managed-schema.xml";
@@ -260,7 +259,6 @@ public class SolrUtils {
     } catch (NotSupportedException e) {
       throw new GenericException("Could not query index", e);
     }
-
     return ret;
   }
 
@@ -280,7 +278,6 @@ public class SolrUtils {
   public static <T extends IsIndexed> Pair<IndexResult<T>, String> find(SolrClient index, Class<T> classToRetrieve,
     Filter filter, int pageSize, String cursorMark, User user, boolean justActive, List<String> fieldsToReturn)
     throws GenericException, RequestNotValidException {
-
     Pair<IndexResult<T>, String> ret;
     SolrQuery query = new SolrQuery();
     query.setParam("q.op", DEFAULT_QUERY_PARSER_OPERATOR);
@@ -334,19 +331,24 @@ public class SolrUtils {
     query.setSorts(parseSorter(sorter));
     query.setStart(sublist.getFirstElementIndex());
     query.setRows(sublist.getMaximumElementCount());
-    query.setFields(fieldsToReturn.toArray(new String[fieldsToReturn.size()]));
+    List<String> fl = new ArrayList<>(fieldsToReturn);
+    if (!fl.contains("ancestors")) {
+      fl.add("ancestors");
+    }
+    fl.add("path_docs:[subquery]");
+    query.setFields(fl.toArray(new String[0]));
+    query.set("path_docs.q", "{!terms f=id v=$row.ancestors}");
+    query.set("path_docs.fl", "id,title");
     parseAndConfigureFacets(facets, query);
     if (hasPermissionFilters(classToRetrieve)) {
       query.addFilterQuery(getFilterQueries(user, justActive, classToRetrieve));
     }
-
     try {
       QueryResponse response = query(index, classToRetrieve, query);
       ret = queryResponseToIndexResult(response, classToRetrieve, facets, fieldsToReturn);
     } catch (NotSupportedException e) {
       throw new GenericException("Could not query index", e);
     }
-
     return ret;
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -144,6 +144,13 @@ public class SolrUtils {
   public static final String COMMON = "common";
   public static final String CONF = "conf";
   public static final String SCHEMA = "managed-schema.xml";
+  // This is a workaround to get the ancestors of an AIP in the same query, without having to do a separate query for each result
+  private static final String ANCESTOR_SUBQUERY_ALIAS = "allAncestorList";
+  private static final String ANCESTOR_SUBQUERY_FIELD = ANCESTOR_SUBQUERY_ALIAS + ":[subquery]";
+  private static final String ANCESTOR_SUBQUERY_PARAM = ANCESTOR_SUBQUERY_ALIAS + ".q";
+  private static final String ANCESTOR_SUBQUERY_FIELDS_PARAM = ANCESTOR_SUBQUERY_ALIAS + ".fl";
+  private static final String ANCESTOR_SUBQUERY = "{!terms f=id v=$row." + RodaConstants.AIP_ANCESTORS + "}";
+  private static final String ANCESTOR_SUBQUERY_RETURN_FIELDS = "id,title";
 
   private SolrUtils() {
     // do nothing
@@ -352,13 +359,14 @@ public class SolrUtils {
     query.setStart(sublist.getFirstElementIndex());
     query.setRows(sublist.getMaximumElementCount());
     List<String> fl = new ArrayList<>(fieldsToReturn);
-    if (!fl.contains("ancestors")) {
-      fl.add("ancestors");
+    if (!fl.contains(RodaConstants.AIP_ANCESTORS)) {
+      fl.add(RodaConstants.AIP_ANCESTORS);
     }
-    fl.add("allAncestorList:[subquery]");
+    fl.add(ANCESTOR_SUBQUERY_FIELD);
+
     query.setFields(fl.toArray(new String[0]));
-    query.set("allAncestorList.q", "{!terms f=id v=$row.ancestors}");
-    query.set("allAncestorList.fl", "id,title");
+    query.set(ANCESTOR_SUBQUERY_PARAM, ANCESTOR_SUBQUERY);
+    query.set(ANCESTOR_SUBQUERY_FIELDS_PARAM, ANCESTOR_SUBQUERY_RETURN_FIELDS);
     parseAndConfigureFacets(facets, query);
     if (hasPermissionFilters(classToRetrieve)) {
       query.addFilterQuery(getFilterQueries(user, justActive, classToRetrieve));

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -100,18 +101,8 @@ import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
 import org.roda.core.data.v2.index.sort.SortParameter;
 import org.roda.core.data.v2.index.sort.Sorter;
 import org.roda.core.data.v2.index.sublist.Sublist;
-import org.roda.core.data.v2.ip.AIP;
-import org.roda.core.data.v2.ip.AIPState;
-import org.roda.core.data.v2.ip.DIP;
-import org.roda.core.data.v2.ip.DIPFile;
-import org.roda.core.data.v2.ip.File;
-import org.roda.core.data.v2.ip.HasPermissionFilters;
-import org.roda.core.data.v2.ip.IndexedAIP;
-import org.roda.core.data.v2.ip.Permissions;
+import org.roda.core.data.v2.ip.*;
 import org.roda.core.data.v2.ip.Permissions.PermissionType;
-import org.roda.core.data.v2.ip.Representation;
-import org.roda.core.data.v2.ip.StoragePath;
-import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.ip.disposal.DisposalActionCode;
 import org.roda.core.data.v2.ip.disposal.DisposalSchedule;
 import org.roda.core.data.v2.ip.disposal.RetentionPeriodCalculation;
@@ -322,8 +313,37 @@ public class SolrUtils {
   }
 
   public static <T extends IsIndexed> IndexResult<T> find(SolrClient index, Class<T> classToRetrieve, Filter filter,
-    Sorter sorter, Sublist sublist, Facets facets, User user, boolean justActive, List<String> fieldsToReturn)
+                                                          Sorter sorter, Sublist sublist, Facets facets, User user, boolean justActive, List<String> fieldsToReturn)
+          throws GenericException, RequestNotValidException {
+    IndexResult<T> ret;
+    SolrQuery query = new SolrQuery();
+    query.setParam("q.op", DEFAULT_QUERY_PARSER_OPERATOR);
+    query.setQuery(parseFilter(filter));
+    query.setSorts(parseSorter(sorter));
+    query.setStart(sublist.getFirstElementIndex());
+    query.setRows(sublist.getMaximumElementCount());
+    query.setFields(fieldsToReturn.toArray(new String[fieldsToReturn.size()]));
+    parseAndConfigureFacets(facets, query);
+    if (hasPermissionFilters(classToRetrieve)) {
+      query.addFilterQuery(getFilterQueries(user, justActive, classToRetrieve));
+    }
+
+    try {
+      QueryResponse response = query(index, classToRetrieve, query);
+      ret = queryResponseToIndexResult(response, classToRetrieve, facets, fieldsToReturn);
+    } catch (NotSupportedException e) {
+      throw new GenericException("Could not query index", e);
+    }
+    return ret;
+  }
+
+  public static <T extends IsIndexed> IndexResult<T> find(SolrClient index, Class<T> classToRetrieve, Filter filter,
+    Sorter sorter, Sublist sublist, Facets facets, User user, boolean justActive, List<String> fieldsToReturn, boolean includeAipFullPath)
     throws GenericException, RequestNotValidException {
+
+    if (!includeAipFullPath) {
+      return find(index, classToRetrieve, filter, sorter, sublist, facets, user, justActive, fieldsToReturn);
+    }
     IndexResult<T> ret;
     SolrQuery query = new SolrQuery();
     query.setParam("q.op", DEFAULT_QUERY_PARSER_OPERATOR);
@@ -335,10 +355,10 @@ public class SolrUtils {
     if (!fl.contains("ancestors")) {
       fl.add("ancestors");
     }
-    fl.add("path_docs:[subquery]");
+    fl.add("allAncestorList:[subquery]");
     query.setFields(fl.toArray(new String[0]));
-    query.set("path_docs.q", "{!terms f=id v=$row.ancestors}");
-    query.set("path_docs.fl", "id,title");
+    query.set("allAncestorList.q", "{!terms f=id v=$row.ancestors}");
+    query.set("allAncestorList.fl", "id,title");
     parseAndConfigureFacets(facets, query);
     if (hasPermissionFilters(classToRetrieve)) {
       query.addFilterQuery(getFilterQueries(user, justActive, classToRetrieve));
@@ -1773,5 +1793,18 @@ public class SolrUtils {
     }
 
     return disposalSchedule;
+  }
+
+  public static List<ParentAncestorMap> objectToParentAncestorList(SolrDocumentList solrDocumentList){
+    List<ParentAncestorMap> parentAncestorMapList = null;
+    if(!solrDocumentList.isEmpty()){
+      parentAncestorMapList =  solrDocumentList.stream().map(c -> {
+        ParentAncestorMap map = new ParentAncestorMap();
+        map.setAncestorId((String) c.get("id"));
+        map.setTitle((String) c.get("title"));
+        return map;
+      }).collect(Collectors.toList());
+    }
+    return parentAncestorMapList;
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
@@ -97,6 +97,47 @@ public class ConfigurableAsyncTableCell<T extends IsIndexed> extends AsyncTableC
     DEFAULT_COLUMNS_FIELDS.put("default_IndexedAIP_hasrepresentations",
       Arrays.asList(RodaConstants.AIP_HAS_REPRESENTATIONS));
 
+    // ADD PATH COLUMN FOR AIPs
+    DEFAULT_COLUMNS.put("default_IndexedAIP_path", new TextColumn<IndexedAIP>() {
+      @Override
+      public String getValue(IndexedAIP aip) {
+        if (aip == null) {
+          return null;
+        }
+        @SuppressWarnings("unchecked")
+        List<String> ancestors = (List<String>) aip.getFields().get(RodaConstants.AIP_ANCESTORS);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> pathDocs = (List<Map<String, Object>>) aip.getFields().get("path_docs");
+        if (ancestors == null || ancestors.isEmpty()) {
+          return aip.getTitle() != null && !aip.getTitle().trim().isEmpty() ? "root/" + aip.getTitle() : "root/" + aip.getId();
+        }
+        List<String> pathParts = new ArrayList<>();
+        Map<String, String> ancestorTitles = new HashMap<>();
+        if (pathDocs != null) {
+          for (Map<String, Object> pathDoc : pathDocs) {
+            String id = (String) pathDoc.get("id");
+            String title = (String) pathDoc.get("title");
+            if (id != null) {
+              ancestorTitles.put(id, title != null && !title.trim().isEmpty() ? title : id);
+            }
+          }
+        }
+        List<String> reversedAncestors = new ArrayList<>(ancestors);
+        Collections.reverse(reversedAncestors);
+        pathParts.add("root");
+        for (String ancestorId : reversedAncestors) {
+          String ancestorName = ancestorTitles.get(ancestorId);
+          if (ancestorName == null) {
+            ancestorName = ancestorId; // Fallback to ID if title not available
+          }
+          pathParts.add(ancestorName);
+        }
+        String currentAipName = aip.getTitle() != null && !aip.getTitle().trim().isEmpty() ? aip.getTitle() : aip.getId();
+        pathParts.add(currentAipName);
+        return StringUtils.join(pathParts, " / ");
+      }
+    });
+    DEFAULT_COLUMNS_FIELDS.put("default_IndexedAIP_path", Arrays.asList("path", "path_docs", RodaConstants.AIP_ANCESTORS, RodaConstants.AIP_TITLE));
     /********************************************
      * Representations
      ********************************************/
@@ -277,6 +318,15 @@ public class ConfigurableAsyncTableCell<T extends IsIndexed> extends AsyncTableC
         fieldsToReturn.add(c.getField());
       }
     });
+
+    if (IndexedAIP.class.equals(options.getClassToReturn()) &&
+            "SelectAipDialog_AIPs".equals(options.getListId())) {
+      fieldsToReturn.add("path");
+      fieldsToReturn.add("path_docs");
+      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS); // Needed for path calculation
+      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS); // Needed for path calculation
+      fieldsToReturn.add(RodaConstants.AIP_TITLE); // Needed for current AIP title
+    }
 
     // if index object has permissions, add permissions fields
     if (HAS_PERMISSIONS.contains(options.getClassToReturn())) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
@@ -19,15 +19,7 @@ import java.util.stream.Collectors;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.v2.index.IsIndexed;
 import org.roda.core.data.v2.index.sort.Sorter;
-import org.roda.core.data.v2.ip.AIP;
-import org.roda.core.data.v2.ip.DIP;
-import org.roda.core.data.v2.ip.HasDisposal;
-import org.roda.core.data.v2.ip.HasPermissions;
-import org.roda.core.data.v2.ip.HasState;
-import org.roda.core.data.v2.ip.IndexedAIP;
-import org.roda.core.data.v2.ip.IndexedDIP;
-import org.roda.core.data.v2.ip.IndexedFile;
-import org.roda.core.data.v2.ip.IndexedRepresentation;
+import org.roda.core.data.v2.ip.*;
 import org.roda.core.data.v2.ip.metadata.FileFormat;
 import org.roda.wui.client.common.lists.utils.ColumnOptions.RenderingHint;
 import org.roda.wui.common.client.tools.DescriptionLevelUtils;
@@ -105,39 +97,44 @@ public class ConfigurableAsyncTableCell<T extends IsIndexed> extends AsyncTableC
           return null;
         }
         @SuppressWarnings("unchecked")
-        List<String> ancestors = (List<String>) aip.getFields().get(RodaConstants.AIP_ANCESTORS);
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> pathDocs = (List<Map<String, Object>>) aip.getFields().get("path_docs");
+        List<String> ancestors = aip.getAncestors();
+        String currentAipName = getDisplayName(aip.getTitle(), aip.getId());
+
         if (ancestors == null || ancestors.isEmpty()) {
-          return aip.getTitle() != null && !aip.getTitle().trim().isEmpty() ? "root/" + aip.getTitle() : "root/" + aip.getId();
+          return "root/" + currentAipName;
         }
-        List<String> pathParts = new ArrayList<>();
+
         Map<String, String> ancestorTitles = new HashMap<>();
+        List<ParentAncestorMap> pathDocs = aip.getParentAncestorsList();
+
         if (pathDocs != null) {
-          for (Map<String, Object> pathDoc : pathDocs) {
-            String id = (String) pathDoc.get("id");
-            String title = (String) pathDoc.get("title");
+          for (ParentAncestorMap pathDoc : pathDocs) {
+            String id = pathDoc.getAncestorId();
             if (id != null) {
-              ancestorTitles.put(id, title != null && !title.trim().isEmpty() ? title : id);
+              ancestorTitles.put(id, getDisplayName(pathDoc.getTitle(), id));
             }
           }
         }
-        List<String> reversedAncestors = new ArrayList<>(ancestors);
-        Collections.reverse(reversedAncestors);
+
+        List<String> pathParts = new ArrayList<>(ancestors.size() + 2);
         pathParts.add("root");
-        for (String ancestorId : reversedAncestors) {
-          String ancestorName = ancestorTitles.get(ancestorId);
-          if (ancestorName == null) {
-            ancestorName = ancestorId; // Fallback to ID if title not available
-          }
-          pathParts.add(ancestorName);
+
+        for (int i = ancestors.size() - 1; i >= 0; i--) {
+          String ancestorId = ancestors.get(i);
+          pathParts.add(ancestorTitles.getOrDefault(ancestorId, ancestorId));
         }
-        String currentAipName = aip.getTitle() != null && !aip.getTitle().trim().isEmpty() ? aip.getTitle() : aip.getId();
+
         pathParts.add(currentAipName);
         return StringUtils.join(pathParts, " / ");
       }
+
+      private String getDisplayName(String title, String fallback) {
+        return title != null && !title.trim().isEmpty() ? title : fallback;
+      }
     });
-    DEFAULT_COLUMNS_FIELDS.put("default_IndexedAIP_path", Arrays.asList("path", "path_docs", RodaConstants.AIP_ANCESTORS, RodaConstants.AIP_TITLE));
+
+    DEFAULT_COLUMNS_FIELDS.put("default_IndexedAIP_path",
+            Arrays.asList("path", RodaConstants.AIP_ANCESTORS_LIST, RodaConstants.AIP_ANCESTORS, RodaConstants.AIP_TITLE));
     /********************************************
      * Representations
      ********************************************/
@@ -322,10 +319,9 @@ public class ConfigurableAsyncTableCell<T extends IsIndexed> extends AsyncTableC
     if (IndexedAIP.class.equals(options.getClassToReturn()) &&
             "SelectAipDialog_AIPs".equals(options.getListId())) {
       fieldsToReturn.add("path");
-      fieldsToReturn.add("path_docs");
-      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS); // Needed for path calculation
-      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS); // Needed for path calculation
-      fieldsToReturn.add(RodaConstants.AIP_TITLE); // Needed for current AIP title
+      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS_LIST);
+      fieldsToReturn.add(RodaConstants.AIP_ANCESTORS);
+      fieldsToReturn.add(RodaConstants.AIP_TITLE);
     }
 
     // if index object has permissions, add permissions fields

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
@@ -18,6 +18,7 @@ ui.search.fields.IndexedAIP.overdueDate=Overdue on
 ui.search.fields.IndexedAIP.destroyedOn=Destroyed on
 ui.search.fields.IndexedAIP.destroyedBy=Destroyed by
 ui.search.fields.IndexedAIP.disposalScheduleName=Disposal schedule
+ui.search.fields.IndexedAIP.path=Path
 
 ui.search.fields.IndexedRepresentation.identifier=Identifier
 ui.search.fields.IndexedRepresentation.uuid=Identifier

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
@@ -18,6 +18,7 @@ ui.search.fields.IndexedAIP.overdueDate=FÃ¶rfaller
 ui.search.fields.IndexedAIP.destroyedOn=Gallrad den
 ui.search.fields.IndexedAIP.destroyedBy=Gallrad av
 ui.search.fields.IndexedAIP.disposalScheduleName=Gallringsschema
+ui.search.fields.IndexedAIP.path=Sökväg
 
 ui.search.fields.IndexedRepresentation.identifier=Identifierare
 ui.search.fields.IndexedRepresentation.uuid=Identifierare

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
@@ -18,7 +18,7 @@ ui.search.fields.IndexedAIP.overdueDate=FÃ¶rfaller
 ui.search.fields.IndexedAIP.destroyedOn=Gallrad den
 ui.search.fields.IndexedAIP.destroyedBy=Gallrad av
 ui.search.fields.IndexedAIP.disposalScheduleName=Gallringsschema
-ui.search.fields.IndexedAIP.path=Sökväg
+ui.search.fields.IndexedAIP.path=SÃ¶kvÃ¤g
 
 ui.search.fields.IndexedRepresentation.identifier=Identifierare
 ui.search.fields.IndexedRepresentation.uuid=Identifierare

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -1166,6 +1166,11 @@ ui.lists.SelectAipDialog_AIPs.columns[].title.field = title
 ui.lists.SelectAipDialog_AIPs.columns[].title.header = ui.search.fields.IndexedAIP.title
 ui.lists.SelectAipDialog_AIPs.columns[].title.sortBy = title_sort
 
+ui.lists.SelectAipDialog_AIPs.columns[] = default_IndexedAIP_path
+ui.lists.SelectAipDialog_AIPs.columns[].default_IndexedAIP_path.header = ui.search.fields.IndexedAIP.path
+ui.lists.SelectAipDialog_AIPs.columns[].default_IndexedAIP_path.width = 25.0
+
+
 ui.lists.SelectAipDialog_AIPs.columns[] = default_IndexedAIP_dates
 ui.lists.SelectAipDialog_AIPs.columns[].default_IndexedAIP_dates.header = ui.search.fields.IndexedAIP.dates
 ui.lists.SelectAipDialog_AIPs.columns[].default_IndexedAIP_dates.sortBy = dateInitial


### PR DESCRIPTION
This PR adds a new column to display the full hierarchical path of an AIP (root → leaf) in the Move AIP dialog and search results.

The implementation builds the path using the indexed ancestors field, reversing the order to construct a readable hierarchy and appending the current AIP title/ID. Ancestor titles are fetched via a Solr subquery, ensuring complete path information even when parent AIPs are not part of the current result page.