### PR TITLE
refactor: Update i18n pluralization rule syntax from `[one]` to `[=1]…

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1540,20 +1540,20 @@ deleteDisposalRuleDialogMessage:Are you sure you want to remove the disposal rul
 associateDisposalHoldButton:Associate disposal hold
 disposalHoldSelectionDialogTitle:Associate disposal hold
 applyDisposalHoldDialogTitle:Confirm disposal hold association to intellectual entity
-applyDisposalHoldDialogMessage[one]:Are you sure you want to apply the disposal hold to the selected item?
+applyDisposalHoldDialogMessage[=1]:Are you sure you want to apply the disposal hold to the selected item?
 applyDisposalHoldDialogMessage:Are you sure you want to apply the disposal hold to the selected {0, number} items?
 applyDisposalHoldButton:Associate disposal hold
 createDisposalHoldButton:Create disposal hold
 clearDisposalHoldButton:Clear disposal holds
 overrideDisposalHoldButton:Override disposal hold
 clearDisposalHoldDialogTitle:Clear disposal holds
-clearDisposalHoldDialogMessage[one]:Are you sure you want to disassociate all disposal holds from the selected item?
+clearDisposalHoldDialogMessage[=1]:Are you sure you want to disassociate all disposal holds from the selected item?
 clearDisposalHoldDialogMessage:Are you sure you want to disassociate all disposal holds from the selected {0, number} items?
 disassociateDisposalHoldDialogTitle:Disassociate disposal hold
-disassociateDisposalHoldDialogMessage[one]:Are you sure you want to disassociate the disposal hold from the selected item?
+disassociateDisposalHoldDialogMessage[=1]:Are you sure you want to disassociate the disposal hold from the selected item?
 disassociateDisposalHoldDialogMessage:Are you sure you want to disassociate the disposal hold from the selected {0, number} items?
 disassociateDisposalScheduleDialogTitle:Disassociate disposal schedule
-disassociateDisposalScheduleDialogMessage[one]:Are you sure you want to disassociate the disposal schedule from the selected item?
+disassociateDisposalScheduleDialogMessage[=1]:Are you sure you want to disassociate the disposal schedule from the selected item?
 disassociateDisposalScheduleDialogMessage:Are you sure you want to disassociate the disposal schedule from the selected {0, number} items?
 disposalHoldAssociatedOn:Associated on
 disposalHoldAssociatedBy:Associated by
@@ -1576,12 +1576,12 @@ disposalPolicyConfirmationSummary:Assigned to a disposal confirmation
 disposalPolicyActionSummary:{0}
 disposalPolicyActionSummary[REVIEW]:revision
 disposalPolicyActionSummary[DESTROY]:destruction
-disposalPolicyScheduleMonthSummary[one]:in 1 month
+disposalPolicyScheduleMonthSummary[=1]:in 1 month
 disposalPolicyScheduleMonthSummary:in {0,number} months
-disposalPolicyScheduleYearSummary[one]:in 1 year
+disposalPolicyScheduleYearSummary[=1]:in 1 year
 disposalPolicyScheduleYearSummary:in {0,number} years
 disposalPolicyScheduleDaySummary[\=0]:today
-disposalPolicyScheduleDaySummary[one]:tomorrow
+disposalPolicyScheduleDaySummary[=1]:tomorrow
 disposalPolicyScheduleDaySummary:in {0,number} days
 disposalPolicySummaryReady:Overdue for {0}
 permanentlyRetained:Never

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_AT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_AT.properties
@@ -1434,20 +1434,20 @@ deleteDisposalRuleDialogMessage:Sind Sie sicher, dass Sie die Entsorgungsregel {
 associateDisposalHoldButton:Entsorgungssperre zuordnen
 disposalHoldSelectionDialogTitle:Entsorgungssperre zuordnen
 applyDisposalHoldDialogTitle:Zuordnung der Entsorgungssperre zur intellektuellen Entität bestätigen
-applyDisposalHoldDialogMessage[one]:Sind Sie sicher, dass Sie die Entsorgungssperre auf das ausgewählte Element anwenden möchten?
+applyDisposalHoldDialogMessage[=1]:Sind Sie sicher, dass Sie die Entsorgungssperre auf das ausgewählte Element anwenden möchten?
 applyDisposalHoldDialogMessage:Sind Sie sicher, dass Sie die Entsorgungssperre auf die ausgewählten {0, number} Elemente anwenden möchten?
 applyDisposalHoldButton:Entsorgungssperre verbinden
 createDisposalHoldButton:Entsorgungssperre erstellen
 clearDisposalHoldButton:Entsorgungssperre bereinigen
 overrideDisposalHoldButton:Entsorgungssperre überschreiben
 clearDisposalHoldDialogTitle:Entsorgungssperre bereinigen
-clearDisposalHoldDialogMessage[one]:Sind Sie sicher, dass Sie alle Entsorgungssperren auf das ausgewählte Element aufheben möchten?
+clearDisposalHoldDialogMessage[=1]:Sind Sie sicher, dass Sie alle Entsorgungssperren auf das ausgewählte Element aufheben möchten?
 clearDisposalHoldDialogMessage:Sind Sie sicher, dass Sie alle Entsorgungssperren auf die ausgewählten {0, number} Elemente aufheben möchten?
 disassociateDisposalHoldDialogTitle:Entsorgungssperre aufheben
-disassociateDisposalHoldDialogMessage[one]:Sind Sie sicher, dass Sie die Entsorgungssperre auf das ausgewählte Element aufheben möchten?
+disassociateDisposalHoldDialogMessage[=1]:Sind Sie sicher, dass Sie die Entsorgungssperre auf das ausgewählte Element aufheben möchten?
 disassociateDisposalHoldDialogMessage:Sind Sie sicher, dass Sie die Entsorgungssperre auf die ausgewählten {0, number} Elemente aufheben möchten?
 disassociateDisposalScheduleDialogTitle:Entsorgungsplan aufheben
-disassociateDisposalScheduleDialogMessage[one]:Sind Sie sicher, dass Sie den Entsorgungsplan von dem ausgewählten Element trennen möchten?
+disassociateDisposalScheduleDialogMessage[=1]:Sind Sie sicher, dass Sie den Entsorgungsplan von dem ausgewählten Element trennen möchten?
 disassociateDisposalScheduleDialogMessage:Sind Sie sicher, dass Sie den Entsorgungsplan von den ausgewählten {0, number} Elementen trennen möchten?
 disposalHoldAssociatedOn:Verbunden am
 disposalHoldAssociatedBy:Verbunden von
@@ -1470,12 +1470,12 @@ disposalPolicyConfirmationSummary:Einer Entsorgungsbestätigung zugeordnet
 disposalPolicyActionSummary:{0}
 disposalPolicyActionSummary[REVIEW]:Überarbeitung
 disposalPolicyActionSummary[DESTROY]:Zerstörung
-disposalPolicyScheduleMonthSummary[one]:in 1 Monat
+disposalPolicyScheduleMonthSummary[=1]:in 1 Monat
 disposalPolicyScheduleMonthSummary:in {0,number} Monaten
-disposalPolicyScheduleYearSummary[one]:in 1 Jahr
+disposalPolicyScheduleYearSummary[=1]:in 1 Jahr
 disposalPolicyScheduleYearSummary:in {0,number} Jahren
 disposalPolicyScheduleDaySummary[\=0]:Heute
-disposalPolicyScheduleDaySummary[one]:Morgen
+disposalPolicyScheduleDaySummary[=1]:Morgen
 disposalPolicyScheduleDaySummary:in {0,number} Tagen
 disposalPolicySummaryReady:Überfällig für {0}
 permanentlyRetained:Niemals

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hu.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hu.properties
@@ -1495,20 +1495,20 @@ deleteDisposalRuleDialogMessage:Are you sure you want to remove the disposal rul
 associateDisposalHoldButton:Associate disposal hold
 disposalHoldSelectionDialogTitle:Associate disposal hold
 applyDisposalHoldDialogTitle:Confirm disposal hold association to intellectual entity
-applyDisposalHoldDialogMessage[one]:Are you sure you want to apply the disposal hold to the selected item?
+applyDisposalHoldDialogMessage[=1]:Are you sure you want to apply the disposal hold to the selected item?
 applyDisposalHoldDialogMessage:Are you sure you want to apply the disposal hold to the selected {0, number} items?
 applyDisposalHoldButton:Associate disposal hold
 createDisposalHoldButton:Create disposal hold
 clearDisposalHoldButton:Clear disposal holds
 overrideDisposalHoldButton:Override disposal hold
 clearDisposalHoldDialogTitle:Clear disposal holds
-clearDisposalHoldDialogMessage[one]:Are you sure you want to disassociate all disposal holds from the selected item?
+clearDisposalHoldDialogMessage[=1]:Are you sure you want to disassociate all disposal holds from the selected item?
 clearDisposalHoldDialogMessage:Are you sure you want to disassociate all disposal holds from the selected {0, number} items?
 disassociateDisposalHoldDialogTitle:Disassociate disposal hold
-disassociateDisposalHoldDialogMessage[one]:Are you sure you want to disassociate the disposal hold from the selected item?
+disassociateDisposalHoldDialogMessage[=1]:Are you sure you want to disassociate the disposal hold from the selected item?
 disassociateDisposalHoldDialogMessage:Are you sure you want to disassociate the disposal hold from the selected {0, number} items?
 disassociateDisposalScheduleDialogTitle:Disassociate disposal schedule
-disassociateDisposalScheduleDialogMessage[one]:Are you sure you want to disassociate the disposal schedule from the selected item?
+disassociateDisposalScheduleDialogMessage[=1]:Are you sure you want to disassociate the disposal schedule from the selected item?
 disassociateDisposalScheduleDialogMessage:Are you sure you want to disassociate the disposal schedule from the selected {0, number} items?
 disposalHoldAssociatedOn:Társítva
 disposalHoldAssociatedBy:Associated by
@@ -1531,12 +1531,12 @@ disposalPolicyConfirmationSummary:Assigned to a disposal confirmation
 disposalPolicyActionSummary:{0}
 disposalPolicyActionSummary[REVIEW]:felülvizsgálat
 disposalPolicyActionSummary[DESTROY]:megsemmisítés
-disposalPolicyScheduleMonthSummary[one]:1 hónap alatt
+disposalPolicyScheduleMonthSummary[=1]:1 hónap alatt
 disposalPolicyScheduleMonthSummary:{0,number} hónap alatt
-disposalPolicyScheduleYearSummary[one]:1 év alatt
+disposalPolicyScheduleYearSummary[=1]:1 év alatt
 disposalPolicyScheduleYearSummary:{0,number} év alatt
 disposalPolicyScheduleDaySummary[\=0]:ma
-disposalPolicyScheduleDaySummary[one]:holnap
+disposalPolicyScheduleDaySummary[=1]:holnap
 disposalPolicyScheduleDaySummary:{0,number} nap alatt
 disposalPolicySummaryReady:Overdue for {0}
 permanentlyRetained:Soha

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
@@ -1438,20 +1438,20 @@ deleteDisposalRuleDialogMessage:Tem a certeza que pretende remover a condição 
 associateDisposalHoldButton:Associar suspensão de eliminação
 disposalHoldSelectionDialogTitle:Associar suspensão de eliminação
 applyDisposalHoldDialogTitle:Confirmar a associação de suspensão de eliminação a uma entidade intelectual
-applyDisposalHoldDialogMessage[one]:Tem a certeza que pretende aplicar a suspensão de eliminação ao item selecionado?
+applyDisposalHoldDialogMessage[=1]:Tem a certeza que pretende aplicar a suspensão de eliminação ao item selecionado?
 applyDisposalHoldDialogMessage:Tem a certeza que pretende aplicar a suspensão de eliminação aos {0, number} items selecionados?
 applyDisposalHoldButton:Associar suspensão de eliminação
 createDisposalHoldButton:Criar suspensão de eliminação
 clearDisposalHoldButton:Limpar suspensões de eliminação
 overrideDisposalHoldButton:Substituir suspensão de eliminação
 clearDisposalHoldDialogTitle:Limpar suspensões de eliminação
-clearDisposalHoldDialogMessage[one]:Tem a certeza que pretende desassociar todas as suspensões de eliminação do item selecionado?
+clearDisposalHoldDialogMessage[=1]:Tem a certeza que pretende desassociar todas as suspensões de eliminação do item selecionado?
 clearDisposalHoldDialogMessage:Tem a certeza que pretende desassociar todas as suspensões de eliminação dos {0, number} items selecionados?
 disassociateDisposalHoldDialogTitle:Desassociar suspensão de eliminação
-disassociateDisposalHoldDialogMessage[one]:Tem a certeza que prentende desassociar a suspensão de eliminação do item selecionado?
+disassociateDisposalHoldDialogMessage[=1]:Tem a certeza que prentende desassociar a suspensão de eliminação do item selecionado?
 disassociateDisposalHoldDialogMessage:Tem a certeza que prentende desassociar a suspensão de eliminação dos {0, number} items selecionados?
 disassociateDisposalScheduleDialogTitle:Desassociar tabela de seleção
-disassociateDisposalScheduleDialogMessage[one]:Tem a certeza que pretende desassociar a tabela de seleção do item selecionado?
+disassociateDisposalScheduleDialogMessage[=1]:Tem a certeza que pretende desassociar a tabela de seleção do item selecionado?
 disassociateDisposalScheduleDialogMessage:Tem a certeza que pretende desassociar a tabela de seleção dos {0, number} items selecionados?
 disposalHoldAssociatedOn:Associado em
 disposalHoldAssociatedBy:Associado por
@@ -1474,12 +1474,12 @@ disposalPolicyConfirmationSummary:Atribuído a um auto de eliminação
 disposalPolicyActionSummary:{0}
 disposalPolicyActionSummary[REVIEW]:revisão
 disposalPolicyActionSummary[DESTROY]:eliminação
-disposalPolicyScheduleMonthSummary[one]:em 1 mês
+disposalPolicyScheduleMonthSummary[=1]:em 1 mês
 disposalPolicyScheduleMonthSummary:em {0,number} meses
-disposalPolicyScheduleYearSummary[one]:em 1 ano
+disposalPolicyScheduleYearSummary[=1]:em 1 ano
 disposalPolicyScheduleYearSummary:em {0,number} anos
 disposalPolicyScheduleDaySummary[\=0]:hoje
-disposalPolicyScheduleDaySummary[one]:amanhã
+disposalPolicyScheduleDaySummary[=1]:amanhã
 disposalPolicyScheduleDaySummary:em {0,number} dias
 disposalPolicySummaryReady:Pronto para {0}
 permanentlyRetained:Nunca

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1537,20 +1537,20 @@ deleteDisposalRuleDialogMessage:Är du säker på att du vill ta bort gallringsr
 associateDisposalHoldButton:Koppla gallringsstopp
 disposalHoldSelectionDialogTitle:Koppla gallringsstopp
 applyDisposalHoldDialogTitle:Bekräfta koppling av gallringsstopp till logisk enhet
-applyDisposalHoldDialogMessage[one]:Är du säker på att du vill koppla gallringsstoppet till det valda objektet?
+applyDisposalHoldDialogMessage[=1]:Är du säker på att du vill koppla gallringsstoppet till det valda objektet?
 applyDisposalHoldDialogMessage:Är du säker på att du vill koppla gallringsstoppet till de valda {0, antal} objekten?
 applyDisposalHoldButton:Koppla gallringsstopp
 createDisposalHoldButton:Skapa gallringsstopp
 clearDisposalHoldButton:Rensa bort gallringsstopp
 overrideDisposalHoldButton:Åsidosätt gallringsstopp
 clearDisposalHoldDialogTitle:Rensa bort gallringsstopp
-clearDisposalHoldDialogMessage[one]:Är du säker på att du vill koppla bort alla gallringsstopp från det valda objektet?
+clearDisposalHoldDialogMessage[=1]:Är du säker på att du vill koppla bort alla gallringsstopp från det valda objektet?
 clearDisposalHoldDialogMessage:Är du säker på att du vill koppla bort alla gallringsstopp från de valda {0, number} objekten?
 disassociateDisposalHoldDialogTitle:Koppla loss gallringsstopp
-disassociateDisposalHoldDialogMessage[one]:Är du säker på att du vill koppla bort gallringsstoppet från det valda objektet?
+disassociateDisposalHoldDialogMessage[=1]:Är du säker på att du vill koppla bort gallringsstoppet från det valda objektet?
 disassociateDisposalHoldDialogMessage:Är du säker på att du vill koppla bort gallringsstoppet från de valda {0, number} objekten?
 disassociateDisposalScheduleDialogTitle:Koppla loss gallringsschema
-disassociateDisposalScheduleDialogMessage[one]:Är du säker på att du vill koppla bort gallringsschemat från det valda objektet?
+disassociateDisposalScheduleDialogMessage[=1]:Är du säker på att du vill koppla bort gallringsschemat från det valda objektet?
 disassociateDisposalScheduleDialogMessage:Är du säker på att du vill koppla bort gallringsschemat från de valda {0, number} objekten?
 disposalHoldAssociatedOn:Associerad med
 disposalHoldAssociatedBy:Associerad av
@@ -1573,12 +1573,12 @@ disposalPolicyConfirmationSummary:Tilldelad en gallringsbekräftelse
 disposalPolicyActionSummary:{0}
 disposalPolicyActionSummary[REVIEW]:revision
 disposalPolicyActionSummary[DESTROY]:gallring
-disposalPolicyScheduleMonthSummary[one]:om 1 månad
+disposalPolicyScheduleMonthSummary[=1]:om 1 månad
 disposalPolicyScheduleMonthSummary:om {0,number} månader
-disposalPolicyScheduleYearSummary[one]:om 1 år
+disposalPolicyScheduleYearSummary[=1]:om 1 år
 disposalPolicyScheduleYearSummary:om {0,number} år
 disposalPolicyScheduleDaySummary[\=0]:idag
-disposalPolicyScheduleDaySummary[one]:imorgon
+disposalPolicyScheduleDaySummary[=1]:imorgon
 disposalPolicyScheduleDaySummary:om {0,number} dagar
 disposalPolicySummaryReady:Förfallen för {0} 
 permanentlyRetained:Aldrig


### PR DESCRIPTION
The Problem:

GWT's i18n system is complaining about the plural form [one] being used
English (DefaultRule) doesn't recognize one as a valid plural category
Swedish locale is missing the [one] form that the default locale defines

The Solution: 

Replace [one] with [=1] in all properties files. The [=1] syntax means "exactly equal to 1" and works universally across all locales.