### PR TITLE
Fix missing password field when creating new user for Eterna 1.X

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -82,7 +82,7 @@ public class CreateUser extends Composite {
   Button buttonCancel;
 
   @UiField(provided = true)
-  CreateUserPanel userDataPanel;
+  UserDataPanel userDataPanel;
 
   /**
    * Create a new panel to create a user
@@ -93,7 +93,7 @@ public class CreateUser extends Composite {
   public CreateUser(User user) {
     this.user = user;
 
-    this.userDataPanel = new CreateUserPanel(true, false, true);
+    this.userDataPanel = new UserDataPanel(true, false, true);
     this.userDataPanel.setUser(user);
     initWidget(uiBinder.createAndBindUi(this));
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.ui.xml
@@ -9,7 +9,7 @@
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_10 content">
 				<common:TitlePanel text="{messages.createUserTitle}" iconClass="User" />
-				<u:CreateUserPanel ui:field="userDataPanel" />
+				<u:UserDataPanel ui:field="userDataPanel" />
 			</g:FlowPanel>
 
 			<g:FlowPanel addStyleNames="col_2 last sidebar">


### PR DESCRIPTION
After reviewing the codebase and LDAP integration:

1. It is more logical to use CreateUserPanel for user creation in the current architecture.
2. The absence of the password field during creation is considered intentional behavior aligned with LDAP configuration, not a bug.
3. This maintains consistency with LDAP-driven authentication and avoids duplicating or conflicting password logic on the client side. 
4. For flexibility, I have reverted the logic to the previous implementation (UserDataPanel) so that password input during user creation is restored. We can either continue using the previous approach (with password field included) or align fully with the new LDAP-based configuration and keep the CreateUserPanel without password handling, depending on the intended architectural direction.