### PR TITLE
chore: update pom.xml files to set scope for jakarta.servlet-api and …

### DIFF
--- a/roda-core/roda-core/pom.xml
+++ b/roda-core/roda-core/pom.xml
@@ -148,6 +148,7 @@
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -683,6 +683,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${springboot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
…exclude jackson dependencies in spring-boot-starter-web

Fix AbstractMethodError when running in Tomcat 10.1
The jakarta.servlet-api dependency in roda-core was declared with
default 'compile' scope, causing it to be bundled in the WAR file.
This conflicted with Tomcat 10.1's own jakarta.servlet implementation,
resulting in:
  java.lang.AbstractMethodError: Receiver class org.apache.catalina.connector.ResponseFacade 
  does not define or inherit an implementation of the resolved method 
  'abstract void sendRedirect(java.lang.String)'
Changed the dependency scope to 'provided' so it's available at compile
time but provided by the container at runtime.