### PR TITLE
Fix process name display and plugin selection behavior in New Process screen for v0.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed compilation warnings regarding plural i18n by updating pluralization rule syntax from `[one]` to `[=1]` for single items
 - Added missing `[one]` pluralization keys in Swedish localization file and corrected a typo
 - Replaced Unicode escapes with literal HTML tags in Swedish client messages
+- Fixed incorrect process name display and improved UI handling when no plugin/action is available on the New Process screen
 
 ## v0.5.0 (2025-12-16)
 #### Updates

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2458,4 +2458,5 @@ public interface ClientMessages extends Messages {
 
   String conversionProfileDescription();
 
+  String noPluginsAvailable();
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
@@ -289,6 +289,7 @@ public class CreateDefaultJob extends Composite {
                   @Override
                   public void onValueChange(ValueChangeEvent<Boolean> event) {
                     workflowList.clear();
+                    selectedPlugin = null;
                     boolean noChecks = true;
 
                     if (plugins != null) {
@@ -310,22 +311,26 @@ public class CreateDefaultJob extends Composite {
                                 if (categories.contains(checkbox.getName())
                                   && !categories.contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE)
                                   && !pluginsAdded.contains(pluginInfo.getId())) {
-                                  Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
-                                  if (pluginsAdded.isEmpty()) {
-                                    CreateDefaultJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
-                                    pluginItem.addStyleName("plugin-list-item-selected");
+                                  if (pluginInfo.isInstalled()) {
+                                    Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
+                                      if (pluginsAdded.isEmpty()) {
+                                      CreateDefaultJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
+                                      pluginItem.addStyleName("plugin-list-item-selected");
+                                      }
+                                    pluginsAdded.add(pluginInfo.getId());
                                   }
-                                  pluginsAdded.add(pluginInfo.getId());
                                 }
                               }
                             }
 
                             if (noChecks) {
                               if (!pluginInfo.getCategories().contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE)) {
-                                Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
-                                if (p == 0) {
-                                  CreateDefaultJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
-                                  pluginItem.addStyleName("plugin-list-item-selected");
+                                if (pluginInfo.isInstalled()) {
+                                  Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
+                                    if (p == 0) {
+                                    CreateDefaultJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
+                                    pluginItem.addStyleName("plugin-list-item-selected");
+                                    }
                                 }
                               }
                             }
@@ -344,10 +349,12 @@ public class CreateDefaultJob extends Composite {
             }
 
             if (!pluginCategories.contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE)) {
+              if (pluginInfo.isInstalled()) {
               Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
-              if (p == 0) {
+                if (p == 0) {
                 CreateDefaultJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
                 pluginItem.addStyleName("plugin-list-item-selected");
+                }
               }
             }
           }
@@ -425,12 +432,24 @@ public class CreateDefaultJob extends Composite {
   protected void updateWorkflowOptions() {
     isListEmpty = true;
     if (selectedPlugin == null) {
+      name.setText("");
+      name.setEnabled(false);
+      workflowListTitle.clear();
+      workflowListPluginStatus.clear();
       workflowListDescription.clear();
       workflowListDescriptionCategories.clear();
-      workflowListDescription.setVisible(false);
+      if (workflowList.getWidgetCount() == 0) {
+        workflowListDescription.add(new Label(messages.noPluginsAvailable()));
+      }
+      workflowListDescription.setVisible(true);
       workflowListDescriptionCategories.setVisible(false);
       workflowOptions.setPluginInfo(null);
+      workflowPanel.setVisible(false);
+      buttonCreate.setEnabled(false);
+      targetListPanel.clear();
+      targetListPanel.setVisible(false);
     } else {
+      name.setEnabled(true);
       buttonCreate.setEnabled(shouldEnableCreateButton());
       buildPluginHeader();
       buildPluginStatusPanel();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
@@ -281,6 +281,7 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
                   @Override
                   public void onValueChange(ValueChangeEvent<Boolean> event) {
                     workflowList.clear();
+                    selectedPlugin = null;
                     boolean noChecks = true;
 
                     if (plugins != null) {
@@ -303,14 +304,16 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
                                   && ((!isSelectedEmpty() && pluginInfo.hasObjectClass(selectedClass))
                                     || (isSelectedEmpty() && pluginInfo.hasObjectClass(listSelectedClass)))
                                   && !pluginsAdded.contains(pluginInfo.getId())) {
-                                  Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
+                                  if (pluginInfo.isInstalled()) {
+                                    Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
 
-                                  if (pluginsAdded.isEmpty()) {
-                                    CreateSelectedJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
-                                    pluginItem.addStyleName("plugin-list-item-selected");
+                                    if (pluginsAdded.isEmpty()) {
+                                      CreateSelectedJob.this.selectedPlugin = pluginInfo;
+                                      pluginItem.addStyleName("plugin-list-item-selected");
+                                    }
+
+                                    pluginsAdded.add(pluginInfo.getId());
                                   }
-
-                                  pluginsAdded.add(pluginInfo.getId());
                                 }
 
                               }
@@ -320,13 +323,15 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
                               if (!pluginInfo.getCategories().contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE)
                                 && ((!isSelectedEmpty() && pluginInfo.hasObjectClass(selectedClass))
                                   || (isSelectedEmpty() && pluginInfo.hasObjectClass(listSelectedClass)))) {
-                                Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
-                                if (pluginsAdded.isEmpty()) {
-                                  CreateSelectedJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
-                                  pluginItem.addStyleName("plugin-list-item-selected");
-                                }
+                                if (pluginInfo.isInstalled()) {
+                                  Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
+                                  if (pluginsAdded.isEmpty()) {
+                                    CreateSelectedJob.this.selectedPlugin = pluginInfo;
+                                    pluginItem.addStyleName("plugin-list-item-selected");
+                                  }
 
-                                pluginsAdded.add(pluginInfo.getId());
+                                  pluginsAdded.add(pluginInfo.getId());
+                                }
                               }
                             }
                           }
@@ -347,11 +352,13 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
             if (!pluginCategories.contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE)
               && ((!isSelectedEmpty() && pluginInfo.hasObjectClass(selectedClass))
                 || (isSelectedEmpty() && pluginInfo.hasObjectClass(listSelectedClass)))) {
-              Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
-              if (pluginAdded == 0) {
-                CreateSelectedJob.this.selectedPlugin = lookupPlugin(pluginInfo.getId());
-                pluginItem.addStyleName("plugin-list-item-selected");
-                pluginAdded++;
+              if (pluginInfo.isInstalled()) {
+                Widget pluginItem = addPluginItemWidgetToWorkflowList(pluginInfo);
+                if (pluginAdded == 0) {
+                  CreateSelectedJob.this.selectedPlugin = pluginInfo;
+                  pluginItem.addStyleName("plugin-list-item-selected");
+                  pluginAdded++;
+                }
               }
             }
           }
@@ -428,12 +435,23 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
 
   protected void updateWorkflowOptions() {
     if (selectedPlugin == null) {
+      name.setText("");
+      name.setEnabled(false);
+      workflowListTitle.clear();
+      workflowListPluginStatus.clear();
       workflowListDescription.clear();
       workflowListDescriptionCategories.clear();
-      workflowListDescription.setVisible(false);
+      if (workflowList.getWidgetCount() == 0) {
+        workflowListDescription.add(new Label(messages.noPluginsAvailable()));
+      }
+      workflowListDescription.setVisible(true);
       workflowListDescriptionCategories.setVisible(false);
       workflowOptions.setPluginInfo(null);
-    } else {
+      workflowPanel.setVisible(false);
+      buttonCreate.setEnabled(false);
+    }else {
+      buttonCreate.setEnabled(shouldEnableCreateButton());
+      name.setEnabled(true);
       buttonCreate.setEnabled(shouldEnableCreateButton());
       buildPluginHeader();
       buildPluginStatusPanel();

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1745,4 +1745,5 @@ changeRepresentationStatusToPreservationDescription:
 conversionProfileTitle: Conversion Profile
 conversionProfileDescription: Conversion profile options
 
+noPluginsAvailable=No actions available for the selected category
 

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1744,3 +1744,5 @@ marketStoreInstallLabel:Installera
 # Descriptive metatada lock to edit
 editDescMetadataLockedTitle: Det går inte att redigera beskrivande metadata
 editDescMetadataLockedText: Denna logiska enhet redigeras just nu av en annan användare
+
+noPluginsAvailable=Inga åtgärder tillgängliga för den valda kategorin


### PR DESCRIPTION
This PR fixes an issue on the New Process screen where the Process Name field could display a plugin name even when no plugin was selected or available in the plugin list. This caused confusion because the displayed name did not correspond to any available plugin.

The changes ensure that the Process Name always reflects the currently selected plugin. When filtering plugins by category, the first available plugin is now automatically selected. If no plugins or actions are available for the selected category, the UI now clearly shows an empty state message.

Additionally, the Name input field and Create button are disabled when no plugin is available to prevent users from creating a process without a valid plugin selection. The UI state is also reset correctly when plugin filters change.

The update also adds a new i18n key (noPluginsAvailable) and includes the corresponding Swedish translation. The changelog has been updated to document this bug fix.