### PR TITLE
Bugfix/restore plugin license documentation visibility v1.x

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
@@ -291,7 +291,4 @@ public class PluginInfo implements Serializable {
   public void setMarketInfo(MarketInfo marketInfo) {
     this.marketInfo = marketInfo;
   }
-
-
-
 }

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This class contains information about a plugin.
@@ -249,6 +250,7 @@ public class PluginInfo implements Serializable {
     isInstalled = installed;
   }
 
+  @JsonProperty("hasLicenseFile")
   public Boolean hasLicenseFile() {
     return hasLicenseFile;
   }
@@ -265,6 +267,7 @@ public class PluginInfo implements Serializable {
     this.licenseFilePath = licenseFilePath;
   }
 
+  @JsonProperty("hasDocumentationFile")
   public Boolean hasDocumentationFile() {
     return hasDocumentationFile;
   }
@@ -288,4 +291,7 @@ public class PluginInfo implements Serializable {
   public void setMarketInfo(MarketInfo marketInfo) {
     this.marketInfo = marketInfo;
   }
+
+
+
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
@@ -471,6 +471,7 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
         licenseButton.addClickHandler(e -> Dialogs.showLicenseModal(messages.pluginLicenseLabel(),
           new HTMLWidgetWrapper(selectedPlugin.getLicenseFilePath(), RodaConstants.ResourcesTypes.PLUGINS)));
       }
+      rightPanel.add(licenseButton);
     } else if (marketInfo != null && marketInfo.getLicense() != null) {
       LicenseInfo license = marketInfo.getLicense();
       licenseButton.setText(license.getName());


### PR DESCRIPTION
This PR restores the visibility of plugin documentation and license information that was available in ETERNA 0.5 but was no longer displayed in ETERNA 1.x.

The backend already contained the relevant fields (hasLicenseFile, licenseFilePath, hasDocumentationFile, and documentationFilePath), but they were not being correctly exposed through the REST API. Because of this, the UI was unable to detect whether documentation or license files existed for a plugin and therefore did not render the corresponding options.

In this change, the serialization of these properties was corrected so that the REST API properly returns the hasLicenseFile and hasDocumentationFile values. This allows the UI to determine when documentation and license files are available and display the corresponding actions again.

As a result, plugins that include documentation or license files will once again show the appropriate options in the interface, restoring the behavior that existed in ETERNA 0.5.