### PR TITLE
chore: bump container image versions and update ZooKeeper dependency

### DIFF
--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -1,6 +1,6 @@
 services:
   zoo:
-    image: docker.io/zookeeper:3.9.2-jre-17
+    image: docker.io/zookeeper:3.9.4-jre-17
     restart: unless-stopped
     ports:
       - "2181:2181"
@@ -52,7 +52,7 @@ services:
       # Mapping /tmp to enable usage with local testing via mvn test
       - /tmp:/tmp:ro
   swagger:
-    image: docker.io/swaggerapi/swagger-ui:latest
+    image: docker.io/swaggerapi/swagger-ui:v5.32.0
     restart: on-failure
     ports:
       - "8081:8080"

--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -10,22 +10,23 @@ services:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
   solr:
-    image: docker.io/solr:9
+    image: docker.io/solr:9.9
     restart: unless-stopped
     ports:
       - "8983:8983"
     environment:
+      SOLR_HEAP: 2g
       ZK_HOST: zoo:2181
       SOLR_HOST: localhost
       SOLR_OPTS: "-Dsolr.environment=dev,label=DEV+ENV"
     depends_on:
       - zoo
-    command:
-      - -c
+    command: -c
     volumes:
       - solr_data:/var/solr
+
   clamd:
-    image: docker.io/clamav/clamav:1.2.2
+    image: docker.io/clamav/clamav:stable
     restart: unless-stopped
     ports:
       - "3310:3310"
@@ -37,7 +38,7 @@ services:
       - /tmp:/tmp
 
   siegfried:
-    image: ghcr.io/keeps/siegfried:v1.11.0
+    image: ghcr.io/keeps/siegfried:v1.11.4
     restart: unless-stopped
     ports:
       - "5138:5138"
@@ -51,7 +52,7 @@ services:
       # Mapping /tmp to enable usage with local testing via mvn test
       - /tmp:/tmp:ro
   swagger:
-    image: docker.io/swaggerapi/swagger-ui:v5.13.0
+    image: docker.io/swaggerapi/swagger-ui:latest
     restart: on-failure
     ports:
       - "8081:8080"

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   zoo:
-    image: docker.io/zookeeper:3.9.2-jre-17
+    image: docker.io/zookeeper:3.9.4-jre-17
     restart: unless-stopped
     environment:
       - ZOO_4LW_COMMANDS_WHITELIST=mntr,conf,ruok
@@ -35,7 +35,7 @@ services:
       - siegfried_data:/root/siegfried/
       - roda_data:/roda/data/
   swagger:
-    image: docker.io/swaggerapi/swagger-ui:latest
+    image: docker.io/swaggerapi/swagger-ui:v5.32.0
     restart: on-failure
     ports:
       - "8081:8080"
@@ -44,7 +44,7 @@ services:
       - DOC_EXPANSION=none
       - VALIDATOR_URL=none
   eterna:
-    image: ghcr.io/eterna-earkiv/eterna:0.6.0-SNAPSHOT
+    image: ghcr.io/eterna-earkiv/eterna:v0.5.0
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
   solr:
-    image: docker.io/solr:9.5.0
+    image: docker.io/solr:9.9
     restart: unless-stopped
     ports:
       - "8983:8983"
@@ -20,13 +20,13 @@ services:
       - solr_data:/var/solr
 
   clamd:
-    image: docker.io/clamav/clamav:1.2.2
+    image: docker.io/clamav/clamav:stable
     restart: unless-stopped
     volumes:
       - clam_data:/var/lib/clamav
       - roda_data:/roda/data/
   siegfried:
-    image: ghcr.io/keeps/siegfried:v1.11.0
+    image: ghcr.io/keeps/siegfried:v1.11.4
     restart: unless-stopped
     environment:
       SIEGFRIED_HOST: 0.0.0.0
@@ -35,7 +35,7 @@ services:
       - siegfried_data:/root/siegfried/
       - roda_data:/roda/data/
   swagger:
-    image: docker.io/swaggerapi/swagger-ui:v5.13.0
+    image: docker.io/swaggerapi/swagger-ui:latest
     restart: on-failure
     ports:
       - "8081:8080"
@@ -44,7 +44,7 @@ services:
       - DOC_EXPANSION=none
       - VALIDATOR_URL=none
   eterna:
-    image: ghcr.io/eterna-earkiv/eterna:v0.5.0
+    image: ghcr.io/eterna-earkiv/eterna:0.6.0-SNAPSHOT
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex; \
     chmod g-s /usr/bin/chage && \
     chmod g-s /sbin/unix_chkpwd && \
     chmod g-s /sbin/unix2_chkpwd && \
-    chmod g-s /usr/lib/utempter/utempter
+    chmod g-s /usr/lib/utempter/utempter 
 
 
 # Copy Tomcat from the official image (maintains /usr/local/tomcat layout)
@@ -66,7 +66,8 @@ RUN set -ex; \
     echo "core.plugins.internal.virus_check.clamav.get_version = clamdscan --version" >> config/roda-core.properties && \
     echo "core.tools.siegfried.mode = server" >> config/roda-core.properties && \
     zip -q /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/roda-core-*.jar config/roda-core.properties && \
-    zypper clean -a
+    zypper clean -a && \
+    rm -f /usr/bin/container-suseconnect
 
 ENV RODA_HOME=/roda \
     SIEGFRIED_MODE=server \

--- a/pom.xml
+++ b/pom.xml
@@ -1129,12 +1129,12 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.9.4</version>
+                <version>3.9.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper-jute</artifactId>
-                <version>3.9.4</version>
+                <version>3.9.5</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>


### PR DESCRIPTION
Update Docker Compose service images (Solr 9.9, ClamAV stable, Siegfried v1.11.4, Swagger UI latest, ETERNA 0.6.0-SNAPSHOT), add SOLR_HEAP setting in dev, remove container-suseconnect from Dockerfile, and bump ZooKeeper from 3.9.4 to 3.9.5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly version bumps, but switching to `clamav:stable`, `swagger-ui:latest`, and `eterna:0.6.0-SNAPSHOT` can introduce unpinned changes that may affect runtime behavior and reproducibility.
> 
> **Overview**
> Updates the standalone Docker Compose setups to newer service images: Solr `9.9`, Siegfried `v1.11.4`, ClamAV `stable`, Swagger UI `latest`, and ETERNA `0.6.0-SNAPSHOT` (plus adds `SOLR_HEAP=2g` in dev).
> 
> Tweaks the container build cleanup in `docker/Dockerfile` by removing `container-suseconnect` after package operations, and bumps Maven-managed ZooKeeper dependencies (`zookeeper`/`zookeeper-jute`) from `3.9.4` to `3.9.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb68c575f08a123c1ecb4b1ce87a8bffad15671e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->