### PR TITLE
feat: add GitHub Action to sync project board order to Linear

### DIFF
--- a/.github/scripts/sync-linear-order.js
+++ b/.github/scripts/sync-linear-order.js
@@ -1,0 +1,232 @@
+/**
+ * sync-linear-order.js
+ *
+ * Läser kortens ordning per kolumn från GitHub Projects (v2)
+ * och uppdaterar Linear-issuens sortOrder så att den matchar.
+ *
+ * GitHub Projects är "source of truth" – Linear skriver aldrig
+ * tillbaka ordningen till GitHub.
+ *
+ * Konfigureras via miljövariabler (se workflow-filen):
+ *   GITHUB_TOKEN          – Personal access token med scope: read:project
+ *   LINEAR_API_KEY        – Linear API-nyckel
+ *   GH_PROJECT_NUMBER – Siffran i URL:en för projektet (t.ex. 42)
+ *   GH_ORG            – GitHub-organisationens namn
+ */
+
+const GITHUB_API = 'https://api.github.com/graphql';
+const LINEAR_API = 'https://api.linear.app/graphql';
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const LINEAR_API_KEY = process.env.LINEAR_API_KEY;
+const PROJECT_NUMBER = parseInt(process.env.GH_PROJECT_NUMBER, 10);
+const GITHUB_ORG = process.env.GH_ORG;
+
+// Avstånd mellan sortOrder-värden – ger plats att lägga in
+// nya issues utan att behöva räkna om allt direkt.
+const SORT_STEP = 10_000;
+
+// ─── Hjälpfunktioner ───────────────────────────────────────────────────────
+
+async function githubQuery(query, variables = {}) {
+  const res = await fetch(GITHUB_API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `bearer ${GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(`GitHub GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+async function linearQuery(query, variables = {}) {
+  const res = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: LINEAR_API_KEY,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(`Linear GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+// ─── Steg 1: Hämta alla items från GitHub Projects ────────────────────────
+
+async function fetchGitHubProjectItems() {
+  const allItems = [];
+  let cursor = null;
+
+  do {
+    const data = await githubQuery(
+      `query($org: String!, $number: Int!, $cursor: String) {
+        organization(login: $org) {
+          projectV2(number: $number) {
+            items(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                # Status-kolumnen (anpassa fältnamnet om det heter något annat)
+                fieldValueByName(name: "Status") {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                  }
+                }
+                content {
+                  ... on Issue {
+                    number
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { org: GITHUB_ORG, number: PROJECT_NUMBER, cursor }
+    );
+
+    const page = data.organization.projectV2.items;
+    allItems.push(...page.nodes);
+    cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+  } while (cursor);
+
+  return allItems;
+}
+
+// ─── Steg 2: Bygg en map GitHub-issue-URL → önskad sortOrder ─────────────
+//
+// Items returneras från GitHub i den ordning de visas på brädan
+// (per kolumn, uppifrån och ner). Vi grupperar per kolumn och
+// tilldelar ett sortOrder-värde baserat på positionen inom kolumnen.
+
+function buildSortOrderMap(items) {
+  // Räkna positioner per kolumn
+  const columnCounters = {};
+  const map = new Map(); // githubIssueUrl → sortOrder
+
+  for (const item of items) {
+    // Hoppa över items som inte är Issues (t.ex. draft cards)
+    if (!item.content?.url) continue;
+
+    const column = item.fieldValueByName?.name ?? '__no_status__';
+
+    if (columnCounters[column] === undefined) {
+      columnCounters[column] = 0;
+    }
+
+    const position = columnCounters[column]++;
+    // Position 0 (överst) → lägst sortOrder → hamnar högst i Linear
+    map.set(item.content.url, position * SORT_STEP);
+  }
+
+  return map;
+}
+
+// ─── Steg 3: Hämta Linear-issues med GitHub-koppling ─────────────────────
+
+async function fetchLinearIssuesWithGitHubUrls() {
+  const allIssues = [];
+  let cursor = null;
+
+  do {
+    const data = await linearQuery(
+      `query($cursor: String) {
+        issues(
+          first: 250
+          after: $cursor
+          filter: { attachments: { url: { contains: "github.com" } } }
+        ) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            sortOrder
+            attachments {
+              nodes { url }
+            }
+          }
+        }
+      }`,
+      { cursor }
+    );
+
+    const page = data.issues;
+    allIssues.push(...page.nodes);
+    cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+  } while (cursor);
+
+  return allIssues;
+}
+
+// ─── Steg 4: Uppdatera sortOrder i Linear ─────────────────────────────────
+
+async function updateLinearSortOrder(issueId, sortOrder) {
+  await linearQuery(
+    `mutation($id: String!, $sortOrder: Float!) {
+      issueUpdate(id: $id, input: { sortOrder: $sortOrder }) {
+        success
+      }
+    }`,
+    { id: issueId, sortOrder }
+  );
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Hämtar items från GitHub Projects #${PROJECT_NUMBER} (${GITHUB_ORG})…`);
+  const ghItems = await fetchGitHubProjectItems();
+  console.log(`  ${ghItems.length} items hittades.`);
+
+  const sortOrderMap = buildSortOrderMap(ghItems);
+  console.log(`  ${sortOrderMap.size} issues med GitHub-URL mappade.`);
+
+  console.log('Hämtar Linear-issues med GitHub-attachments…');
+  const linearIssues = await fetchLinearIssuesWithGitHubUrls();
+  console.log(`  ${linearIssues.length} Linear-issues hittades.`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const issue of linearIssues) {
+    // En issue kan ha flera attachments – leta upp den som matchar en GitHub-issue-URL
+    const githubUrl = issue.attachments.nodes
+      .map((a) => a.url)
+      .find((url) => sortOrderMap.has(url));
+
+    if (!githubUrl) {
+      skipped++;
+      continue;
+    }
+
+    const desiredSortOrder = sortOrderMap.get(githubUrl);
+
+    // Hoppa över om sortOrder redan stämmer (undviker onödiga API-anrop)
+    if (Math.abs(issue.sortOrder - desiredSortOrder) < 1) {
+      skipped++;
+      continue;
+    }
+
+    console.log(`  Uppdaterar issue ${issue.id}: sortOrder ${issue.sortOrder} → ${desiredSortOrder}`);
+    await updateLinearSortOrder(issue.id, desiredSortOrder);
+    updated++;
+
+    // Enkel rate-limiting: vänta 100 ms mellan varje mutation
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  console.log(`\nKlart! Uppdaterade: ${updated}, hoppade över: ${skipped}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/sync-linear-order.yml
+++ b/.github/workflows/sync-linear-order.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/15 * * * *'   # Kör var 15:e minut
   workflow_dispatch:          # Kan också triggas manuellt
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-linear-order.yml
+++ b/.github/workflows/sync-linear-order.yml
@@ -1,0 +1,24 @@
+name: Sync GitHub Projects order → Linear
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # Kör var 15:e minut
+  workflow_dispatch:          # Kan också triggas manuellt
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Sync order
+        run: node .github/scripts/sync-linear-order.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          GITHUB_PROJECT_NUMBER: ${{ vars.GH_PROJECT_NUMBER }}
+          GITHUB_ORG: ${{ vars.GH_ORG }}


### PR DESCRIPTION
Add a scheduled workflow (every 15 min) and Node.js script that reads item ordering per column from GitHub Projects v2 and updates the corresponding Linear issues' sortOrder to match. GitHub Projects serves as the source of truth for prioritization.