### PR TITLE
Fix Jersey classpath conflict between versions 3.1.6 and 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <java_version>21</java_version>
         <gwt.version>2.13.0</gwt.version>
         <cas.client.version>4.0.4</cas.client.version>
-        <jersey.version>3.1.6</jersey.version>
+        <jersey.version>4.0.2</jersey.version>
         <swagger.version>2.2.21</swagger.version>
         <jackson.version>2.18.6</jackson.version>
         <spring.version>7.0.5</spring.version>
@@ -891,14 +891,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey.bundles</groupId>
-                <artifactId>jaxrs-ri</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-spring6</artifactId>
-                <version>3.1.9</version>
+                <version>${jersey.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.springframework</groupId>
@@ -910,16 +905,11 @@
             <dependency>
                 <groupId>jakarta.ws.rs</groupId>
                 <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>3.1.0</version>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet-core</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
             <dependency>

--- a/roda-core/roda-core/pom.xml
+++ b/roda-core/roda-core/pom.xml
@@ -443,10 +443,6 @@
 			<groupId>org.eclipse.angus</groupId>
 			<artifactId>angus-mail</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.bundles</groupId>
-			<artifactId>jaxrs-ri</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>

--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -477,22 +477,16 @@
         </dependency>
         <!-- REST API related dependencies - start -->
         <dependency>
-            <groupId>org.glassfish.jersey.bundles</groupId>
-            <artifactId>jaxrs-ri</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-json-binding</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/UTF8MultiPartReader.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/UTF8MultiPartReader.java
@@ -25,7 +25,7 @@ import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartProperties;
-import org.glassfish.jersey.media.multipart.internal.LocalizationMessages;
+import org.glassfish.jersey.media.multipart.internal.l10n.LocalizationMessages;
 import org.glassfish.jersey.message.internal.MediaTypes;
 import org.jvnet.mimepull.Header;
 import org.jvnet.mimepull.MIMEConfig;


### PR DESCRIPTION
Spring Boot 4.0.3 pins several Jersey artifacts to 4.0.2 via its BOM, while pom.xml pins others to 3.1.6. On top of that, jaxrs-ri-3.1.6.jar is a fat-JAR that bundles all Jersey 3.1.6 classes, creating duplicates of
classes that also exist in the individual 4.0.2 JARs.

Which version of a duplicate class gets loaded depends on the order the JVM scans JARs in WEB-INF/lib — and that order varies by environment. We observed different listing orders for the same image across three environments (k3s on Linux, Docker Desktop on Intel Mac, Colima on M4 Mac), with the same JVM (OpenJDK 21.0.10+7) and identical bytecode. Our assumption is that the filesystem or runtime environment affects the directory listing order, which determines whether the version mix causes a crash or happens to work.

On environments where it works, jaxrs-ri appears to load early enough that the inject classes end up consistently at 3.1.6. On environments where it crashes, individual 4.0.2 JARs load first for some classes while
jaxrs-ri provides 3.1.6 for others — creating a mix within the same package that results in:

ArrayStoreException: can not cast one of the elements of
org.glassfish.jersey.internal.inject.Binder[]
to the type of the destination array,
org.glassfish.jersey.internal.inject.AbstractBinder

Fix:

Upgrade jersey.version to 4.0.2 to match Spring Boot, remove the jaxrs-ri fat-JAR and adjusts related dependencies for Jersey 4.x compatibility.