### PR TITLE
Add external conversion services for media and office documents for Eterna 0.X

### DIFF
--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -43,8 +43,23 @@ services:
       - URL=http://localhost:8080/api/openapi.json
       - DOC_EXPANSION=none
       - VALIDATOR_URL=none
+  unoserver:
+    image: philiplehmann/unoserver:latest
+    restart: unless-stopped
+    entrypoint: [ "unoserver", "--interface", "0.0.0.0", "--port", "2003" ]
+    volumes:
+      - roda_data:/roda/data/
+  ffmpeg:
+    image: jrottenberg/ffmpeg:6.1-alpine
+    restart: unless-stopped
+    entrypoint: /bin/sh
+    command: /roda/data/ffmpeg-service/start.sh
+    environment:
+      - SHARED_VOLUME_PATH=/roda/data
+    volumes:
+      - roda_data:/roda/data
   eterna:
-    image: ghcr.io/eterna-earkiv/eterna:v0.5.0
+    image: eterna-earkiv/eterna:0.6.0-SNAPSHOT
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -58,9 +73,12 @@ services:
       - solr
       - clamd
       - siegfried
+      - unoserver
+      - ffmpeg
     volumes:
       - roda_data:/roda/data/
     environment:
+      - SHARED_VOLUME_PATH=/roda/data
       # Solr Cloud configuration
       - RODA_CORE_SOLR_TYPE=CLOUD
       - RODA_CORE_SOLR_CLOUD_URLS=zoo:2181

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,12 +10,16 @@ RUN set -ex; \
     zypper -n refresh && \
     zypper -n update && \
     zypper -n install --no-recommends \
-        java-21-openjdk-headless \
-        clamav \
-        zip \
-        unzip \
-        rsync \
-        jq && \
+            java-21-openjdk-headless \
+            clamav \
+            zip \
+            unzip \
+            rsync \
+            jq \
+            curl \
+            python311 \
+            python311-pip && \
+    pip3.11 install --no-cache-dir "unoserver==2.0.2" && \
     zypper clean -a && \
     chmod u-s /usr/bin/su && \
     chmod u-s /usr/bin/newgrp && \
@@ -31,7 +35,7 @@ RUN set -ex; \
     chmod g-s /usr/bin/chage && \
     chmod g-s /sbin/unix_chkpwd && \
     chmod g-s /sbin/unix2_chkpwd && \
-    chmod g-s /usr/lib/utempter/utempter 
+    chmod g-s /usr/lib/utempter/utempter
 
 
 # Copy Tomcat from the official image (maintains /usr/local/tomcat layout)
@@ -65,6 +69,8 @@ RUN set -ex; \
     echo "core.plugins.internal.virus_check.clamav.params = -m --fdpass" >> config/roda-core.properties && \
     echo "core.plugins.internal.virus_check.clamav.get_version = clamdscan --version" >> config/roda-core.properties && \
     echo "core.tools.siegfried.mode = server" >> config/roda-core.properties && \
+    echo "core.tools.unoserver.bin = /usr/local/bin/unoconvert" >> config/roda-core.properties && \
+    echo "core.tools.unoserver.params = --host unoserver --port 2003" >> config/roda-core.properties && \
     zip -q /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/roda-core-*.jar config/roda-core.properties && \
     zypper clean -a && \
     rm -f /usr/bin/container-suseconnect
@@ -86,6 +92,9 @@ RUN set -ex; \
     mkdir -p -m0770 "$RODA_HOME/data" && \
     mkdir -p -m0770 "$RODA_HOME/config" && \
     chown -R "$RODA_USER:0" "$RODA_HOME"
+
+COPY docker-files/ffmpeg-service /roda/data/ffmpeg-service
+RUN chmod +x /roda/data/ffmpeg-service/start.sh
 
 VOLUME "$RODA_HOME/data"
 

--- a/docker/docker-files/ffmpeg-service/server.py
+++ b/docker/docker-files/ffmpeg-service/server.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+import subprocess
+import os
+
+app = Flask(__name__)
+
+BASE_PATH = os.getenv("SHARED_VOLUME_PATH", "/roda/data")
+
+@app.route("/convert", methods=["POST"])
+def convert():
+    data = request.json
+
+    input_file = os.path.join(BASE_PATH, data["input"])
+    output_file = os.path.join(BASE_PATH, data["output"])
+
+    cmd = ["ffmpeg", "-y", "-i", input_file, output_file]
+
+    try:
+        subprocess.run(cmd, check=True)
+        return jsonify({"status": "success"})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8090)

--- a/docker/docker-files/ffmpeg-service/start.sh
+++ b/docker/docker-files/ffmpeg-service/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+apk add --no-cache python3 py3-pip
+pip install flask --break-system-packages
+
+python3 /roda/data/ffmpeg-service/server.py


### PR DESCRIPTION
### 1. Docker Compose Updates

Added new services:

- **Unoserver**
  - Provides LibreOffice-based document conversion.
  - Used for converting office documents via `unoconvert`.
  - Runs on port `2003`.

- **FFmpeg Service**
  - Handles media conversions using FFmpeg.
  - Implemented as a lightweight Flask API service.
  - Uses a shared volume to read input files and write outputs.

The `eterna` service was updated to:

- Depend on `unoserver` and `ffmpeg` services
- Share the same `roda_data` volume for file exchange
- Use `SHARED_VOLUME_PATH=/roda/data` for conversion workflows


### 2. Docker Image Updates

The Docker image was updated to support document conversion tools:

Installed:

- `python311`
- `python311-pip`
- `curl`

Other changes:

- Installed **Unoserver (`unoconvert`)** via pip
- Updated `roda-core.properties` configuration to include:
  - `core.tools.unoserver.bin`
  - `core.tools.unoserver.params`
- Added FFmpeg service startup scripts


### 3. FFmpeg Conversion Service

Added a lightweight Flask-based service that:

- Exposes a `/convert` API endpoint
- Executes FFmpeg commands to convert media files
- Uses the shared volume to access files