### PR TITLE
Realign page size selector in the table footer in Eterna 1.X

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -363,13 +363,18 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
     FlowPanel footer = new FlowPanel();
     footer.addStyleName("my-asyncdatagrid-footer");
 
+    FlowPanel footerLeft = new FlowPanel();
+    footerLeft.addStyleName("footer-left");
+    FlowPanel footerRight = new FlowPanel();
+    footerRight.addStyleName("footer-right");
+    footerLeft.add(csvDownloadButton);
+    footerRight.add(pageSizeSelectorPanel);
+    footerRight.add(resultsPager);
+    footerRight.add(autoUpdatePanel);
+    footer.add(footerLeft);
+    footer.add(footerRight);
     mainPanel.add(display);
     mainPanel.add(footer);
-    footer.add(csvDownloadButton);
-    footer.add(pageSizePager);
-    mainPanel.add(pageSizeSelectorPanel);
-    footer.add(resultsPager);
-    footer.add(autoUpdatePanel);
 
     sidePanel.add(actionsToolbar);
     sidePanel.add(sidePanelDivider);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -8026,10 +8026,21 @@ span.code {
 }
 
 .my-asyncdatagrid-footer {
-    display: flex;
-    justify-content: end;
-    align-items: center;
-    gap: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.my-asyncdatagrid-footer .footer-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.my-asyncdatagrid-footer .footer-left {
+  display: flex;
+  align-items: center;
 }
 
 .ActionableStyleButtons {


### PR DESCRIPTION
## Summary
Realigned the table footer layout to improve the placement of footer controls.

## Changes
- Moved the **Save Results** button to the left side of the footer.
- Grouped the **page size selector**, **pager** on the right side.
- Adjusted the footer layout to keep all controls aligned on a single row.

## Result
Improves the visual consistency and usability of the table footer by clearly separating the action button from pagination controls.
<img width="1366" height="768" alt="Screenshot from 2026-03-16 16-09-10" src="https://github.com/user-attachments/assets/cdb070c9-8797-40de-98cd-64fc9c23dbbf" />
