### PR TITLE
Chore/UI remove preingest menu item from Eterna V1.X

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/Ingest.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/Ingest.java
@@ -96,9 +96,7 @@ public class Ingest {
       init();
       callback.onSuccess(layout);
     } else {
-      if (historyTokens.get(0).equals(PreIngest.RESOLVER.getHistoryToken())) {
-        PreIngest.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
-      } else if (historyTokens.get(0).equals(IngestTransfer.RESOLVER.getHistoryToken())) {
+      if (historyTokens.get(0).equals(IngestTransfer.RESOLVER.getHistoryToken())) {
         IngestTransfer.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);
       } else if (historyTokens.get(0).equals(IngestProcess.RESOLVER.getHistoryToken())) {
         IngestProcess.RESOLVER.resolve(HistoryUtils.tail(historyTokens), callback);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
@@ -96,7 +96,6 @@ public class Header extends Composite {
   private MenuItem disseminationSearchBasic;
 
   private AcessibleMenuBar ingestMenu;
-  private MenuItem ingestPre;
   private MenuItem ingestTransfer;
   private MenuItem ingestList;
   private MenuItem ingestAppraisal;
@@ -149,9 +148,6 @@ public class Header extends Composite {
 
     ingestMenu = new AcessibleMenuBar(true);
     ingestMenu.addStyleName("bannerHeaderColors");
-    ingestPre = ingestMenu.addItem(messages.title("ingest_preIngest"),
-      createCommand(PreIngest.RESOLVER.getHistoryPath()));
-    ingestPre.addStyleName("ingest_pre_item");
     ingestTransfer = ingestMenu.addItem(messages.title("ingest_transfer"),
       createCommand(IngestTransfer.RESOLVER.getHistoryPath()));
     ingestTransfer.addStyleName("ingest_transfer_item");
@@ -280,7 +276,6 @@ public class Header extends Composite {
     updateResolverTopItemVisibility(Search.RESOLVER, disseminationSearchBasic, 2);
 
     // Ingest
-    updateResolverSubItemVisibility(PreIngest.RESOLVER, ingestPre);
     updateResolverSubItemVisibility(IngestTransfer.RESOLVER, ingestTransfer);
     updateResolverSubItemVisibility(IngestProcess.RESOLVER, ingestList);
     updateResolverSubItemVisibility(IngestAppraisal.RESOLVER, ingestAppraisal);

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1058,7 +1058,6 @@ title[planning_format]:Format register
 title[planning_riskregister]:Risk register
 title[ingest]:Ingest
 title[ingest_pre]:Pre-ingest
-title[ingest_preIngest]:Pre-ingest
 title[ingest_process]:Ingest process
 title[ingest_transfer]:Transfer
 title[ingest_submit]:Submit

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_AT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_AT.properties
@@ -1013,7 +1013,6 @@ title[planning_event]:Erhaltungsmaßnahmen
 title[planning_agent]:Preservation-Werkzeuge
 title[planning_format]:Formatregister
 title[ingest]:Ingest
-title[ingest_preIngest]:Pre-Ingest
 title[ingest_transfer]:Übertragung
 title[ingest_submit]:Einreichen
 title[ingest_submit_upload]:Paket senden

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_DE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_de_DE.properties
@@ -1013,7 +1013,6 @@ title[planning_event]:Erhaltungsereignisse
 title[planning_agent]:Erhaltungsmittel
 title[planning_format]:Formatregister
 title[ingest]:Übernahme
-title[ingest_preIngest]:Pre-Ingest
 title[ingest_transfer]:Übertragung
 title[ingest_submit]:Einreichen
 title[ingest_submit_upload]:Paket senden

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_es.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_es.properties
@@ -1013,7 +1013,6 @@ title[planning_event]:Eventos de preservación
 title[planning_agent]:Agentes de preservación
 title[planning_format]:Formato de Registro
 title[ingest]:Ingesta 
-title[ingest_preIngest]:Pre-ingesta
 title[ingest_transfer]:Transfer
 title[ingest_submit]:Enviar
 title[ingest_submit_upload]:Enviar paquete

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_es_CL.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_es_CL.properties
@@ -693,7 +693,6 @@ title[planning_agent]: Registro de agentes
 title[planning_format]: Formato de Registro
 
 title[ingest]: Ingesta
-title[ingest_preIngest]: Pre-ingesta
 title[ingest_transfer]: Transferir
 title[ingest_submit]: Enviar
 title[ingest_submit_upload]: Enviar paquete

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hr.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hr.properties
@@ -874,7 +874,6 @@ title[planning_event]:Registar događaja
 title[planning_agent]:Registar agenata
 title[planning_format]:Registar formata
 title[ingest]:Zaprimanje
-title[ingest_preIngest]:Prethodno zaprimanje
 title[ingest_transfer]:Prenesi
 title[ingest_submit]:Dostaviti
 title[ingest_submit_upload]:Pošaljite paket

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hu.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_hu.properties
@@ -1004,7 +1004,6 @@ title[planning_event]:Megőrzési események
 title[planning_agent]:Megőrzési képviseletek
 title[planning_format]:Formátum jegyzék
 title[ingest]:Befogadás
-title[ingest_preIngest]:Pre-ingest
 title[ingest_transfer]:Áthelyezés
 title[ingest_submit]:Beküldés
 title[ingest_submit_upload]:Csomag küldése

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
@@ -1038,7 +1038,6 @@ title[planning_event]:Eventos de preservação
 title[planning_agent]:Agentes de preservação
 title[planning_format]:Diretório de formatos
 title[ingest]:Ingestão
-title[ingest_preIngest]:Pré-ingestão
 title[ingest_transfer]:Transferência
 title[ingest_submit]:Enviar
 title[ingest_submit_upload]:Enviar pacote

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1034,7 +1034,6 @@ title[planning_format]:Formatregister
 title[planning_riskregister]:Riskregister
 title[ingest]:Leverans
 title[ingest_pre]:Leveransförberedelse
-title[ingest_preIngest]:Leveransförberedelse
 title[ingest_process]:Inleveransprocess
 title[ingest_transfer]:Inleverans
 title[ingest_submit]:Lämna in


### PR DESCRIPTION
## Summary
This PR removes the **PreIngest** menu item from the application along with its associated i18n keys and references.

## Changes
- Removed `ingest_preIngest` key from all i18n locale files  
- Removed **PreIngest** menu item from the Header navigation  
- Deleted related variable (`ingestPre`) and menu initialization logic  
- Removed visibility handling for PreIngest in the navigation menu  

## Impact
- The PreIngest option is no longer available in the UI  
- No impact on other ingest-related functionalities (Transfer, List, Appraisal remain intact)


<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7cc8737f-efb4-4492-b269-fb9ee2418e7f" />
