### PR TITLE
Add external conversion services for media and office documents for Eterna v1.X

### DIFF
--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - solr_data:/var/solr
 
   clamd:
-    image: docker.io/clamav/clamav:1.4
+    image: docker.io/clamav/clamav:stable
     restart: unless-stopped
     volumes:
       - clam_data:/var/lib/clamav
@@ -56,7 +56,7 @@ services:
       - "8025:8025" # web ui
 
   openldap:
-    image: docker.io/bitnami/openldap:2.6
+    image: docker.io/bitnamilegacy/openldap:latest
     restart: unless-stopped
     user: 1001:root
     ports:
@@ -72,8 +72,25 @@ services:
     volumes:
       - ./ldap/ldif/pbkdf2.ldif:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
 
+  unoserver:
+    image: philiplehmann/unoserver:latest
+    restart: unless-stopped
+    entrypoint: [ "unoserver", "--interface", "0.0.0.0", "--port", "2003" ]
+    volumes:
+      - roda_data:/roda/data/
+
+  ffmpeg:
+    image: jrottenberg/ffmpeg:6.1-alpine
+    restart: unless-stopped
+    entrypoint: /bin/sh
+    command: /roda/data/ffmpeg-service/start.sh
+    environment:
+      - SHARED_VOLUME_PATH=/roda/data
+    volumes:
+      - roda_data:/roda/data
+
   eterna:
-    image: ghcr.io/eterna-earkiv/eterna:test-eterna-v1-alpha-latest
+    image: eterna-earkiv/eterna:latest
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -82,10 +99,13 @@ services:
       - clamd
       - siegfried
       - postgres
+      - unoserver
+      - ffmpeg
     volumes:
       - roda_data:/roda/data/
       - ./roda/config/roda-core.properties:/roda/config/roda-core.properties:ro
     environment:
+      - SHARED_VOLUME_PATH=/roda/data
       # Spring configuration
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/roda_core_db
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,15 +5,17 @@ LABEL maintainer="admin@keep.pt" vendor="KEEP SOLUTIONS"
 RUN set -ex; \
     apt-get -qq update && \
     apt-get -qq -y install software-properties-common && \
-    apt-get -qq -y --no-install-recommends install clamdscan jq rsync && \
+    apt-get -qq -y --no-install-recommends install \
+        clamdscan jq rsync \
+        python3 python3-pip && \
+    pip3 install --no-cache-dir unoserver==2.0.2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-	DEBIAN_FRONTEND=noninteractive \
-	apt-get autoremove -y --purge "*python*"
+	DEBIAN_FRONTEND=noninteractive
 
-COPY ./docker/docker-files/clamd.conf /etc/clamav/clamd.conf
+COPY ./docker-files/clamd.conf /etc/clamav/clamd.conf
 
 # Copy the Roda WUI WAR file
-COPY roda-ui/roda-wui/target/roda-wui-*.jar  /KEEPS/bin/
+COPY ./target/roda-wui-1.0.0-alpha-SNAPSHOT.jar  /KEEPS/bin/
 
 ENV RODA_HOME=/roda \
     LDAP_SERVER_URL=ldap://openldap \
@@ -26,8 +28,8 @@ ENV RODA_HOME=/roda \
     RODA_GROUP="roda" \
     RODA_GID="1000"
 
-COPY ./docker/docker-files/docker-entrypoint.sh /
-COPY ./docker/docker-files/docker-entrypoint.d/* /docker-entrypoint.d/
+COPY ./docker-files/docker-entrypoint.sh /
+COPY ./docker-files/docker-entrypoint.d/* /docker-entrypoint.d/
 
 RUN set -ex; \
   groupadd -r --gid "$RODA_GID" "$RODA_GROUP"; \
@@ -35,6 +37,9 @@ RUN set -ex; \
   mkdir -p -m0770 "$RODA_HOME/data"; \
   mkdir -p -m0770 "$RODA_HOME/config"; \
   chown -R "$RODA_USER:0" "$RODA_HOME"
+
+COPY docker-files/ffmpeg-service /roda/data/ffmpeg-service
+RUN chmod +x /roda/data/ffmpeg-service/start.sh
 
 VOLUME "$RODA_HOME/data"
 

--- a/docker/docker-files/ffmpeg-service/server.py
+++ b/docker/docker-files/ffmpeg-service/server.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+import subprocess
+import os
+
+app = Flask(__name__)
+
+BASE_PATH = os.getenv("SHARED_VOLUME_PATH", "/roda/data")
+
+@app.route("/convert", methods=["POST"])
+def convert():
+    data = request.json
+
+    input_file = os.path.join(BASE_PATH, data["input"])
+    output_file = os.path.join(BASE_PATH, data["output"])
+
+    cmd = ["ffmpeg", "-y", "-i", input_file, output_file]
+
+    try:
+        subprocess.run(cmd, check=True)
+        return jsonify({"status": "success"})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8090)

--- a/docker/docker-files/ffmpeg-service/start.sh
+++ b/docker/docker-files/ffmpeg-service/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+apk add --no-cache python3 py3-pip
+pip install flask --break-system-packages
+
+python3 /roda/data/ffmpeg-service/server.py


### PR DESCRIPTION
### 1. Docker Compose Updates

Added new services:

- **Unoserver**
  - Provides LibreOffice-based document conversion.
  - Used for converting office documents via `unoconvert`.
  - Runs on port `2003`.

- **FFmpeg Service**
  - Handles media conversions using FFmpeg.
  - Implemented as a lightweight Flask API service.
  - Uses a shared volume to read input files and write outputs.

The `eterna` service was updated to:

- Depend on `unoserver` and `ffmpeg` services
- Share the same `roda_data` volume for file exchange
- Use `SHARED_VOLUME_PATH=/roda/data` for conversion workflows


### 2. Docker Image Updates

The Docker image was updated to support document conversion tools:

Installed:

- `python311`
- `python311-pip`
- `curl`

Other changes:

- Installed **Unoserver (`unoconvert`)** via pip
- Updated `roda-core.properties` configuration to include:
  - `core.tools.unoserver.bin`
  - `core.tools.unoserver.params`
- Added FFmpeg service startup scripts


### 3. FFmpeg Conversion Service

Added a lightweight Flask-based service that:

- Exposes a `/convert` API endpoint
- Executes FFmpeg commands to convert media files
- Uses the shared volume to access files