### PR TITLE
Feat/pdf redactor enhancements integration

### DIFF
--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <gwt.module.main>org.roda.wui.RodaWUI</gwt.module.main>
         <gwt.module.portal>org.roda.wui.RodaWUIPortal</gwt.module.portal>
+        <pdf.redactor.version>1.0.2</pdf.redactor.version>
     </properties>
     <packaging>jar</packaging>
     <profiles>
@@ -701,7 +702,7 @@
         <dependency>
             <groupId>se.whitered.eterna</groupId>
             <artifactId>pdf-redactor</artifactId>
-            <version>1.0.1</version>
+            <version>${pdf.redactor.version}</version>
         </dependency>
         <!-- Spring boot -->
         <dependency>

--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <gwt.module.main>org.roda.wui.RodaWUI</gwt.module.main>
         <gwt.module.portal>org.roda.wui.RodaWUIPortal</gwt.module.portal>
-        <pdf.redactor.version>1.0.2</pdf.redactor.version>
+        <pdf.redactor.version>1.0.3</pdf.redactor.version>
     </properties>
     <packaging>jar</packaging>
     <profiles>

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2658,4 +2658,8 @@ public interface ClientMessages extends Messages {
   String reasonCantActOnUser();
 
   String reasonCantActOnGroup();
+
+  String redactPdfInvalidFormatMessage();
+
+  String redactPdfMissingIdentifiers();
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
@@ -66,7 +66,7 @@ public class FileSearchWrapperActions extends AbstractActionable<IndexedFile> {
 
   private static final Set<Action<IndexedFile>> POSSIBLE_ACTIONS_ON_SINGLE_FILE_BITSTREAM = new HashSet<>(
     Arrays.asList(FileSearchWrapperAction.MOVE, FileSearchWrapperAction.REMOVE, FileSearchWrapperAction.NEW_PROCESS,
-      FileSearchWrapperAction.IDENTIFY_FORMATS,FileSearchWrapperAction.REDACT_PDF));
+      FileSearchWrapperAction.IDENTIFY_FORMATS));
 
   private static final Set<Action<IndexedFile>> POSSIBLE_ACTIONS_ON_MULTIPLE_FILES_FROM_THE_SAME_REPRESENTATION = new HashSet<>(
     Arrays.asList(FileSearchWrapperAction.MOVE, FileSearchWrapperAction.REMOVE, FileSearchWrapperAction.NEW_PROCESS,
@@ -148,6 +148,12 @@ public class FileSearchWrapperActions extends AbstractActionable<IndexedFile> {
     if (AIPState.UNDER_APPRAISAL.equals(state)) {
       return new CanActResult(POSSIBLE_ACTIONS_ON_SINGLE_FILE_UNDER_APPRAISAL.contains(action),
         CanActResult.Reason.CONTEXT, messages.reasonAIPUnderAppraisal());
+    }
+
+    if (FileSearchWrapperAction.REDACT_PDF.equals(action)) {
+      boolean canRedact = !file.isDirectory()
+              && FileFormatSharedUtils.hasFileFormat(file, FileFormatSharedUtils.MIMETYPE_PDF, FileFormatSharedUtils.EXTENSION_PDF);
+      return new CanActResult(canRedact, CanActResult.Reason.CONTEXT, messages.reasonCantActOnFileBitstream());
     }
 
     if (file.isDirectory()) {
@@ -238,9 +244,8 @@ public class FileSearchWrapperActions extends AbstractActionable<IndexedFile> {
 
   // ACTIONS
     private void redactPdf(final IndexedFile file, final AsyncCallback<ActionImpact> callback) {
-    if (!FileFormatSharedUtils.hasFileFormat(file, "application/pdf", "pdf")) {
-      Dialogs.showInformationDialog(messages.redactPdfToastTitle(),
-        messages.redactPdfOnlyPdfDialogMessage(), messages.dialogOk(), false);
+    if (!FileFormatSharedUtils.hasFileFormat(file, FileFormatSharedUtils.MIMETYPE_PDF, FileFormatSharedUtils.EXTENSION_PDF)) {
+      Dialogs.showInformationDialog("Error!", "Can only redact PDF-files.", "Ok", false);
       callback.onSuccess(ActionImpact.NONE);
       return;
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
@@ -245,7 +245,12 @@ public class FileSearchWrapperActions extends AbstractActionable<IndexedFile> {
   // ACTIONS
     private void redactPdf(final IndexedFile file, final AsyncCallback<ActionImpact> callback) {
     if (!FileFormatSharedUtils.hasFileFormat(file, FileFormatSharedUtils.MIMETYPE_PDF, FileFormatSharedUtils.EXTENSION_PDF)) {
-      Dialogs.showInformationDialog("Error!", "Can only redact PDF-files.", "Ok", false);
+      Dialogs.showInformationDialog(
+              messages.alertErrorTitle(),
+              messages.redactPdfInvalidFormatMessage(),// or a more specific key if available
+              messages.dialogOk(),
+              false
+      );
       callback.onSuccess(ActionImpact.NONE);
       return;
     }
@@ -256,7 +261,7 @@ public class FileSearchWrapperActions extends AbstractActionable<IndexedFile> {
     List<String> path = file.getPath() != null ? file.getPath() : Collections.emptyList();
 
     if (aipId == null || representationId == null || fileId == null) {
-      Toast.showError("Cannot redact PDF: Missing required identifiers (AIP: " + aipId + ", Rep: " + representationId + ", File: " + fileId + ")");
+      Toast.showError(messages.redactPdfMissingIdentifiers());
       callback.onSuccess(ActionImpact.NONE);
       return;
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileToolbarActions.java
@@ -69,7 +69,7 @@ public class FileToolbarActions extends AbstractActionable<IndexedFile> {
       FileAction.IDENTIFY_FORMATS));
 
   private static final Set<FileAction> POSSIBLE_ACTIONS_ON_SINGLE_FILE_BITSTREAM = new HashSet<>(Arrays.asList(
-    FileAction.DOWNLOAD, FileAction.MOVE, FileAction.REMOVE, FileAction.NEW_PROCESS, FileAction.IDENTIFY_FORMATS, FileAction.REDACT_PDF));
+    FileAction.DOWNLOAD, FileAction.MOVE, FileAction.REMOVE, FileAction.NEW_PROCESS, FileAction.IDENTIFY_FORMATS));
 
   private static final Set<FileAction> POSSIBLE_ACTIONS_ON_MULTIPLE_FILES_FROM_THE_SAME_REPRESENTATION = new HashSet<>(
     Arrays.asList(FileAction.MOVE, FileAction.REMOVE, FileAction.NEW_PROCESS, FileAction.IDENTIFY_FORMATS));
@@ -148,6 +148,12 @@ public class FileToolbarActions extends AbstractActionable<IndexedFile> {
     if (AIPState.UNDER_APPRAISAL.equals(state)) {
       return new CanActResult(POSSIBLE_ACTIONS_ON_FILE_UNDER_APPRAISAL.contains(action),
               CanActResult.Reason.CONTEXT, messages.reasonAIPUnderAppraisal());
+    }
+
+    if (FileAction.REDACT_PDF.equals(action)) {
+      boolean canRedact = !file.isDirectory()
+              && FileFormatSharedUtils.hasFileFormat(file, FileFormatSharedUtils.MIMETYPE_PDF, FileFormatSharedUtils.EXTENSION_PDF);
+      return new CanActResult(canRedact, CanActResult.Reason.CONTEXT, messages.reasonCantActOnFileBitstream());
     }
 
     if (file.isDirectory()) {
@@ -248,10 +254,10 @@ public class FileToolbarActions extends AbstractActionable<IndexedFile> {
 
   // ACTIONS
     private void redactPdf(final IndexedFile file, final AsyncCallback<ActionImpact> callback) {
-    if (!FileFormatSharedUtils.hasFileFormat(file, "application/pdf", "pdf")) {
-      Dialogs.showInformationDialog(messages.redactPdfToastTitle(),
-        messages.redactPdfOnlyPdfDialogMessage(), messages.dialogOk(), false);
-      callback.onSuccess(ActionImpact.NONE);
+        if (!FileFormatSharedUtils.hasFileFormat(file, FileFormatSharedUtils.MIMETYPE_PDF, FileFormatSharedUtils.EXTENSION_PDF)) {
+            Dialogs.showInformationDialog(messages.redactPdfToastTitle(),
+                    messages.redactPdfOnlyPdfDialogMessage(), messages.dialogOk(), false);
+            callback.onSuccess(ActionImpact.NONE);
       return;
     }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FileFormatSharedUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FileFormatSharedUtils.java
@@ -5,6 +5,8 @@ import org.roda.core.data.v2.ip.IndexedFile;
 import org.roda.core.data.v2.ip.metadata.FileFormat;
 
 public class FileFormatSharedUtils {
+  public static final String MIMETYPE_PDF = "application/pdf";
+  public static final String EXTENSION_PDF = "pdf";
 
   private FileFormatSharedUtils() {}
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -60,8 +60,8 @@ public class PDFRedactor extends Composite {
 
   private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
 
-  public static final String JS_PATH = "webjars/pdf-redactor/1.0.1/pdf-redactor.js";
-  public static final String CSS_PATH = "webjars/pdf-redactor/1.0.1/pdf-redactor.css";
+  public static final String JS_PATH = "webjars/pdf-redactor/pdf-redactor.js";
+  public static final String CSS_PATH = "webjars/pdf-redactor/pdf-redactor.css";
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
   public static String[] requiredRoles = new String[]{"representation.view", "representation.read", "representation.create", "representation.update"};
   private static PDFRedactor instance = null;
@@ -174,7 +174,7 @@ public class PDFRedactor extends Composite {
   private void initPdfRedactorPanel(final String aipId, final IndexedFile file, final String downloadUrl) {
     pdfRedactorPanel.setUrl(downloadUrl);
     pdfRedactorPanel.mount();
-    pdfRedactorPanel.setSaveCallback((Blob pdfData) -> {
+    pdfRedactorPanel.setSaveCallback((Blob pdfData) ->
       getOrCreateRedactedRepresentation(aipId).then((representation) -> {
         List<String> path = new ArrayList<>(file.getPath());
 
@@ -187,24 +187,23 @@ public class PDFRedactor extends Composite {
         requestInit.setMethod("POST");
         requestInit.setBody(formData);
 
-        fetch(uploadUrl, requestInit).then(response -> {
+        return fetch(uploadUrl, requestInit).then(response -> {
           if (response.ok) {
             Toast.showInfo(messages.redactPdfToastTitle(), messages.redactPdfSaveSuccessDescription());
+            return Promise.resolve(response);
           } else if (response.status == RodaConstants.HTTP_RESPONSE_CODE_REQUEST_CONFLICT) {
             Toast.showError(messages.redactPdfToastTitle(), messages.fileAlreadyExists());
+            return Promise.resolve(response);
           } else {
             Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
-          }
-          return null;
+                  return Promise.resolve(response);
+                }
+              });
         }).catch_(error -> {
           Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
-          return null;
-        });
-        return null;
-      });
-
-      return true;
-    });
+          return Promise.reject(error);
+        })
+    );
   }
 
   private static Promise<IndexedRepresentation> getOrCreateRedactedRepresentation(String aipId) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -15,6 +15,7 @@ import org.roda.core.data.v2.index.IndexedRepresentationRequest;
 import org.roda.wui.client.common.NavigationToolbar;
 import org.roda.wui.common.client.widgets.Toast;
 import org.roda.wui.common.client.widgets.wcag.AccessibleFocusPanel;
+import elemental2.dom.AbortSignal;
 import elemental2.dom.Blob;
 import elemental2.dom.FormData;
 import elemental2.dom.RequestInit;
@@ -174,7 +175,7 @@ public class PDFRedactor extends Composite {
   private void initPdfRedactorPanel(final String aipId, final IndexedFile file, final String downloadUrl) {
     pdfRedactorPanel.setUrl(downloadUrl);
     pdfRedactorPanel.mount();
-    pdfRedactorPanel.setSaveCallback((Blob pdfData) ->
+    pdfRedactorPanel.setSaveCallback((Blob pdfData, AbortSignal signal) ->
       getOrCreateRedactedRepresentation(aipId).then((representation) -> {
         List<String> path = new ArrayList<>(file.getPath());
 
@@ -186,6 +187,7 @@ public class PDFRedactor extends Composite {
         RequestInit requestInit = RequestInit.create();
         requestInit.setMethod("POST");
         requestInit.setBody(formData);
+        requestInit.setSignal(signal);
 
         return fetch(uploadUrl, requestInit).then(response -> {
           if (response.ok) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -195,12 +195,12 @@ public class PDFRedactor extends Composite {
             return Promise.resolve(response);
           } else if (response.status == RodaConstants.HTTP_RESPONSE_CODE_REQUEST_CONFLICT) {
             Toast.showError(messages.redactPdfToastTitle(), messages.fileAlreadyExists());
-            return Promise.resolve(response);
+            return Promise.reject(response);
           } else {
             Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
-                  return Promise.resolve(response);
-                }
-              });
+            return Promise.reject(response);
+          }
+        });
         }).catch_(error -> {
           Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
           return Promise.reject(error);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
@@ -1,6 +1,7 @@
 package org.roda.wui.client.redact;
 
 import com.google.gwt.dom.client.Element;
+import elemental2.dom.AbortSignal;
 import elemental2.dom.Blob;
 import elemental2.promise.Promise;
 import jsinterop.annotations.JsFunction;
@@ -12,7 +13,7 @@ import jsinterop.annotations.JsType;
 public class PDFRedactorObject {
   @JsFunction
   public interface SaveCallback {
-    Promise<?> onInvoke(Blob pdfData);
+    Promise<?> onInvoke(Blob pdfData, AbortSignal signal);
   }
 
   @JsMethod

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
@@ -2,6 +2,7 @@ package org.roda.wui.client.redact;
 
 import com.google.gwt.dom.client.Element;
 import elemental2.dom.Blob;
+import elemental2.promise.Promise;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
@@ -11,7 +12,7 @@ import jsinterop.annotations.JsType;
 public class PDFRedactorObject {
   @JsFunction
   public interface SaveCallback {
-    public abstract boolean onInvoke(Blob pdfData);
+    Promise<?> onInvoke(Blob pdfData);
   }
 
   @JsMethod

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -385,6 +385,8 @@ redactPdfButton:Redact PDF
 redactPdfToastTitle:PDF Redactor
 redactPdfSaveSuccessDescription:Redacted PDF saved successfully.
 redactPdfSaveErrorDescription:Error saving redacted PDF.
+redactPdfInvalidFormatMessage:Only PDF files can be redacted.
+redactPdfMissingIdentifiersMessage:Cannot redact PDF due to missing required information.
 redactPdfOnlyPdfDialogMessage:Can only redact PDF files.
 # Identify formats
 identifyFormatsButton:Identify formats

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -386,7 +386,7 @@ redactPdfToastTitle:PDF Redactor
 redactPdfSaveSuccessDescription:Redacted PDF saved successfully.
 redactPdfSaveErrorDescription:Error saving redacted PDF.
 redactPdfInvalidFormatMessage:Only PDF files can be redacted.
-redactPdfMissingIdentifiersMessage:Cannot redact PDF due to missing required information.
+redactPdfMissingIdentifiers:Cannot redact PDF due to missing required information.
 redactPdfOnlyPdfDialogMessage:Can only redact PDF files.
 # Identify formats
 identifyFormatsButton:Identify formats

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -381,7 +381,7 @@ redactPdfToastTitle:PDF-redigerare
 redactPdfSaveSuccessDescription:Den redigerade PDF-filen har sparats.
 redactPdfSaveErrorDescription:Ett fel uppstod när den redigerade PDF-filen skulle sparas.
 redactPdfInvalidFormatMessage:Endast PDF-filer kan maskeras.
-redactPdfMissingIdentifiersMessage:Kan inte maskera PDF på grund av saknad nödvändig information.
+redactPdfMissingIdentifiers:Kan inte maskera PDF på grund av saknad nödvändig information.
 redactPdfOnlyPdfDialogMessage:Det går bara att maskera PDF-filer.
 # Identify formats
 identifyFormatsButton:Identifiera format

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -380,6 +380,8 @@ redactPdfButton:Maskera PDF
 redactPdfToastTitle:PDF-redigerare
 redactPdfSaveSuccessDescription:Den redigerade PDF-filen har sparats.
 redactPdfSaveErrorDescription:Ett fel uppstod när den redigerade PDF-filen skulle sparas.
+redactPdfInvalidFormatMessage:Endast PDF-filer kan maskeras.
+redactPdfMissingIdentifiersMessage:Kan inte maskera PDF på grund av saknad nödvändig information.
 redactPdfOnlyPdfDialogMessage:Det går bara att maskera PDF-filer.
 # Identify formats
 identifyFormatsButton:Identifiera format


### PR DESCRIPTION
## Summary
This PR updates ETERNA to integrate the enhanced [eterna-pdf-redactor](https://github.com/ETERNA-earkiv/eterna-pdf-redactor) library with async save callback support and improved redaction behavior.

## Changes
- Updated dependency to [eterna-pdf-redactor@1.0.3](https://github.com/ETERNA-earkiv/eterna-pdf-redactor)
- Adapted integration to support async save callbacks (`Promise<boolean>`)
- Improved save/upload handling to reflect actual operation result
- Fixed incorrect success feedback when upload fails

## Behavior Improvements
- Save operation now correctly reflects backend upload status
- UI feedback aligns with actual success/failure conditions

## Dependency
- Depends on [eterna-pdf-redactor@1.0.3](https://github.com/ETERNA-earkiv/eterna-pdf-redactor)

## Notes
- This PR should be merged only after the eterna-pdf-redactor version 1.0.3 is published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nya funktioner**
  * Redigera (redacta) PDF direkt från filverktyget via ny knapp.
  * Navigeringshistorik skapas automatiskt efter redigering.

* **Felkorrigeringar**
  * Åtgärd endast tillgänglig för PDF-filer; tydliga dialoger/toasts vid ogiltiga filer eller saknade identifierare.
  * Hantering av sparresultat förbättrad: visar framgång, konflikt eller generellt fel beroende på serverrespons.

* **Chores**
  * Uppdaterade resurspaketvägar och nya översatta i18n-strängar för redigeringsflödet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->