### PR TITLE
Fix/conversion list alphabetical order v1.x

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
@@ -9,7 +9,7 @@ package org.roda.core.data.v2.properties;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -22,7 +22,7 @@ public class ConversionProfiles implements Serializable {
   private Set<ConversionProfile> conversionProfileSet;
 
   public ConversionProfiles() {
-    conversionProfileSet = new HashSet<>();
+    conversionProfileSet = new LinkedHashSet<>();
   }
 
   public Set<ConversionProfile> getConversionProfileSet() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ConfigurationsService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ConfigurationsService.java
@@ -95,20 +95,24 @@ public class ConfigurationsService {
     List<String> dropdownItems = RodaUtils.copyList(
       RodaCoreFactory.getRodaConfiguration().getList("core.plugins.conversion.profile." + pluginName + ".profiles[]"));
     Locale locale = ServerTools.parseLocale(localeString);
-
     ResourceBundle pluginMessages = RodaCoreFactory.getPluginMessages(pluginId, locale);
 
+    List<ConversionProfile> profiles = new ArrayList<>();
     for (String item : dropdownItems) {
       ConversionProfile conversionProfile = retrieveConversionProfileItem(item, pluginName, pluginMessages);
       if (outcomeType.equals(ConversionProfileOutcomeType.REPRESENTATION)
         && conversionProfile.canBeUsedForRepresentation()) {
-        items.addObject(conversionProfile);
+        profiles.add(conversionProfile);
       }
 
       if (outcomeType.equals(ConversionProfileOutcomeType.DISSEMINATION)
         && conversionProfile.canBeUsedForDissemination()) {
-        items.addObject(conversionProfile);
+        profiles.add(conversionProfile);
       }
+    }
+    profiles.sort((a, b) -> a.getTitle().compareToIgnoreCase(b.getTitle()));
+    for (ConversionProfile profile : profiles) {
+      items.addObject(profile);
     }
 
     return items;


### PR DESCRIPTION
##  Summary
Fixes inconsistent ordering of conversion profiles in the dropdown.

---

## Changes
- Sort conversion profiles alphabetically by title
- Replace `HashSet` with `LinkedHashSet` to preserve order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Konverteringsprofiler presenteras nu i alfabetisk ordning efter titel för förbättrad användarupplevelse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->