### PR TITLE
fix: resolve file UUID to full composite path in download endpoint

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -247,7 +247,7 @@ public class FilesService {
   public StreamResponse retrieveAIPRepresentationFile(RequestContext requestContext, IndexedFile indexedFile)
     throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
     ModelService model = requestContext.getModelService();
-    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(File.class, indexedFile.getId());
+    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(indexedFile);
     if (liteFile.isEmpty()) {
       throw new RequestNotValidException("Couldn't retrieve file with id: " + indexedFile.getId());
     }


### PR DESCRIPTION
Closes #239

## Summary

- `GET /api/v2/files/{uuid}/download` was calling `LiteRODAObjectFactory.get(File.class, indexedFile.getId())`, passing only the filename as a single ID
- `LiteRODAObjectFactory` requires a minimum of 3 IDs (`aipId + representationId + fileId`) for `File.class` — with only 1, it returned `Optional.empty()`, causing a 400 for every file
- Fixed by replacing with `LiteRODAObjectFactory.get(indexedFile)`, which invokes `getFileFromIndex()` and correctly assembles the full composite path `[aipId, representationId, ...path, fileId]` — the same resolution used by the working `/preview` endpoint

## Test plan

- [ ] `GET /api/v2/files/{uuid}/download` returns 200 with binary content for a `.warc` file
- [ ] `GET /api/v2/files/{uuid}/download` returns 200 with binary content for `.pdf` and `.xml` files
- [ ] `GET /api/v2/files/{uuid}/download` returns 200 for a file nested inside a directory path
- [ ] `GET /api/v2/files/{uuid}/preview` continues to work as before (no regression)
- [ ] Directory download (export as ZIP) still works via the same code path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Förbättrad intern hantering av filhämtning för ökad systemstabilitet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->