### PR TITLE
Fix/user details extra fields error message v1.x

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
@@ -583,7 +583,11 @@ public class HtmlSnippetUtils {
       final Label mvText = new Label();
       mvText.setTitle(mvLabel.getText());
       mvText.addStyleName("value");
-      mvText.setText(mv.get("value"));
+      String displayValue = mv.get("value");
+      if ("list".equals(mv.get("type"))) {
+        displayValue = FormUtilities.getLocalizedListValue(mv, displayValue);
+      }
+      mvText.setText(displayValue);
 
       layout.add(mvLabel);
       layout.add(mvText);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
@@ -13,15 +13,12 @@ import java.util.Set;
 
 import org.roda.core.data.v2.user.RODAMember;
 import org.roda.core.data.v2.user.User;
-import org.roda.core.data.v2.generics.MetadataValue;
-import org.roda.wui.client.browse.bundle.UserExtraBundle;
 import org.roda.wui.client.common.NoAsyncCallback;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.actions.Actionable;
 import org.roda.wui.client.common.actions.RODAMemberActions;
 import org.roda.wui.client.common.actions.model.ActionableObject;
 import org.roda.wui.client.common.actions.widgets.ActionableWidgetBuilder;
-import org.roda.wui.client.common.utils.FormUtilities;
 import org.roda.wui.client.common.utils.HtmlSnippetUtils;
 import org.roda.wui.client.common.utils.SidebarUtils;
 import org.roda.wui.client.management.access.AccessKeyTablePanel;
@@ -34,7 +31,6 @@ import org.roda.wui.common.client.tools.ListUtils;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
@@ -156,7 +152,6 @@ public class ShowUser extends Composite {
     SidebarUtils.toggleSidebar(contentFlowPanel, sidebarFlowPanel, rodaMemberActions.hasAnyRoles());
     actionsSidebar.setWidget(actionableWidgetBuilder.buildListWithObjects(new ActionableObject<>(this.user)));
   }
-
 
   private void buildPermissionList() {
     Set<String> allUserRoles = user.getAllRoles();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
@@ -124,7 +124,7 @@ public class ShowUser extends Composite {
     stateValue.setHTML(HtmlSnippetUtils.getUserStateHtml(user));
 
     // Extra fields
-    loadExtraFields();
+//    loadExtraFields();
 
     if (!user.getExtra().isEmpty()) {
       HtmlSnippetUtils.createExtraShow(extraValue, user.getExtra(), false);
@@ -160,53 +160,53 @@ public class ShowUser extends Composite {
     actionsSidebar.setWidget(actionableWidgetBuilder.buildListWithObjects(new ActionableObject<>(this.user)));
   }
 
-  private void loadExtraFields() {
-    UserManagementService.Util.getInstance().retrieveUserExtraBundle(user.getName(),
-      new AsyncCallback<UserExtraBundle>() {
-        @Override
-        public void onFailure(Throwable caught) {
-          extraValue.add(new Label("Error loading extra fields"));
-        }
+//  private void loadExtraFields() {
+//    UserManagementService.Util.getInstance().retrieveUserExtraBundle(user.getName(),
+//      new AsyncCallback<UserExtraBundle>() {
+//        @Override
+//        public void onFailure(Throwable caught) {
+//          extraValue.add(new Label("Error loading extra fields"));
+//        }
+//
+//        @Override
+//        public void onSuccess(UserExtraBundle bundle) {
+//          displayExtraFields(bundle);
+//        }
+//      });
+//  }
 
-        @Override
-        public void onSuccess(UserExtraBundle bundle) {
-          displayExtraFields(bundle);
-        }
-      });
-  }
-
-  private void displayExtraFields(UserExtraBundle bundle) {
-    if (bundle != null && bundle.getValues() != null && !bundle.getValues().isEmpty()) {
-      for (MetadataValue mv : bundle.getValues()) {
-        String label = FormUtilities.getFieldLabel(mv);
-        String value = mv.get("value");
-
-        if (value != null && !value.trim().isEmpty()) {
-          // For list fields, convert stored value to localized display text
-          String displayValue = value;
-          String fieldType = mv.get("type");
-          if ("list".equals(fieldType)) {
-            displayValue = FormUtilities.getLocalizedListValue(mv, value);
-          }
-
-          FlowPanel fieldPanel = new FlowPanel();
-          fieldPanel.setStyleName("field");
-
-          Label labelWidget = new Label(label);
-          labelWidget.setStyleName("label");
-
-          Label valueWidget = new Label(displayValue);
-          valueWidget.setStyleName("value");
-
-          fieldPanel.add(labelWidget);
-          fieldPanel.add(valueWidget);
-
-          extraValue.add(fieldPanel);
-        }
-      }
-    }
-    // Don't show anything when there are no extra fields
-  }
+//  private void displayExtraFields(UserExtraBundle bundle) {
+//    if (bundle != null && bundle.getValues() != null && !bundle.getValues().isEmpty()) {
+//      for (MetadataValue mv : bundle.getValues()) {
+//        String label = FormUtilities.getFieldLabel(mv);
+//        String value = mv.get("value");
+//
+//        if (value != null && !value.trim().isEmpty()) {
+//          // For list fields, convert stored value to localized display text
+//          String displayValue = value;
+//          String fieldType = mv.get("type");
+//          if ("list".equals(fieldType)) {
+//            displayValue = FormUtilities.getLocalizedListValue(mv, value);
+//          }
+//
+//          FlowPanel fieldPanel = new FlowPanel();
+//          fieldPanel.setStyleName("field");
+//
+//          Label labelWidget = new Label(label);
+//          labelWidget.setStyleName("label");
+//
+//          Label valueWidget = new Label(displayValue);
+//          valueWidget.setStyleName("value");
+//
+//          fieldPanel.add(labelWidget);
+//          fieldPanel.add(valueWidget);
+//
+//          extraValue.add(fieldPanel);
+//        }
+//      }
+//    }
+//    // Don't show anything when there are no extra fields
+//  }
 
   private void buildPermissionList() {
     Set<String> allUserRoles = user.getAllRoles();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
@@ -123,9 +123,6 @@ public class ShowUser extends Composite {
     emailValue.setText(user.getEmail());
     stateValue.setHTML(HtmlSnippetUtils.getUserStateHtml(user));
 
-    // Extra fields
-//    loadExtraFields();
-
     if (!user.getExtra().isEmpty()) {
       HtmlSnippetUtils.createExtraShow(extraValue, user.getExtra(), false);
     }
@@ -160,53 +157,6 @@ public class ShowUser extends Composite {
     actionsSidebar.setWidget(actionableWidgetBuilder.buildListWithObjects(new ActionableObject<>(this.user)));
   }
 
-//  private void loadExtraFields() {
-//    UserManagementService.Util.getInstance().retrieveUserExtraBundle(user.getName(),
-//      new AsyncCallback<UserExtraBundle>() {
-//        @Override
-//        public void onFailure(Throwable caught) {
-//          extraValue.add(new Label("Error loading extra fields"));
-//        }
-//
-//        @Override
-//        public void onSuccess(UserExtraBundle bundle) {
-//          displayExtraFields(bundle);
-//        }
-//      });
-//  }
-
-//  private void displayExtraFields(UserExtraBundle bundle) {
-//    if (bundle != null && bundle.getValues() != null && !bundle.getValues().isEmpty()) {
-//      for (MetadataValue mv : bundle.getValues()) {
-//        String label = FormUtilities.getFieldLabel(mv);
-//        String value = mv.get("value");
-//
-//        if (value != null && !value.trim().isEmpty()) {
-//          // For list fields, convert stored value to localized display text
-//          String displayValue = value;
-//          String fieldType = mv.get("type");
-//          if ("list".equals(fieldType)) {
-//            displayValue = FormUtilities.getLocalizedListValue(mv, value);
-//          }
-//
-//          FlowPanel fieldPanel = new FlowPanel();
-//          fieldPanel.setStyleName("field");
-//
-//          Label labelWidget = new Label(label);
-//          labelWidget.setStyleName("label");
-//
-//          Label valueWidget = new Label(displayValue);
-//          valueWidget.setStyleName("value");
-//
-//          fieldPanel.add(labelWidget);
-//          fieldPanel.add(valueWidget);
-//
-//          extraValue.add(fieldPanel);
-//        }
-//      }
-//    }
-//    // Don't show anything when there are no extra fields
-//  }
 
   private void buildPermissionList() {
     Set<String> allUserRoles = user.getAllRoles();


### PR DESCRIPTION
Fixes an issue on the User Details page where an incorrect error message — "Error loading extra fields" — was displayed even when the API response was successful and data was properly rendered.

The issue was caused by an additional asynchronous call to fetch extra fields, which could trigger the error message independently of the actual data already available on the user object.

This change removes the redundant API call and relies on the existing user data to display extra fields, ensuring consistency between UI state and backend responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsanteckningar

* **Omstrukturering**
  * Förenklad hämtning av användarextradata genom att ta bort asynkron laddning och uppdaterad rendering för att endast använda inlinedata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklista före godkännande

- [x] PR:n är kopplad till relevant issue eller task.
- [x] Titel och beskrivning gör det tydligt vad ändringen gäller.
- [x] Rätt labels eller taggar är satta.
- [x] PR:n är rimligt avgränsad och möjlig att granska.
- [x] Alla automatiska tester och kontroller har gått igenom.
- [x] Relevanta kommentarer från verktyg och reviewer är hanterade.
- [x] Eventuella risker, beroenden, migrationer eller manuella steg är beskrivna.
- [x] Vid uppdatering av beroenden är dessa säkerhetstestade.
- [x] Relevant dokumentation eller konfiguration är uppdaterad vid behov.
- [x] PR:n är mergebar utan olösta konflikter.
- [x] Det finns inget uppenbart som blockerar merge.