### PR TITLE
fix: allow git-commit-id-plugin to fail gracefully in Eclipse builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,8 @@
                                 <goal>revision</goal>
                             </goals>
                             <configuration>
+                                <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                                <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                                 <generateGitPropertiesFile>true</generateGitPropertiesFile>
                                 <generateGitPropertiesFilename>
                                     ${project.build.directory}/${project.build.finalName}/version.json
@@ -431,6 +433,8 @@
                                 <goal>revision</goal>
                             </goals>
                             <configuration>
+                                <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                                <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                                 <generateGitPropertiesFile>true</generateGitPropertiesFile>
                                 <generateGitPropertiesFilename>
                                     ${project.build.directory}/classes/static/version.json


### PR DESCRIPTION
Add failOnNoGitDirectory and failOnUnableToExtractRepoInfo to both plugin executions so Eclipse/m2e workspace builds don't crash when the .git directory is not accessible.

When building the project inside Eclipse (via m2e), the `git-commit-id-plugin` runs during the `initialize` phase and attempts to read the `.git` directory using JGit. In certain Eclipse workspace configurations, JGit fails to resolve the HEAD ref and throws an exception, causing the entire build to fail with:

```
Could not get HEAD Ref, are you sure you have some commits in the dotGitDirectory?
```

This does not affect Maven CLI builds or CI/CD pipelines where `.git` is always accessible.

**Fix:** Added `failOnNoGitDirectory=false` and `failOnUnableToExtractRepoInfo=false` to both plugin executions (`servlet-resource` and `internal-resource`) in the root `pom.xml`. This makes the plugin skip gracefully when git info is unavailable, instead of failing the build. In normal builds where `.git` is accessible, the plugin behaves exactly as before and continues to generate `version.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Underhål**
  * Förbättrad stabilitet i byggprocessen. Systemet kan nu byggas utan fel även när Git-metadatakatalogen inte är tillgänglig eller när information om versionskontrollarkivet inte kan extraheras automatiskt från systemet. Detta ökar flexibiliteten i olika distributionsscenarion och utvecklingsmiljöer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->