### PR TITLE
feat: enhance HTMLWidgetWrapper to open external links in a new tab

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/HTMLWidgetWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/HTMLWidgetWrapper.java
@@ -155,6 +155,11 @@ public class HTMLWidgetWrapper extends HTML {
                   RodaConstants.CORE_MARKDOWN_FOLDER + "/$1");
 
               html = imgRegExp.replace(html, imgReplacement);
+
+              // open external links in a new tab
+              RegExp extLinkRegExp = RegExp.compile("<a href=\"(https?://[^\"]*)\">", "g");
+              String extLinkReplacement = "<a href=\"$1\" target=\"_blank\" rel=\"noopener noreferrer\">";
+              html = extLinkRegExp.replace(html, extLinkReplacement);
             } else {
               html = response.getText();
             }


### PR DESCRIPTION
## Summary

- Added functionality to the `HTMLWidgetWrapper` class to ensure that external links open in a new tab with appropriate security attributes (`target="_blank" rel="noopener noreferrer"`)
- Improves user experience when navigating away from the application via documentation links
- Prevents tab hijacking via `rel="noopener noreferrer"`

## Notes

This is a backport of PR #230 to the `eterna-v1-alpha` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nya funktioner
* Externa länkar i markdowninnehål öppnas nu automatiskt i nya webbläsarflikar med säkerhetskontroller för ökad användarvänlighet och säkerhet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->