### PR TITLE
feat: disable RODATransactionManager for large-scale ingest jobs (#279)

### DIFF
--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -610,20 +610,21 @@ core.user_registration.disabled = false
 #
 # Enables the legacy (non-transactional) implementation for storage operations.
 #
-# By default, this property is set to 'false', meaning the system will use
-# the new transactional implementation to ensure consistency and reliability
-# during read/write operations on the storage layer.
+# Set to 'true' to disable transactional behavior and use the legacy storage
+# implementation, which does not provide transactional guarantees per AIP.
 #
-# Set this property to 'true' to disable transactional behavior and fall back
-# to the legacy storage implementation, which does not provide transactional guarantees.
+# Set to 'false' to use the transactional implementation (RODATransactionManager),
+# which wraps entire ingest jobs in atomic transactions — meaning a single
+# failing AIP causes the entire ingest batch to roll back.
 #
-# NOTE: The transactional implementation is still under active development.
-#       Enabling the legacy implementation may be necessary for compatibility
-#       with older environments or data, but is not recommended for new deployments.
+# ETERNA decision (issue #279): This property is set to 'true' (legacy mode) because
+# the transactional rollback behavior is unsuitable for large-scale ingest jobs.
+# When ingesting thousands of AIPs, one invalid AIP must not abort the entire batch.
+# Individual AIP failures are instead handled at the plugin/job level.
 #
-# Status: experimental
+# Status: in use
 ##########################################################################
-core.storage.legacy.implementation.enabled = false
+core.storage.legacy.implementation.enabled = true
 
 ##########################################################################
 # External authentication settings


### PR DESCRIPTION
Bakgrund

RODATransactionManager omsluter hela inleveransjobb i atomara transaktioner. Det innebar att ett enda felaktigt AIP rullar tillbaka hela inleveransen, ett beteende som ar oacceptabelt vid storskaliga inleveranser med tusentals AIP:er.

Andring

Aktiverar det icke-transaktionella (legacy) lagringslaget genom att satta core.storage.legacy.implementation.enabled = true i roda-core.properties. Enskilda AIP-fel hanteras istallet pa plugin/jobb-niva.

Kommentarblocket i roda-core.properties ar uppdaterat med en tydlig forklaring av beslutet och referens till detta issue.

Testplan

- [ ] Starta ETERNA med den uppdaterade konfigurationen
- [ ] Verifiera att varningen RODA transactions are an experimental feature inte syns i loggen vid uppstart
- [ ] Leverera in ett jobb med ett avsiktligt felaktigt AIP och verifiera att ovriga AIP:er inlevereras korrekt

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Aktiverade legacy-lagringsimplementering för systemets lagringsoperationer. Systemet använder nu icke-transaktionell lagring istället för den tidigare transaktionella implementeringen. Detta påverkar direkt hur inmatningsbatchoperationer hanterar återställning och felhantering i olika driftsscenarier. Konfigurationsinställningen uppdaterades från experimentell till produktionsklart läge med motsvarande uppdaterad dokumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->