### PR TITLE
feat: disable RODATransactionManager for large-scale ingest jobs (#279)

### DIFF
--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -610,20 +610,21 @@ core.user_registration.disabled = false
 #
 # Enables the legacy (non-transactional) implementation for storage operations.
 #
-# By default, this property is set to 'false', meaning the system will use
-# the new transactional implementation to ensure consistency and reliability
-# during read/write operations on the storage layer.
+# Set to 'true' to disable transactional behavior and use the legacy storage
+# implementation, which does not provide transactional guarantees per AIP.
 #
-# Set this property to 'true' to disable transactional behavior and fall back
-# to the legacy storage implementation, which does not provide transactional guarantees.
+# Set to 'false' to use the transactional implementation (RODATransactionManager),
+# which wraps entire ingest jobs in atomic transactions — meaning a single
+# failing AIP causes the entire ingest batch to roll back.
 #
-# NOTE: The transactional implementation is still under active development.
-#       Enabling the legacy implementation may be necessary for compatibility
-#       with older environments or data, but is not recommended for new deployments.
+# ETERNA decision (issue #279): This property is set to 'true' (legacy mode) because
+# the transactional rollback behavior is unsuitable for large-scale ingest jobs.
+# When ingesting thousands of AIPs, one invalid AIP must not abort the entire batch.
+# Individual AIP failures are instead handled at the plugin/job level.
 #
-# Status: experimental
+# Status: in use
 ##########################################################################
-core.storage.legacy.implementation.enabled = false
+core.storage.legacy.implementation.enabled = true
 
 ##########################################################################
 # External authentication settings


### PR DESCRIPTION
## Vad ändringen gör

Inaktiverar RODATransactionManager genom att aktivera legacy-lagringsläget:



## Bakgrund

RODATransactionManager omsluter hela inleveransjobb i atomära transaktioner. Det innebär att ett enda felaktigt AIP rullar tillbaka hela inleveransen. Detta är oacceptabelt vid storskaliga inleveranser med tusentals AIP:er. Enskilda AIP-fel hanteras istället på plugin/jobb-nivå.

## Ändringar

-  — värdet ändrat från  till , kommentarblocket uppdaterat med beslutsmotivering och referens till detta issue.

## Testning

- [x] Manuella användartester genomförda lokalt på http://localhost:8080
- [x] Verifierat i uppstartsloggen att varningen  **inte** visas
- [x] Verifierat att  inte initialiseras (via  returnerar  i legacy-läge)
- [x] Kodgranskning genomförd — logikflödet i  bekräftar korrekt beteende

## Manuella steg vid driftsättning

Inga migrationer krävs. Konfigurationsändringen träder i kraft vid nästa omstart av Spring Boot.

## Risker och beroenden

 skapas fortfarande som Spring-bean men är inaktiv i legacy-läge (skyddas av -check). Inget som blockerar denna PR.

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Ändrad lagringskonfiguration från transaktionell lagring till äldre, icke-transaktionell implementering som standardbeteende. Konfigurationskommentarer uppdaterades för att reflektera denna ändring, och status uppdaterades från experimentell till i bruk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->