### PR TITLE
fix: visa lokal tid istället för UTC i hela gränssnittet

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2535,7 +2535,7 @@ csv.delimiter = ;
 ui.date.format.title = predef\:DATE_LONG
 ui.date.format.simple = yyyy-MM-dd
 ui.dateTime.format.simple = yyyy-MM-dd HH:mm:ss z
-ui.dateTime.format.UTC=true
+ui.dateTime.format.UTC=false
 
 ##########################################################################
 # List export limit settings


### PR DESCRIPTION
## Sammanfattning
- Flaggan  var felaktigt satt till ui.dateTime.format.UTC=true i roda-wui.properties
- Det medförde att ALL datumformatering i hela applikationen (katalog, inleverans, gallring, administration m.m.) visade UTC-tid istället för lokal tid
- Ändring till  gör att  ETERNA använder systemets lokala tidszon för alla datum

Fixar #275

## Testplan
- [ ] Bygg utan fel: 
- [ ] Verifiera att datum i katalogen (AIP-lista) visas i lokal tid
- [ ] Verifiera att datum i inleveransöversikten visas i lokal tid
- [ ] Verifiera att datum i gallringsvyer visas i lokal tid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Ändringar

* **Buggfixar**
  * Datum- och tidsformat uppdaterat för att visa tider i användarens lokala tidzon istället för UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->