### PR TITLE
fix: rätta volym-sökvägar för Siegfried och ClamAV i docker-compose-dev.yaml

### DIFF
--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -36,8 +36,8 @@ services:
     volumes:
       - clam_data:/var/lib/clamav
       # Mapping $HOME/.roda to enable usage with spring-boot mode
-      - ./.roda/data/storage:$HOME/.roda/data/storage:ro
-      - ./.roda/data/staging-storage:$HOME/.roda/data/staging-storage:ro
+      - ${HOME}/.roda/data/storage:${HOME}/.roda/data/storage:ro
+      - ${HOME}/.roda/data/staging-storage:${HOME}/.roda/data/staging-storage:ro
       # Mapping /tmp to enable usage with local testing via mvn test
       - /tmp:/tmp
 
@@ -52,8 +52,8 @@ services:
     volumes:
       - siegfried_data:/root/siegfried/
       # Mapping $HOME/.roda to enable usage with spring-boot mode
-      - ./.roda/data/storage:$HOME/.roda/data/storage:ro
-      - ./.roda/data/staging-storage:$HOME/.roda/data/staging-storage:ro
+      - ${HOME}/.roda/data/storage:${HOME}/.roda/data/storage:ro
+      - ${HOME}/.roda/data/staging-storage:${HOME}/.roda/data/staging-storage:ro
       # Mapping /tmp to enable usage with local testing via mvn test
       - /tmp:/tmp:ro
 


### PR DESCRIPTION
Fixar #293

## Sammanfattning
- Volym-källsökvägarna för Siegfried och ClamAV i  använde  (relativ sökväg från compose-filens plats )
- Det innebar att Docker monterade  — en katalog som inte existerar — istället för  där ETERNA faktiskt lagrar data i Spring Boot dev-läge
- Siegfried svarade därför med 404 på alla filidentifieringsbegäranden, vilket fick inleveranser att misslyckas
- Fixad genom att ersätta  med  i båda volym-definitionerna

## Testplan
- [ ] Bygg utan fel: [[1;34mINFO[m] Scanning for projects...
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] [1;31mBUILD FAILURE[m
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;34mINFO[m] Total time:  0.055 s
[[1;34mINFO[m] Finished at: 2026-04-16T15:23:16+02:00
[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
[[1;31mERROR[m] The goal you specified requires a project to execute but there is no POM in this directory (/mnt/c/Users/OscarGillenius/Claude). Please verify you invoked Maven from the correct directory. -> [1m[Help 1][m
[[1;31mERROR[m] 
[[1;31mERROR[m] To see the full stack trace of the errors, re-run Maven with the [1m-e[m switch.
[[1;31mERROR[m] Re-run Maven using the [1m-X[m switch to enable full debug logging.
[[1;31mERROR[m] 
[[1;31mERROR[m] For more information about the errors and possible solutions, please read the following articles:
[[1;31mERROR[m] [1m[Help 1][m http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
- [ ] Starta infrastruktur: 
- [ ] Gör en inleverans och verifiera att Siegfried inte returnerar 404