### PR TITLE
fix(i18n): korrigera svensk text i dialog för borttagning av gallringsbekräftelse

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1524,8 +1524,8 @@ disposalOnHoldStatusLabel:Stoppad
 disposalClearStatusLabel:Inte stoppad
 disposalScheduleListAips:Bevarandeobjekt med detta schema
 disposalHoldListAips:Bevarandeobjekt med detta gallringsstopp
-deleteConfirmationReportDialogTitle:Bekräfta gallring av logiska enheter
-deleteConfirmationReportDialogMessage:Är du säker på att du vill gallra de logiska enheterna?
+deleteConfirmationReportDialogTitle:Bekräfta borttagning av gallringsbekräftelse
+deleteConfirmationReportDialogMessage:Är du säker på att du vill ta bort gallringsbekräftelsen?
 deleteConfirmationReportSuccessTitle:Raderar gallringsbekräftelse
 deleteConfirmationReportSuccessMessage:Utför åtgärd för att radera gallringsbekräftelse
 disposalConfirmationDataPanelTitle:Titel


### PR DESCRIPTION
## Summary

- Dialogen för att ta bort en gallringsbekräftelse visade felaktigt att logiska enheter/AIP gallras
- Texten är nu ändrad så att det tydligt framgår att det är gallringsbekräftelsen som tas bort

Closes #200

## Test plan

- [ ] Navigera till Gallring → Gallringsbekräftelser
- [ ] Markera en gallringsbekräftelse med status "Väntar"
- [ ] Klicka "Ta bort"
- [ ] Verifiera att dialogen visar "Bekräfta borttagning av gallringsbekräftelse"
- [ ] Verifiera att dialogtexten lyder "Är du säker på att du vill ta bort gallringsbekräftelsen?"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Uppdaterad svensk gränssnitttext för bekräftelsedialog vid borttagning av dispositionsbekräftelse. Dialogmeddelanden har reviderats för att återspegla korrekt innehål.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->