### PR TITLE
fix: preserve insertion order in ConversionProfile dropdown

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
@@ -9,7 +9,7 @@ package org.roda.core.data.v2.properties;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -22,7 +22,7 @@ public class ConversionProfiles implements Serializable {
   private Set<ConversionProfile> conversionProfileSet;
 
   public ConversionProfiles() {
-    conversionProfileSet = new HashSet<>();
+    conversionProfileSet = new LinkedHashSet<>();
   }
 
   public Set<ConversionProfile> getConversionProfileSet() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
@@ -9,7 +9,7 @@ package org.roda.wui.client.ingest.process;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -485,7 +485,7 @@ public class PluginParameterPanel extends Composite {
   }
 
   private void createConversionProfileLayout(FlowPanel result, String repOrDip, String pluginId) {
-    Set<ConversionProfile> treeSet = new HashSet<>();
+    Set<ConversionProfile> treeSet = new LinkedHashSet<>();
     Label parameterName = new Label(messages.conversionProfileTitle());
     final Label description = new Label();
     final ListBox dropdown = new ListBox();


### PR DESCRIPTION
## Summary
- Replace `HashSet` with `LinkedHashSet` in `ConversionProfiles.java`
- Replace `HashSet` with `LinkedHashSet` in `PluginParameterPanel.java`

Profiles are now displayed in the order defined in the plugin's
configuration file, consistently on every open.

Closes #307

## Test plan
- [ ] Open the Conversion Profile dropdown in the plugin configuration
- [ ] Verify that profiles appear in the same order as defined in the config file
- [ ] Verify that the order is consistent across multiple opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsinformation

* **Förbättringar**
  * Konverteringsprofiler visar nu i en konsistent ordning i användargränssnittet. Profilerna behålls nu i den ordning de lagrades istället för i slumpmässig ordning, vilket förbättrar användarupplevelsen vid val av konverteringsprofiler i plugin-parameterpanelen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->