### PR TITLE
Stöd för konvertering av kontorsdokument via unoserver

### DIFF
--- a/.github/workflows/unoserver-build.yml
+++ b/.github/workflows/unoserver-build.yml
@@ -1,0 +1,43 @@
+name: 'Unoserver Build'
+
+on:
+  push:
+    branches:
+      - "eterna-v1-alpha"
+    paths:
+      - "deploys/standalone/unoserver/Dockerfile"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  unoserver-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push unoserver image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: ./deploys/standalone/unoserver
+          file: ./deploys/standalone/unoserver/Dockerfile
+          tags: |
+            ghcr.io/eterna-earkiv/eterna-unoserver:latest
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -73,16 +73,34 @@ services:
     volumes:
       - ./ldap/ldif/pbkdf2.ldif:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
 
+  unoserver:
+    build:
+      context: ./unoserver
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 2003 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
   eterna:
     image: ghcr.io/eterna-earkiv/eterna:test-eterna-v1-alpha-latest
     restart: unless-stopped
     ports:
       - "8080:8080"
     depends_on:
-      - solr
-      - clamd
-      - siegfried
-      - postgres
+      solr:
+        condition: service_started
+      clamd:
+        condition: service_started
+      siegfried:
+        condition: service_started
+      postgres:
+        condition: service_started
+      unoserver:
+        condition: service_healthy
     volumes:
       - roda_data:/roda/data/
       - ./roda/config/roda-core.properties:/roda/config/roda-core.properties:ro
@@ -102,6 +120,8 @@ services:
       # SMTP configuration
       - SMTP_HOST=mailpit
       - SMTP_PORT=1025
+      - UNOSERVER_HOST=unoserver
+      - UNOSERVER_PORT=2003
 
   postgres:
     image: docker.io/postgres:17

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -74,9 +74,7 @@ services:
       - ./ldap/ldif/pbkdf2.ldif:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
 
   unoserver:
-    build:
-      context: ./unoserver
-      dockerfile: Dockerfile
+    image: ghcr.io/eterna-earkiv/eterna-unoserver:latest
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 2003 || exit 1"]

--- a/deploys/standalone/unoserver/Dockerfile
+++ b/deploys/standalone/unoserver/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     useradd -r -u 1001 unoserver
 USER unoserver
-CMD ["unoserver", "--interface", "0.0.0.0", "--port", "2003"]
+ENV UNOSERVER_CONVERSION_TIMEOUT=360
+CMD ["sh", "-c", "unoserver --interface 0.0.0.0 --port 2003 --conversion-timeout ${UNOSERVER_CONVERSION_TIMEOUT}"]

--- a/deploys/standalone/unoserver/Dockerfile
+++ b/deploys/standalone/unoserver/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:24.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libreoffice netcat-openbsd python3-pip && \
+    pip3 install --no-cache-dir --break-system-packages unoserver==3.3.2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    useradd -r -u 1001 unoserver
+USER unoserver
+CMD ["unoserver", "--interface", "0.0.0.0", "--port", "2003"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN set -ex; \
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
         clamdscan jq rsync netcat-openbsd \
         python3 python3-pip && \
-    pip3 install --no-cache-dir unoserver==3.3.2 && \
+    pip3 install --no-cache-dir --break-system-packages unoserver==3.3.2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY ./docker/docker-files/clamd.conf /etc/clamav/clamd.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,14 @@
 FROM eclipse-temurin:21-jre-jammy
 LABEL maintainer="admin@keep.pt" vendor="KEEP SOLUTIONS"
 
-# Install dependencies & Remove python dependency
 RUN set -ex; \
     apt-get -qq update && \
-    apt-get -qq -y install software-properties-common && \
-    apt-get -qq -y --no-install-recommends install clamdscan jq rsync && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-	DEBIAN_FRONTEND=noninteractive \
-	apt-get autoremove -y --purge "*python*"
+    DEBIAN_FRONTEND=noninteractive apt-get -qq -y install software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+        clamdscan jq rsync netcat-openbsd \
+        python3 python3-pip && \
+    pip3 install --no-cache-dir unoserver==3.3.2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY ./docker/docker-files/clamd.conf /etc/clamav/clamd.conf
 
@@ -24,7 +24,9 @@ ENV RODA_HOME=/roda \
     RODA_USER="roda" \
     RODA_UID="1000" \
     RODA_GROUP="roda" \
-    RODA_GID="1000"
+    RODA_GID="1000" \
+    UNOSERVER_HOST=unoserver \
+    UNOSERVER_PORT=2003
 
 COPY ./docker/docker-files/docker-entrypoint.sh /
 COPY ./docker/docker-files/docker-entrypoint.d/* /docker-entrypoint.d/


### PR DESCRIPTION
Stänger #161

## Vad ändringen gäller

Lägger till infrastrukturstöd för att köra Office Documents Converter-pluginen i ETERNA.
Pluginen konverterar kontorsdokument (Word, Excel, PowerPoint m.fl.) till bevarandeformat
via unoserver (LibreOffice/unoconvert).

## Ändringar

- **`docker/Dockerfile`** — installerar `unoconvert`-klient (unoserver pip) och sätter
  miljövariabler `UNOSERVER_HOST`/`UNOSERVER_PORT`
- **`deploys/standalone/unoserver/Dockerfile`** — ny image baserad på ubuntu:24.04
  med LibreOffice och unoserver
- **`deploys/standalone/docker-compose.yaml`** — lägger till unoserver-service med
  healthcheck; eterna-service väntar på att unoserver är healthy
- **`.github/workflows/unoserver-build.yml`** — nytt CI-flöde som bygger och pushar
  unoserver-imagen till GHCR vid ändringar i Dockerfile

## Arkitektur

Pluginen anropar `unoconvert` inuti eterna-containern. Klienten kommunicerar med
unoserver-containern via XML-RPC (port 2003). Filinnehåll strömmas via stdin/stdout
— inga delade volymer krävs.

## Manuella steg vid driftsättning

Miljöer som kör ETERNA via Docker Compose behöver lägga till unoserver-service i sin
docker-compose-konfiguration efter att CI byggt och pushat unoserver-imagen till GHCR.
Se `deploys/standalone/docker-compose.yaml` för referensimplementation.

## Checklista före godkännande

- [x] PR:n är kopplad till relevant issue eller task.
- [x] Titel och beskrivning gör det tydligt vad ändringen gäller.
- [x] Rätt labels eller taggar är satta.
- [x] PR:n är rimligt avgränsad och möjlig att granska.
- [ ] Alla automatiska tester och kontroller har gått igenom.
- [ ] Relevanta kommentarer från verktyg och reviewer är hanterade.
- [x] Eventuella risker, beroenden, migrationer eller manuella steg är beskrivna.
- [ ] Vid uppdatering av beroenden är dessa säkerhetstestade.
- [ ] PR:n är mergebar utan olösta konflikter.
- [ ] Det finns inget uppenbart som blockerar merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Versionsinformation

* **Nya funktioner**
  * Ny Unoserver-tjänst lades till för dokumentkonvertering och tillgänglighet i distributionen.
  * Eterna-tjänsten konfigureras nu för att vänta på Unoserver innan den blir helt aktiv.

* **Chores**
  * Automatisk byggning och publicering av Unoserver Docker-bild via CI implementerad.
  * Uppdaterad containerkonfiguration med hälsokontroll och miljövariabler för Unoserver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->