### PR TITLE
Översätt inleverans- och stödplugins till svenska

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
@@ -78,7 +78,7 @@ public class AntivirusPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticName() {
-    return "Malware detector";
+    return "Detektering av skadlig kod";
   }
 
   @Override
@@ -87,9 +87,9 @@ public class AntivirusPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticDescription() {
-    return "This plugin provides robust security features by leveraging the ClamAV antivirus engine to scan files for potential threats, including trojans, "
-      + "viruses, malware, and other malicious content.\nClamAV is a trusted, open-source (GPL) antivirus engine that is widely used in the industry for its "
-      + "exceptional accuracy and effectiveness in detecting threats";
+    return "Detta insticksprogram erbjuder robusta säkerhetsfunktioner genom att använda ClamAV-antivirusmotorn för att söka igenom filer efter potentiella hot, "
+      + "inklusive trojaner, virus, skadlig kod och annat skadligt innehåll.\nClamAV är en betrodd antivirusmotor med öppen källkod (GPL) som används brett i "
+      + "branschen tack vare sin träffsäkerhet och effektivitet i att upptäcka hot.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
@@ -245,17 +245,17 @@ public class AntivirusPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Scanned package for malicious programs using ClamAV.";
+    return "Sökte igenom paketet efter skadliga program med ClamAV.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "The package does not contain any known malicious programs.";
+    return "Paketet innehåller inga kända skadliga program.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "A malicious program was detected inside the package.";
+    return "Ett skadligt program hittades i paketet.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPlugin.java
@@ -56,14 +56,14 @@ public class PremisSkeletonPlugin<T extends IsRODAObject> extends AbstractAIPCom
    */
 
   public static String getStaticName() {
-    return "File information computation";
+    return "Beräkning av filinformation";
   }
 
   public static String getStaticDescription() {
-    return "Computes file fixity information (also known as checksum) for all data files within an AIP, representation or file and stores this information in PREMIS objects "
-      + "within the corresponding entity. This task uses SHA-256 as the default checksum algorithm, however, other algorithms can be configured in “roda-core.properties”."
-      + "\nFile fixity is the property of a digital file being fixed, or unchanged. “AIP corruption risk assessment” is the process of validating that a file has not changed or been "
-      + "altered from a previous state. In order to validate the fixity of an AIP or file, fixity information has to be generated beforehand.";
+    return "Beräknar filintegritetsinformation (även känd som kontrollsumma) för alla datafiler i ett AIP, en representation eller en fil och lagrar denna information i PREMIS-objekt "
+      + "i motsvarande entitet. Uppgiften använder SHA-256 som standardalgoritm för kontrollsumma, men andra algoritmer kan konfigureras i \"roda-core.properties\"."
+      + "\nFilintegritet är egenskapen att en digital fil är fixerad, eller oförändrad. \"Riskbedömning för AIP-korruption\" är processen att validera att en fil inte har förändrats "
+      + "eller manipulerats från ett tidigare tillstånd. För att validera integriteten hos ett AIP eller en fil måste integritetsinformation ha genererats i förväg.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
@@ -68,13 +68,13 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
    */
 
   public static String getStaticName() {
-    return "File Format Detector";
+    return "Filformatsdetektor";
   }
 
   public static String getStaticDescription() {
-    return "The File Format Detector plugin is an essential tool for identifying and analyzing various file formats.\nIt provides comprehensive information "
-      + "about each file, including its name, designation, version, MIME type, and PRONOM identifier.\nThis information can be used to determine the appropriate "
-      + "software to open and manipulate the file, as well as to ensure compatibility with different systems and applications.";
+    return "Insticksprogrammet Filformatsdetektor är ett viktigt verktyg för att identifiera och analysera olika filformat.\nDet ger omfattande information "
+      + "om varje fil, inklusive dess namn, beteckning, version, MIME-typ och PRONOM-identifierare.\nDenna information kan användas för att avgöra lämplig "
+      + "programvara för att öppna och hantera filen samt för att säkerställa kompatibilitet med olika system och applikationer.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
@@ -57,9 +57,9 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
 
   static {
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_SIEGFRIED_OVERWRITE_MANUAL, PluginParameter
-      .getBuilder(RodaConstants.PLUGIN_PARAMS_SIEGFRIED_OVERWRITE_MANUAL, "Overwrite manually assigned fields",
+      .getBuilder(RodaConstants.PLUGIN_PARAMS_SIEGFRIED_OVERWRITE_MANUAL, "Skriv över manuellt tilldelade fält",
         PluginParameter.PluginParameterType.BOOLEAN)
-      .withDescription("Force the plugin to overwrite file format metadata that has been manually assigned.").build());
+      .withDescription("Tvingar insticksprogrammet att skriva över filformatmetadata som har tilldelats manuellt.").build());
   }
 
   /*
@@ -160,14 +160,14 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
                   if (sources.isEmpty()) {
                     jobPluginInfo.incrementObjectsProcessedWithSkipped();
                     reportItem.setPluginState(PluginState.SKIPPED)
-                      .setPluginDetails("Skipped to prevent overwriting manual values.");
+                      .setPluginDetails("Hoppades över för att undvika överskrivning av manuellt tilldelade värden.");
                   } else {
                     jobPluginInfo.incrementObjectsProcessedWithSuccess();
                     reportItem.setPluginState(PluginState.SUCCESS);
                   }
                 } else {
                   reportItem.setPluginState(PluginState.SKIPPED)
-                    .setPluginDetails("Skipped because no representation was found for this AIP.");
+                    .setPluginDetails("Hoppades över eftersom ingen representation hittades för detta AIP.");
                   jobPluginInfo.incrementObjectsProcessed(PluginState.SKIPPED);
                 }
               } else {
@@ -394,17 +394,17 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
 
   @Override
   public String getPreservationEventDescription() {
-    return "Identified the object's file formats and versions using Siegfried.";
+    return "Identifierade objektets filformat och versioner med Siegfried.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "File formats were identified and recorded in PREMIS objects.";
+    return "Filformat identifierades och registrerades i PREMIS-objekt.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Failed to identify file formats in the package.";
+    return "Misslyckades med att identifiera filformat i paketet.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
@@ -54,9 +54,9 @@ public class ApplyDisposalRulesPlugin extends AbstractPlugin<AIP> {
   static {
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DISPOSAL_SCHEDULE_OVERWRITE_MANUAL,
       PluginParameter
-        .getBuilder(RodaConstants.PLUGIN_PARAMS_DISPOSAL_SCHEDULE_OVERWRITE_MANUAL, "Override disposal schedule",
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_DISPOSAL_SCHEDULE_OVERWRITE_MANUAL, "Åsidosätt gallringsplan",
           PluginParameter.PluginParameterType.BOOLEAN)
-        .withDefaultValue("false").withDescription("Overrides manually associated disposal schedules.").build());
+        .withDefaultValue("false").withDescription("Åsidosätter manuellt kopplade gallringsplaner.").build());
   }
 
   private boolean overrideManualAssociations = false;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
@@ -62,11 +62,11 @@ public class ApplyDisposalRulesPlugin extends AbstractPlugin<AIP> {
   private boolean overrideManualAssociations = false;
 
   public static String getStaticName() {
-    return "Disposal schedule association via disposal rule";
+    return "Koppling av gallringsplan via gallringsregel";
   }
 
   public static String getStaticDescription() {
-    return "Associates a disposal schedule to an AIP via rules previously defined for the repository.";
+    return "Kopplar en gallringsplan till ett AIP via regler som tidigare definierats för arkivet.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
 public class AutoAcceptSIPPlugin extends AbstractPlugin<AIP> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AutoAcceptSIPPlugin.class);
 
-  public static final String FAILURE_MESSAGE = "Failed to add the AIP to the repository's inventory.";
-  public static final String SUCCESS_MESSAGE = "The AIP was successfully added to the repository's inventory.";
-  public static final String DESCRIPTION = "Added package to the inventory. After this point, the responsibility for the digital content’s preservation is passed on to the repository.";
+  public static final String FAILURE_MESSAGE = "Misslyckades med att lägga till AIP:et i arkivförteckningen.";
+  public static final String SUCCESS_MESSAGE = "AIP:et lades till i arkivförteckningen.";
+  public static final String DESCRIPTION = "Lade till paketet i arkivförteckningen. Från och med denna punkt övergår ansvaret för det digitala innehållets bevarande till arkivet.";
 
   @Override
   public void init() throws PluginException {

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
@@ -55,7 +55,7 @@ public class AutoAcceptSIPPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticName() {
-    return "Auto accept";
+    return "Automatiskt godkännande";
   }
 
   @Override
@@ -64,8 +64,8 @@ public class AutoAcceptSIPPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticDescription() {
-    return "Adds information package to the inventory without any human appraisal. After this point, the responsibility for the digital content’s "
-      + "preservation is passed on to the repository.";
+    return "Lägger till informationspaketet i arkivförteckningen utan mänsklig granskning. Från och med denna punkt övergår ansvaret "
+      + "för det digitala innehållets bevarande till arkivet.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
@@ -84,7 +84,7 @@ public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
 
   @Override
   public String getDescription() {
-    return "E-ARK SIP 2 as a zip file.";
+    return "E-ARK SIP 2 som en zip-fil.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
@@ -59,7 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
-  public static final String UNPACK_DESCRIPTION = "Extracted objects from package in E-ARK SIP 2 format.";
+  public static final String UNPACK_DESCRIPTION = "Extraherade objekt från paket i E-ARK SIP 2-format.";
   private static final Logger LOGGER = LoggerFactory.getLogger(EARKSIP2ToAIPPlugin.class);
   private boolean createSubmission = false;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
@@ -86,7 +86,7 @@ public class EARKSIPToAIPPlugin extends SIPToAIPPlugin {
 
   @Override
   public String getDescription() {
-    return "E-ARK SIP as a zip file.";
+    return "E-ARK SIP som en zip-fil.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 public class EARKSIPToAIPPlugin extends SIPToAIPPlugin {
   private static final Logger LOGGER = LoggerFactory.getLogger(EARKSIPToAIPPlugin.class);
 
-  public static final String UNPACK_DESCRIPTION = "Extracted objects from package in E-ARK SIP format.";
+  public static final String UNPACK_DESCRIPTION = "Extraherade objekt från paket i E-ARK SIP-format.";
 
   private boolean createSubmission = false;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
@@ -48,7 +48,7 @@ public class SIPRemovePlugin extends AbstractPlugin<TransferredResource> {
   }
 
   public static String getStaticName() {
-    return "Delete SIP from transfer";
+    return "Radera SIP från överföringsyta";
   }
 
   @Override
@@ -57,7 +57,7 @@ public class SIPRemovePlugin extends AbstractPlugin<TransferredResource> {
   }
 
   public static String getStaticDescription() {
-    return "Deletes SIP from the transfer area if the ingest process is successful.";
+    return "Raderar SIP:et från överföringsytan om inleveransprocessen lyckades.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
@@ -94,8 +94,8 @@ public class SIPRemovePlugin extends AbstractPlugin<TransferredResource> {
 
       if (createEvent) {
         model.createRepositoryEvent(PreservationEventType.DELETION,
-          "The process of deleting an object of the repository", PluginState.SUCCESS,
-          "The transferred resource " + transferredResource.getId() + " has been deleted.", "", job.getUsername(),
+          "Processen att radera ett objekt från arkivet", PluginState.SUCCESS,
+          "Den överförda resursen " + transferredResource.getId() + " har raderats.", "", job.getUsername(),
           true, null);
       }
 
@@ -103,8 +103,8 @@ public class SIPRemovePlugin extends AbstractPlugin<TransferredResource> {
     } catch (RuntimeException | GenericException | AuthorizationDeniedException e) {
       if (createEvent) {
         model.createRepositoryEvent(PreservationEventType.DELETION,
-          "The process of deleting an object of the repository", PluginState.SUCCESS,
-          "The transferred resource " + transferredResource.getId() + " has not been deleted.", "", job.getUsername(),
+          "Processen att radera ett objekt från arkivet", PluginState.SUCCESS,
+          "Den överförda resursen " + transferredResource.getId() + " har inte raderats.", "", job.getUsername(),
           true, null);
       }
 
@@ -139,17 +139,17 @@ public class SIPRemovePlugin extends AbstractPlugin<TransferredResource> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Deleted SIP from the transfer area.";
+    return "Raderade SIP från överföringsytan.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "The original SIP has been deleted from the transfer area.";
+    return "Det ursprungliga SIP:et har raderats från överföringsytan.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Failed to delete the original SIP from the transfer area.";
+    return "Misslyckades med att radera det ursprungliga SIP:et från överföringsytan.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
@@ -71,12 +71,12 @@ public class TransferredResourceToAIPPlugin extends SIPToAIPPlugin {
 
   @Override
   public String getName() {
-    return "Uploaded file/folder";
+    return "Uppladdad fil/mapp";
   }
 
   @Override
   public String getDescription() {
-    return "Treats a file/folder as a SIP.";
+    return "Behandlar en fil/mapp som ett SIP.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
   private static final Logger LOGGER = LoggerFactory.getLogger(VerifyUserAuthorizationPlugin.class);
-  private static final String PARENT_AIP_NOT_FOUND = "The parent of the AIP was not found";
+  private static final String PARENT_AIP_NOT_FOUND = "AIP:ets överordnade objekt hittades inte";
 
   private static final List<String> userFieldsToReturn = Arrays.asList(RodaConstants.MEMBERS_GROUPS,
     RodaConstants.MEMBERS_ID);
@@ -104,12 +104,12 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
     PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
 
     reportItem.setPluginState(PluginState.SUCCESS)
-      .setPluginDetails(String.format("Done with checking user authorization for AIP %s", aip.getId()));
+      .setPluginDetails(String.format("Användarbehörighet för AIP %s har kontrollerats", aip.getId()));
 
     if (cachedJob != null) {
       processAIPPermissions(index, cachedJob, aip, reportItem);
     } else {
-      reportItem.setPluginState(PluginState.FAILURE).setPluginDetails("Unable to determine Job.");
+      reportItem.setPluginState(PluginState.FAILURE).setPluginDetails("Kunde inte fastställa jobb.");
     }
 
     try {
@@ -149,7 +149,7 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
         } catch (AuthorizationDeniedException e) {
           LOGGER.debug("User '{}' doesn't have CREATE permission on parent... Error...", jobCreatorUsername);
           reportItem.setPluginState(PluginState.FAILURE).setPluginDetails(
-            "The user " + jobCreatorUsername + " doesn't have permission to create under AIP " + aip.getId());
+            "Användaren " + jobCreatorUsername + " saknar behörighet att skapa under AIP " + aip.getId());
         }
       } else {
         RODAMember member = index.retrieve(RODAMember.class, IdUtils.getUserId(jobCreatorUsername),
@@ -158,7 +158,7 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
           LOGGER.debug("User have CREATE_TOP_LEVEL_AIP_PERMISSION permission.");
         } else {
           reportItem.setPluginState(PluginState.FAILURE).setPluginDetails(
-            "The user " + jobCreatorUsername + " doesn't have CREATE_TOP_LEVEL_AIP_PERMISSION permission");
+            "Användaren " + jobCreatorUsername + " saknar behörigheten CREATE_TOP_LEVEL_AIP_PERMISSION");
           LOGGER.debug("User doesn't have CREATE_TOP_LEVEL_AIP_PERMISSION permission...");
         }
       }
@@ -190,11 +190,11 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    String description = "User permissions have been checked to ensure that he has sufficient authorization to store the AIP under the desired "
-      + "node of the classification scheme.";
+    String description = "Användarens behörigheter har kontrollerats för att säkerställa att användaren har tillräcklig behörighet att lagra AIP:et under önskad "
+      + "nod i klassificeringsschemat.";
 
     if (hasFreeAccess) {
-      description += " It was given READ permission to the users group as indicated on the descriptive metadata";
+      description += " Gruppen användare fick läsbehörighet enligt den beskrivande metadatan.";
     }
 
     return description;
@@ -202,12 +202,12 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "The user has enough permissions to deposit the AIP under the designated node of the classification scheme";
+    return "Användaren har tillräcklig behörighet för att deponera AIP:et under angiven nod i klassificeringsschemat";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "The user does not have enough permissions to deposit the AIP under the designated node of the classification scheme";
+    return "Användaren saknar tillräcklig behörighet för att deponera AIP:et under angiven nod i klassificeringsschemat";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
@@ -62,7 +62,7 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticName() {
-    return "Verify user authorization";
+    return "Verifiera användarbehörighet";
   }
 
   @Override
@@ -71,7 +71,7 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
   }
 
   public static String getStaticDescription() {
-    return "Checks if the user has enough permissions to place the AIP under the desired node in the classification scheme";
+    return "Kontrollerar om användaren har tillräckliga behörigheter för att placera AIP:et under önskad nod i klassificeringsschemat.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/ConfigurableIngestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/ConfigurableIngestPlugin.java
@@ -84,7 +84,7 @@ public class ConfigurableIngestPlugin extends DefaultIngestPlugin {
 
   @Override
   public String getName() {
-    return "Default ingest workflow";
+    return "Standard inleveransprocess";
   }
 
   @Override
@@ -94,7 +94,7 @@ public class ConfigurableIngestPlugin extends DefaultIngestPlugin {
 
   @Override
   public String getDescription() {
-    return "Performs all the tasks needed to ingest a SIP into the repository and therefore creating an AIP.";
+    return "Utför alla uppgifter som krävs för att inleverera ett SIP till arkivet och därigenom skapa ett AIP.";
   }
 
   @Override
@@ -137,23 +137,23 @@ public class ConfigurableIngestPlugin extends DefaultIngestPlugin {
 
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS,
         PluginParameter
-          .getBuilder(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS, "Format of the Submission Information Packages",
+          .getBuilder(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS, "Format för leveransinformationspaket",
             PluginParameterType.PLUGIN_SIP_TO_AIP)
           .withDefaultValue(EARKSIP2ToAIPPlugin.class.getName()).withDescription(
-            "Select the format of the Submission Information Packages to be ingested in this ingest process.")
+            "Välj format för de leveransinformationspaket som ska inlevereras i denna inleveransprocess.")
           .build());
 
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_PARENT_ID,
-        PluginParameter.getBuilder(RodaConstants.PLUGIN_PARAMS_PARENT_ID, "Parent node", PluginParameterType.AIP_ID)
-          .isMandatory(false).withDescription("Use the provided parent node if the SIPs does not provide one.")
+        PluginParameter.getBuilder(RodaConstants.PLUGIN_PARAMS_PARENT_ID, "Föräldernod", PluginParameterType.AIP_ID)
+          .isMandatory(false).withDescription("Använd den angivna föräldernoden om SIP:et inte anger någon.")
           .build());
 
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID,
         PluginParameter
-          .getBuilder(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID, "Force parent node", PluginParameterType.BOOLEAN)
+          .getBuilder(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID, "Tvinga föräldernod", PluginParameterType.BOOLEAN)
           .withDefaultValue(FALSE).isMandatory(false)
           .withDescription(
-            "Force the use of the selected parent node even if the SIPs provide information about the desired parent.")
+            "Tvinga användningen av den valda föräldernoden även om SIP:en anger information om önskad förälder.")
           .build());
 
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DO_VIRUS_CHECK,
@@ -204,8 +204,9 @@ public class ConfigurableIngestPlugin extends DefaultIngestPlugin {
         pluginParameters.put(DefaultIngestPlugin.PLUGIN_PARAMS_DO_FEATURE_AND_FULL_TEXT_EXTRACTION,
           PluginParameter
             .getBuilder(DefaultIngestPlugin.PLUGIN_PARAMS_DO_FEATURE_AND_FULL_TEXT_EXTRACTION,
-              "Feature & full-text extraction", PluginParameterType.BOOLEAN)
-            .withDefaultValue(FALSE).withDescription("Extraction of technical metadata and full-text using Apache Tika")
+              "Funktions- och fulltextextraktion", PluginParameterType.BOOLEAN)
+            .withDefaultValue(FALSE)
+            .withDescription("Extrahering av tekniska metadata och fulltext med Apache Tika.")
             .build());
       } else {
         deactivatedPlugins.add(DefaultIngestPlugin.PLUGIN_CLASS_TIKA_FULLTEXT);
@@ -236,28 +237,29 @@ public class ConfigurableIngestPlugin extends DefaultIngestPlugin {
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_NOTIFICATION_WHEN_FAILED,
         PluginParameter
           .getBuilder(RodaConstants.PLUGIN_PARAMS_NOTIFICATION_WHEN_FAILED,
-            "Ingest finished notification only when failed", PluginParameterType.BOOLEAN)
+            "Notifikation om avslutad inleverans enbart vid fel", PluginParameterType.BOOLEAN)
           .withDefaultValue(RodaCoreFactory.getRodaConfigurationAsString("ingest.notification.when_failed"))
           .isMandatory(false)
           .withDescription(
-            "If checked, the ingest finished notification will only be sent if a fail occurs during ingestion")
+            "Om markerad skickas notifikationen om avslutad inleverans endast om ett fel uppstår under inleveransen.")
           .build());
 
       pluginParameters.put(RodaConstants.PLUGIN_PARAMS_EMAIL_NOTIFICATION,
         PluginParameter
-          .getBuilder(RodaConstants.PLUGIN_PARAMS_EMAIL_NOTIFICATION, "Ingest finished email notification",
+          .getBuilder(RodaConstants.PLUGIN_PARAMS_EMAIL_NOTIFICATION, "E-postnotifikation om avslutad inleverans",
             PluginParameterType.STRING)
           .isMandatory(false)
           .withDescription(
-            "Send a notification after finishing the ingest process to one or more e-mail addresses (comma separated)")
+            "Skickar en notifikation efter avslutad inleveransprocess till en eller flera e-postadresser (kommaseparerade).")
           .build());
 
       pluginParameters.put(RodaConstants.NOTIFICATION_HTTP_ENDPOINT, PluginParameter
-        .getBuilder(RodaConstants.NOTIFICATION_HTTP_ENDPOINT, "Ingest finished HTTP notification",
+        .getBuilder(RodaConstants.NOTIFICATION_HTTP_ENDPOINT, "HTTP-notifikation om avslutad inleverans",
           PluginParameterType.STRING)
         .withDefaultValue(RodaCoreFactory.getRodaConfigurationAsString("ingest.configurable.http_endpoint"))
         .isMandatory(false)
-        .withDescription("Send a notification after finishing the ingest process to a specific HTTP endpoint").build());
+        .withDescription("Skickar en notifikation efter avslutad inleveransprocess till en specifik HTTP-endpoint.")
+        .build());
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/MinimalIngestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/MinimalIngestPlugin.java
@@ -40,22 +40,22 @@ public class MinimalIngestPlugin extends DefaultIngestPlugin {
   static {
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS,
       PluginParameter
-        .getBuilder(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS, "Format of the Submission Information Packages",
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_SIP_TO_AIP_CLASS, "Format för leveransinformationspaket",
           PluginParameterType.PLUGIN_SIP_TO_AIP)
         .withDefaultValue(EARKSIP2ToAIPPlugin.class.getName()).withDescription(
-          "Select the format of the Submission Information Packages to be ingested in this ingest process.")
+          "Välj format för de leveransinformationspaket som ska inlevereras i denna inleveransprocess.")
         .build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_PARENT_ID,
-      PluginParameter.getBuilder(RodaConstants.PLUGIN_PARAMS_PARENT_ID, "Parent node", PluginParameterType.AIP_ID)
-        .isMandatory(false).withDescription("Use the provided parent node if the SIPs does not provide one.").build());
+      PluginParameter.getBuilder(RodaConstants.PLUGIN_PARAMS_PARENT_ID, "Föräldernod", PluginParameterType.AIP_ID)
+        .isMandatory(false).withDescription("Använd den angivna föräldernoden om SIP:et inte anger någon.").build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID,
       PluginParameter
-        .getBuilder(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID, "Force parent node", PluginParameterType.BOOLEAN)
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_FORCE_PARENT_ID, "Tvinga föräldernod", PluginParameterType.BOOLEAN)
         .withDefaultValue("false").isMandatory(false)
         .withDescription(
-          "Force the use of the selected parent node even if the SIPs provide information about the desired parent.")
+          "Tvinga användningen av den valda föräldernoden även om SIP:en anger information om önskad förälder.")
         .build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DO_DESCRIPTIVE_METADATA_VALIDATION,
@@ -86,11 +86,12 @@ public class MinimalIngestPlugin extends DefaultIngestPlugin {
         .withDefaultValue("true").isReadOnly(true).withDescription(AutoAcceptSIPPlugin.getStaticDescription()).build());
     pluginParameters.put(RodaConstants.NOTIFICATION_HTTP_ENDPOINT,
       PluginParameter
-        .getBuilder(RodaConstants.NOTIFICATION_HTTP_ENDPOINT, "Ingest finished HTTP notification",
+        .getBuilder(RodaConstants.NOTIFICATION_HTTP_ENDPOINT, "HTTP-notifikation om avslutad inleverans",
           PluginParameterType.STRING)
         .withDefaultValue(RodaCoreFactory.getRodaConfigurationAsString("ingest.configurable.http_endpoint"))
         .isMandatory(false)
-        .withDescription("Send a notification after finishing the ingest process to a specific HTTP endpoint").build());
+        .withDescription("Skickar en notifikation efter avslutad inleveransprocess till en specifik HTTP-endpoint.")
+        .build());
 
     // 2) descriptive metadata validation
     steps.add(new IngestStep(DescriptiveMetadataValidationPlugin.class.getName(),
@@ -108,7 +109,7 @@ public class MinimalIngestPlugin extends DefaultIngestPlugin {
 
   @Override
   public String getName() {
-    return "Minimal ingest workflow";
+    return "Minimal inleveransprocess";
   }
 
   @Override
@@ -118,7 +119,7 @@ public class MinimalIngestPlugin extends DefaultIngestPlugin {
 
   @Override
   public String getDescription() {
-    return "Performs the minimum set of tasks needed to ingest a SIP into the repository and therefore creating an AIP.";
+    return "Utför den minsta uppsättningen uppgifter som krävs för att inleverera ett SIP till arkivet och därigenom skapa ett AIP.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
@@ -47,35 +47,35 @@ public class DescriptiveMetadataValidationPlugin extends AbstractPlugin<AIP> {
 
   static {
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_VALIDATE_DESCRIPTIVE_METADATA, PluginParameter
-      .getBuilder(RodaConstants.PLUGIN_PARAMS_VALIDATE_DESCRIPTIVE_METADATA, "Validate descriptive metadata",
+      .getBuilder(RodaConstants.PLUGIN_PARAMS_VALIDATE_DESCRIPTIVE_METADATA, "Validera beskrivande metadata",
         PluginParameterType.BOOLEAN)
       .withDefaultValue("true")
       .withDescription(
-        "If true, the action will check if the descriptive metadata is valid according to the schemas installed in the repository.")
+        "Om aktiverad kontrollerar åtgärden om den beskrivande metadatan är giltig enligt de scheman som är installerade i arkivet.")
       .build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_TYPE, PluginParameter
-      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_TYPE, "Descriptive metadata format",
+      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_TYPE, "Format för beskrivande metadata",
         PluginParameterType.STRING)
       .isMandatory(false)
       .withDescription(
-        "Descriptive metadata format to be used as fallback if the information package does not specify the metadata format or if the action is set to FORCE.")
+        "Format för beskrivande metadata som används som reserv om informationspaketet inte anger metadataformat eller om åtgärden är inställd på FORCE.")
       .build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_VERSION, PluginParameter
-      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_VERSION, "Descriptive metadata version",
+      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_VERSION, "Version av beskrivande metadata",
         PluginParameterType.STRING)
       .isMandatory(false)
       .withDescription(
-        "Descriptive metadata version to be used as fallback if the information package does not specify the metadata version or if the action is set to FORCE.")
+        "Version av beskrivande metadata som används som reserv om informationspaketet inte anger metadataversion eller om åtgärden är inställd på FORCE.")
       .build());
 
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_FORCE_TYPE, PluginParameter
-      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_FORCE_TYPE, "Force metadata format and version",
+      .getBuilder(RodaConstants.PLUGIN_PARAMS_DESCRIPTIVE_METADATA_FORCE_TYPE, "Tvinga metadataformat och version",
         PluginParameterType.BOOLEAN)
       .withDefaultValue("false")
       .withDescription(
-        "If true, bypass the metadata format and version set in the information package and use the metadata format and version passed as parameters (see above).")
+        "Om aktiverad åsidosätts metadataformat och version från informationspaketet och de format och versioner som anges som parametrar används istället (se ovan).")
       .build());
   }
 
@@ -234,24 +234,24 @@ public class DescriptiveMetadataValidationPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Checked whether the descriptive metadata is included in the SIP and if this metadata is valid according to the established policy.";
+    return "Kontrollerade om den beskrivande metadatan finns i SIP:et och om den är giltig enligt fastställd policy.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return addSchemaToBuilder("Descriptive metadata is well formed and complete.");
+    return addSchemaToBuilder("Beskrivande metadata är välformad och fullständig.");
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
     return addSchemaToBuilder(
-      "Descriptive metadata was not well formed or failed to meet the established ingest policy.");
+      "Beskrivande metadata var inte välformad eller uppfyllde inte den fastställda inleveranspolicyn.");
   }
 
   private String addSchemaToBuilder(String eventMessage) {
     if (!schemasInfo.isEmpty()) {
       StringBuilder builder = new StringBuilder(eventMessage);
-      builder.append("\nSchemas used on validation: ");
+      builder.append("\nScheman som användes vid validering: ");
 
       Pair<String, String> firstSchema = schemasInfo.get(0);
       builder.append(firstSchema.getFirst());

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
@@ -87,12 +87,12 @@ public class DescriptiveMetadataValidationPlugin extends AbstractPlugin<AIP> {
   private List<Pair<String, String>> schemasInfo;
 
   public static String getStaticName() {
-    return "Metadata validation";
+    return "Metadatavalidering";
   }
 
   public static String getStaticDescription() {
-    return "Checks if the descriptive metadata included in the Information Package is present, and if it is valid according to the "
-      + "XML Schemas installed in the repository. A validation report is generated indicating which Information Packages have valid and invalid metadata.";
+    return "Kontrollerar om den beskrivande metadata som ingår i informationspaketet finns och om den är giltig enligt de XML-scheman som är installerade i arkivet. "
+      + "En valideringsrapport skapas som anger vilka informationspaket som har giltig respektive ogiltig metadata.";
   }
 
   @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/DetailsPanelTransferredResource.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/DetailsPanelTransferredResource.java
@@ -34,10 +34,10 @@ public class DetailsPanelTransferredResource extends Composite {
   public void init(TransferredResource resource) {
 
     if (resource.isFile()) {
-      details.add(buildField("Size", new InlineHTML(Humanize.readableFileSize(resource.getSize()))));
+      details.add(buildField("Storlek", new InlineHTML(Humanize.readableFileSize(resource.getSize()))));
     }
-    details.add(buildField("Created at", new InlineHTML(Humanize.formatDateTime(resource.getCreationDate()))));
-    details.add(buildField("Last scanned at", new InlineHTML(Humanize.formatDateTime(resource.getLastScanDate()))));
+    details.add(buildField("Skapad", new InlineHTML(Humanize.formatDateTime(resource.getCreationDate()))));
+    details.add(buildField("Senast skannad", new InlineHTML(Humanize.formatDateTime(resource.getLastScanDate()))));
   }
 
   private FlowPanel buildField(String label, InlineHTML html) {


### PR DESCRIPTION
## Vad ändras

Översätter , , ,  samt hårdkodade parameteretiketter och beskrivningar till svenska i inleverans- och stödplugins.

## Berörda filer

**Inleveransplugins:**
- AutoAcceptSIPPlugin
- VerifyUserAuthorizationPlugin
- SIPRemovePlugin
- EARKSIPToAIPPlugin / EARKSIP2ToAIPPlugin
- TransferredResourceToAIPPlugin
- ConfigurableIngestPlugin / MinimalIngestPlugin

**Stödplugins:**
- AntivirusPlugin
- DescriptiveMetadataValidationPlugin
- PremisSkeletonPlugin
- SiegfriedPlugin
- ApplyDisposalRulesPlugin

**Gränssnitt:**
- DetailsPanelTransferredResource (fältetiketter)

## Typ av ändring

Enbart textöversättningar — inga logikändringar, inga nya beroenden, inga migreringar.

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Lokalisering**
  * Plugin- och systemgränssnittets text har översatts till svenska i hela programmet
  * Uppdaterade visningsnamn och beskrivningar för inleveransarbetsflöden, filformatdetektering, metadatavalidering och gallringsregler
  * Användargränssnittets fältetiketter och parameterbeskrivningar för överföringsfunktioner och konfigurationsalternativ presenteras nu på svenska

<!-- end of auto-generated comment: release notes by coderabbit.ai -->