### PR TITLE
docs: IDP dynamic group authorization documentation (#178)

### DIFF
--- a/documentation/administration/IDP_Group_Authorization.md
+++ b/documentation/administration/IDP_Group_Authorization.md
@@ -1,0 +1,68 @@
+# Dynamic Group Authorization via IDP
+
+ETERNA supports dynamic assignment of internal groups based on group membership in an external Identity Provider (IDP). Any IDP that exposes group membership through OIDC or SAML claims is supported, including Azure AD / Microsoft Entra ID, Keycloak, Okta, and others. When a user logs in via CAS, the user's group memberships are retrieved from the IDP and mapped to internal ETERNA groups.
+
+## Configuration
+
+Group mapping is configured in `roda-core.properties`.
+
+### Enable external group mapping
+
+```properties
+core.authorization.external.group_mapping = true
+core.authorization.external.attribute = memberOf
+```
+
+- `group_mapping = true` enables the feature.
+- `attribute = memberOf` specifies which OIDC/SAML attribute contains the user's groups. The attribute name varies between IDPs — `memberOf` is the claim used by Azure AD, but your IDP may use a different name (e.g. `groups` or a custom claim).
+
+### Define mappings
+
+Each mapping connects an IDP group identifier (matched as a regex) to one or more internal ETERNA groups:
+
+```properties
+core.authorization.external.mappings[] = <mapping-name>
+core.authorization.external.mapping.<mapping-name>.external.group = <regex matching IDP group ID>
+core.authorization.external.mapping.<mapping-name>.internal.groups[] = <internal group>
+```
+
+Multiple mappings can be defined by repeating the `mappings[]` entry with different names.
+
+### Example: Azure AD / Microsoft Entra ID
+
+In Azure AD, groups are identified by their object ID (GUID). The following example maps two Azure AD groups to internal ETERNA groups:
+
+```properties
+core.authorization.external.group_mapping = true
+core.authorization.external.attribute = memberOf
+
+# Administrators
+core.authorization.external.mappings[] = map_admins
+core.authorization.external.mapping.map_admins.external.group = bbc466f2-55f4-4ca2-8303-d4238b8884d5
+core.authorization.external.mapping.map_admins.internal.groups[] = administrators
+
+# Standard users
+core.authorization.external.mappings[] = map_users
+core.authorization.external.mapping.map_users.external.group = f390adab-5c81-4a89-8e72-c9cc107bf7d5
+core.authorization.external.mapping.map_users.internal.groups[] = users
+```
+
+The `external.group` value is matched as a regular expression against the group identifier returned by the IDP. For other IDPs the group identifier may be a name, a DN (LDAP-style), or some other string — consult your IDP's documentation.
+
+## Limitations
+
+### No support for nested (recursive) group membership
+
+ETERNA only evaluates the groups returned directly in the `memberOf` attribute from the IDP. If a user is a member of Group A, and Group A is a member of Group B, the internal roles mapped to Group B are **not** assigned to the user.
+
+**Example of what does not work:**
+```
+User → Group A (direct member) → Group B (nested) → mapped to internal group
+```
+The user will not receive the internal group mapped to Group B because the membership is indirect.
+
+**Workaround:** Add users directly to the IDP group that is mapped in `roda-core.properties`, or create an additional mapping targeting the intermediate group.
+
+### Azure AD behavior
+
+By default, Azure AD only includes direct group memberships in the `memberOf` claim via OIDC. Transitive (nested) memberships require additional Graph API calls or specific application registration settings that are not currently handled by ETERNA's CAS integration.

--- a/documentation/administration/IDP_Group_Authorization.md
+++ b/documentation/administration/IDP_Group_Authorization.md
@@ -47,16 +47,16 @@ core.authorization.external.mapping.map_users.external.group = f390adab-5c81-4a8
 core.authorization.external.mapping.map_users.internal.groups[] = users
 ```
 
-The `external.group` value is matched as a regular expression against the group identifier returned by the IDP. For other IDPs the group identifier may be a name, a DN (LDAP-style), or some other string — consult your IDP's documentation.
+The `external.group` value is matched as a regular expression against the group identifier returned by the IDP. To avoid accidental partial matches, prefer anchoring patterns with `^` and `$` (for example `^bbc466f2-55f4-4ca2-8303-d4238b8884d5$`). For other IDPs the group identifier may be a name, a DN (LDAP-style), or some other string — consult your IDP's documentation.
 
 ## Limitations
 
 ### No support for nested (recursive) group membership
 
-ETERNA only evaluates the groups returned directly in the `memberOf` attribute from the IDP. If a user is a member of Group A, and Group A is a member of Group B, the internal roles mapped to Group B are **not** assigned to the user.
+ETERNA only evaluates groups returned directly in the attribute configured via `core.authorization.external.attribute` (commonly `memberOf`). If a user is a member of Group A, and Group A is a member of Group B, the internal roles mapped to Group B are **not** assigned to the user.
 
 **Example of what does not work:**
-```
+```text
 User → Group A (direct member) → Group B (nested) → mapped to internal group
 ```
 The user will not receive the internal group mapped to Group B because the membership is indirect.

--- a/documentation/administration/IDP_Group_Authorization.md
+++ b/documentation/administration/IDP_Group_Authorization.md
@@ -61,8 +61,20 @@ User → Group A (direct member) → Group B (nested) → mapped to internal gro
 ```
 The user will not receive the internal group mapped to Group B because the membership is indirect.
 
-**Workaround:** Add users directly to the IDP group that is mapped in `roda-core.properties`, or create an additional mapping targeting the intermediate group.
+**Workarounds:**
+
+- Add users directly to the IDP group that is mapped in `roda-core.properties`.
+- Create an additional mapping targeting the intermediate group.
+- **Configure your IDP to include transitive group memberships in the token claim.** Most modern IDPs support this natively and it requires no changes to ETERNA. See the IDP-specific notes below.
 
 ### Azure AD behavior
 
-By default, Azure AD only includes direct group memberships in the `memberOf` claim via OIDC. Transitive (nested) memberships require additional Graph API calls or specific application registration settings that are not currently handled by ETERNA's CAS integration.
+By default, Azure AD only includes direct group memberships in the `memberOf` claim via OIDC. To include transitive (nested) memberships, change the `groupMembershipClaims` setting in the application registration manifest from `"SecurityGroup"` to `"All"`:
+
+```json
+"groupMembershipClaims": "All"
+```
+
+This causes Azure AD to include all transitive group memberships in the token, which ETERNA then processes as if they were direct memberships.
+
+For other IDPs, consult their documentation on how to include transitive group memberships in the OIDC/SAML group claim (e.g. Keycloak's group mapper, Okta's group claim filter).

--- a/documentation/administration/IDP_Group_Authorization.md
+++ b/documentation/administration/IDP_Group_Authorization.md
@@ -67,7 +67,7 @@ The user will not receive the internal group mapped to Group B because the membe
 - Create an additional mapping targeting the intermediate group.
 - **Configure your IDP to include transitive group memberships in the token claim.** Most modern IDPs support this natively and it requires no changes to ETERNA. See the IDP-specific notes below.
 
-### Azure AD behavior
+#### Azure AD behavior
 
 By default, Azure AD only includes direct group memberships in the `memberOf` claim via OIDC. To include transitive (nested) memberships, change the `groupMembershipClaims` setting in the application registration manifest from `"SecurityGroup"` to `"All"`:
 

--- a/documentation/administration/IDP_Group_Authorization_sv_SE.md
+++ b/documentation/administration/IDP_Group_Authorization_sv_SE.md
@@ -1,0 +1,70 @@
+# Dynamisk grupptilldelning via IDP
+
+ETERNA stöder dynamisk tilldelning av interna grupper baserat på gruppmedlemskap i en extern identitetsleverantör (IDP). Alla IDP:er som exponerar gruppmedlemskap via OIDC- eller SAML-attribut stöds, inklusive Azure AD / Microsoft Entra ID, Keycloak, Okta och andra. När en användare loggar in via CAS hämtas användarens gruppmedlemskap från IDP:n och mappas till interna ETERNA-grupper.
+
+## Konfiguration
+
+Gruppmappning konfigureras i `roda-core.properties`.
+
+### Aktivera extern gruppmappning
+
+```properties
+core.authorization.external.group_mapping = true
+core.authorization.external.attribute = memberOf
+```
+
+- `group_mapping = true` aktiverar funktionen.
+- `attribute = memberOf` anger vilket OIDC/SAML-attribut som innehåller användarens grupper. Attributnamnet varierar mellan IDP:er — `memberOf` är det attribut som används av Azure AD, men din IDP kan använda ett annat namn (t.ex. `groups` eller ett eget attribut).
+
+### Definiera mappningar
+
+Varje mappning kopplar ett IDP-grupp-ID (matchat som regex) till en eller flera interna ETERNA-grupper:
+
+```properties
+core.authorization.external.mappings[] = <mappningsnamn>
+core.authorization.external.mapping.<mappningsnamn>.external.group = <regex mot IDP-grupp-ID>
+core.authorization.external.mapping.<mappningsnamn>.internal.groups[] = <intern grupp>
+```
+
+Flera mappningar kan definieras genom att upprepa `mappings[]`-posten med olika namn.
+
+### Exempel: Azure AD / Microsoft Entra ID
+
+I Azure AD identifieras grupper med sitt objekt-ID (GUID). Följande exempel mappar två Azure AD-grupper till interna ETERNA-grupper:
+
+```properties
+core.authorization.external.group_mapping = true
+core.authorization.external.attribute = memberOf
+
+# Administratörer
+core.authorization.external.mappings[] = map_admins
+core.authorization.external.mapping.map_admins.external.group = bbc466f2-55f4-4ca2-8303-d4238b8884d5
+core.authorization.external.mapping.map_admins.internal.groups[] = administrators
+
+# Standardanvändare
+core.authorization.external.mappings[] = map_users
+core.authorization.external.mapping.map_users.external.group = f390adab-5c81-4a89-8e72-c9cc107bf7d5
+core.authorization.external.mapping.map_users.internal.groups[] = users
+```
+
+Värdet för `external.group` matchas som ett reguljärt uttryck mot det grupp-ID som returneras av IDP:n. För andra IDP:er kan grupp-ID:t vara ett namn, ett DN (LDAP-format) eller en annan sträng — se din IDP:s dokumentation.
+
+## Begränsningar
+
+### Inget stöd för nästlat (rekursivt) gruppmedlemskap
+
+ETERNA kontrollerar enbart de grupper som returneras direkt i `memberOf`-attributet från IDP:n. Om en användare är medlem i Grupp A, och Grupp A är medlem i Grupp B, tilldelas **inte** de interna roller som är mappade mot Grupp B.
+
+**Exempel på vad som inte fungerar:**
+```
+Användare → Grupp A (direkt medlem) → Grupp B (nästlad) → mappad till intern grupp
+```
+Användaren får inte den interna gruppen som är mappad mot Grupp B eftersom tillhörigheten är indirekt.
+
+**Workaround:** Lägg till användare direkt i den IDP-grupp som är mappad i `roda-core.properties`, eller skapa en extra mappning mot den mellanliggande gruppen.
+
+### Azure AD-beteende
+
+Azure AD returnerar som standard bara direkta gruppmedlemskap i `memberOf`-attributet via OIDC. Transitiva (nästlade) medlemskap kräver ytterligare Graph API-anrop eller specifika appregistreringsinställningar som för närvarande inte hanteras av ETERNAs CAS-integration.
+
+

--- a/documentation/administration/IDP_Group_Authorization_sv_SE.md
+++ b/documentation/administration/IDP_Group_Authorization_sv_SE.md
@@ -61,10 +61,22 @@ Användare → Grupp A (direkt medlem) → Grupp B (nästlad) → mappad till in
 ```
 Användaren får inte den interna gruppen som är mappad mot Grupp B eftersom tillhörigheten är indirekt.
 
-**Workaround:** Lägg till användare direkt i den IDP-grupp som är mappad i `roda-core.properties`, eller skapa en extra mappning mot den mellanliggande gruppen.
+**Lösningar:**
+
+- Lägg till användare direkt i den IDP-grupp som är mappad i `roda-core.properties`.
+- Skapa en extra mappning mot den mellanliggande gruppen.
+- **Konfigurera din IDP att inkludera transitiva gruppmedlemskap i token-attributet.** De flesta moderna IDP:er stödjer detta nativt och kräver inga ändringar i ETERNA. Se IDP-specifika noteringar nedan.
 
 ### Azure AD-beteende
 
-Azure AD returnerar som standard bara direkta gruppmedlemskap i `memberOf`-attributet via OIDC. Transitiva (nästlade) medlemskap kräver ytterligare Graph API-anrop eller specifika appregistreringsinställningar som för närvarande inte hanteras av ETERNAs CAS-integration.
+Azure AD returnerar som standard bara direkta gruppmedlemskap i `memberOf`-attributet via OIDC. För att inkludera transitiva (nästlade) medlemskap, ändra inställningen `groupMembershipClaims` i appregistreringens manifest från `"SecurityGroup"` till `"All"`:
+
+```json
+"groupMembershipClaims": "All"
+```
+
+Detta gör att Azure AD inkluderar alla transitiva gruppmedlemskap i token, vilka ETERNA sedan behandlar som om de vore direkta medlemskap.
+
+För andra IDP:er, se respektive dokumentation för hur transitiva gruppmedlemskap inkluderas i OIDC/SAML-attributet (t.ex. Keycloaks group mapper, Oktas group claim filter).
 
 

--- a/documentation/administration/IDP_Group_Authorization_sv_SE.md
+++ b/documentation/administration/IDP_Group_Authorization_sv_SE.md
@@ -67,7 +67,7 @@ Användaren får inte den interna gruppen som är mappad mot Grupp B eftersom ti
 - Skapa en extra mappning mot den mellanliggande gruppen.
 - **Konfigurera din IDP att inkludera transitiva gruppmedlemskap i token-attributet.** De flesta moderna IDP:er stödjer detta nativt och kräver inga ändringar i ETERNA. Se IDP-specifika noteringar nedan.
 
-### Azure AD-beteende
+#### Azure AD-beteende
 
 Azure AD returnerar som standard bara direkta gruppmedlemskap i `memberOf`-attributet via OIDC. För att inkludera transitiva (nästlade) medlemskap, ändra inställningen `groupMembershipClaims` i appregistreringens manifest från `"SecurityGroup"` till `"All"`:
 

--- a/documentation/administration/IDP_Group_Authorization_sv_SE.md
+++ b/documentation/administration/IDP_Group_Authorization_sv_SE.md
@@ -47,16 +47,16 @@ core.authorization.external.mapping.map_users.external.group = f390adab-5c81-4a8
 core.authorization.external.mapping.map_users.internal.groups[] = users
 ```
 
-Värdet för `external.group` matchas som ett reguljärt uttryck mot det grupp-ID som returneras av IDP:n. För andra IDP:er kan grupp-ID:t vara ett namn, ett DN (LDAP-format) eller en annan sträng — se din IDP:s dokumentation.
+Värdet för `external.group` matchas som ett reguljärt uttryck mot det grupp-ID som returneras av IDP:n. För att undvika oavsiktliga delsträngsmatchningar bör mönstret förankras med `^` och `$` (t.ex. `^bbc466f2-55f4-4ca2-8303-d4238b8884d5$`). För andra IDP:er kan grupp-ID:t vara ett namn, ett DN (LDAP-format) eller en annan sträng — se din IDP:s dokumentation.
 
 ## Begränsningar
 
 ### Inget stöd för nästlat (rekursivt) gruppmedlemskap
 
-ETERNA kontrollerar enbart de grupper som returneras direkt i `memberOf`-attributet från IDP:n. Om en användare är medlem i Grupp A, och Grupp A är medlem i Grupp B, tilldelas **inte** de interna roller som är mappade mot Grupp B.
+ETERNA kontrollerar enbart grupper som returneras direkt i det konfigurerade externa attributet (`core.authorization.external.attribute`, ofta `memberOf`). Om en användare är medlem i Grupp A, och Grupp A är medlem i Grupp B, tilldelas **inte** de interna roller som är mappade mot Grupp B.
 
 **Exempel på vad som inte fungerar:**
-```
+```text
 Användare → Grupp A (direkt medlem) → Grupp B (nästlad) → mappad till intern grupp
 ```
 Användaren får inte den interna gruppen som är mappad mot Grupp B eftersom tillhörigheten är indirekt.


### PR DESCRIPTION
## Summary

- Adds English and Swedish documentation for configuring dynamic group mapping from an external IDP (OIDC/SAML) to internal ETERNA groups via \oda-core.properties\
- Documents configuration syntax with an Azure AD example (clearly labelled as Azure-specific)
- Notes the limitation: no support for nested/recursive group membership — users must be direct members of the mapped IDP group

## Related issue

Closes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dokumentation**
  * Tillagd dokumentation för att konfigurera dynamisk mappning av externa IDP-grupper till interna ETERNA-grupper via OIDC/SAML-attribut.
  * Innehåller konfigurationsguide med stöd för regex-baserad mappning och praktiska exempel för Azure AD.
  * Dokumentation tillgänglig på svenska och engelska, inklusive dokumenterad information om begränsningar avseende direkta gruppmedlemskap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->