### PR TITLE
feat: PDF redaction versioning with user-defined suffix

### DIFF
--- a/documentation/usage/PdfRedaction.md
+++ b/documentation/usage/PdfRedaction.md
@@ -46,7 +46,11 @@ Enter the reason and click **Confirm** to proceed. Click **Cancel** to return to
 
 > **Note:** Depending on your system configuration, providing a reason may be mandatory. By default it is mandatory. When mandatory, the Confirm button is disabled until you have entered a reason.
 
-After confirming the reason, a second dialog asks you to confirm the export. The editor renders each page and replaces the redacted areas with solid black rectangles in the exported file. A progress indicator shows how many pages have been processed. Once complete, the redacted file is saved back to the archive.
+After confirming the reason, a second dialog asks you to confirm the export. It contains a **Version suffix** field where you can give the saved version a descriptive name — for example `personal-data-removed`. The saved file will be named `[original filename]_[suffix].pdf`. Leave the field empty to use an automatically generated timestamp instead (for example `report_2026-04-27T14-30.pdf`).
+
+If a version with the same suffix already exists, an error message appears in the dialog and you can enter a different suffix. Click **Save** to proceed or **Cancel** to return to the editor. The editor renders each page and replaces the redacted areas with solid black rectangles in the exported file. A progress indicator shows how many pages have been processed. Once complete, the redacted file is saved back to the archive.
+
+Multiple redacted versions of the same file can coexist. All versions are stored in the same redacted representation of the archival information package.
 
 ## Audit log
 
@@ -57,6 +61,6 @@ Every time the redaction editor is opened, an entry is created in the audit log 
 - the date and time
 - the reason provided
 
-Each save is also recorded as a separate entry with the action **Upload File Resource**. To find all redaction saves in the audit log, type `Maskerad PDF sparad` in the search box or filter on that value in the right sidebar. The status field on the entry shows whether the save succeeded or failed.
+Each successful save is also recorded as a separate entry with the action **Upload File Resource**. The filename in the entry reflects the version suffix used, making it possible to distinguish between different versions in the audit log. To find all redaction saves, type `Maskerad PDF sparad` in the search box or filter on that value in the right sidebar. Save attempts that fail due to a filename conflict (duplicate suffix) are not recorded — only completed uploads appear in the log.
 
 This ensures that all redaction activity is traceable and can be reviewed later.

--- a/documentation/usage/PdfRedaction_sv_SE.md
+++ b/documentation/usage/PdfRedaction_sv_SE.md
@@ -46,7 +46,11 @@ Ange skälet och klicka på **Bekräfta** för att fortsätta. Klicka på **Avbr
 
 > **Observera:** Beroende på systemkonfigurationen kan det vara obligatoriskt att ange ett skäl. Som standard är det obligatoriskt. När det är obligatoriskt är Bekräfta-knappen inaktiverad tills du har angett ett skäl.
 
-När skälet har bekräftats visas ytterligare en dialog som ber dig bekräfta exporten. Redigeraren renderar varje sida och ersätter de maskerade områdena med solida svarta rektanglar i den exporterade filen. En förloppsindikator visar hur många sidor som har bearbetats. När exporten är klar sparas den maskerade filen tillbaka till arkivet.
+När skälet har bekräftats visas ytterligare en dialog som ber dig bekräfta exporten. Den innehåller ett **Versionssuffix**-fält där du kan ge den sparade versionen ett beskrivande namn — till exempel `personuppgifter-borttagna`. Den sparade filen får namnet `[originalfilnamn]_[suffix].pdf`. Lämna fältet tomt om du vill att en tidsstämpel ska genereras automatiskt istället (till exempel `rapport_2026-04-27T14-30.pdf`).
+
+Om det redan finns en version med samma suffix visas ett felmeddelande i dialogen och du kan ange ett annat suffix. Klicka på **Spara** för att fortsätta eller **Avbryt** för att återgå till redigeraren. Redigeraren renderar varje sida och ersätter de maskerade områdena med solida svarta rektanglar i den exporterade filen. En förloppsindikator visar hur många sidor som har bearbetats. När exporten är klar sparas den maskerade filen tillbaka till arkivet.
+
+Flera maskerade versioner av samma fil kan samexistera. Alla versioner lagras i samma maskerade representation av arkivpaketet.
 
 ## Granskningslogg
 
@@ -57,6 +61,6 @@ Varje gång maskeringsredigeraren öppnas skapas en post i granskningsloggen som
 - datum och tidpunkt
 - det angivna skälet
 
-Varje sparning loggas dessutom som en separat post med åtgärden **Upload File Resource**. För att hitta alla maskeringssparningar i granskningsloggen, skriv in `Maskerad PDF sparad` i sökrutan eller filtrera på det värdet i den högra sidopanelen. Statusfältet på posten visar om sparningen lyckades eller misslyckades.
+Varje lyckad sparning loggas dessutom som en separat post med åtgärden **Upload File Resource**. Filnamnet i posten återspeglar det versionssuffix som användes, vilket gör det möjligt att skilja mellan olika versioner i granskningsloggen. För att hitta alla maskeringssparningar, skriv in `Maskerad PDF sparad` i sökrutan eller filtrera på det värdet i den högra sidopanelen. Sparförsök som misslyckas på grund av namnkrock (duplicerat suffix) registreras inte — bara slutförda uppladdningar visas i loggen.
 
 Detta säkerställer att all maskeringsaktivitet är spårbar och kan granskas i efterhand.

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -252,13 +252,12 @@ public class PDFRedactor extends Composite {
               // Resolve (inte reject) — React visar inline-feltext vid 409, ingen Toast
               return Promise.resolve(response);
             } else {
-              Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
               return Promise.reject(response);
             }
+          }).catch_(error -> {
+            Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
+            return Promise.reject(error);
           });
-        }).catch_(error -> {
-          Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
-          return Promise.reject(error);
         })
     );
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -3,6 +3,7 @@ package org.roda.wui.client.redact;
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -51,6 +52,7 @@ import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.tools.RestUtils;
 
+import java.util.Date;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,6 +103,21 @@ public class PDFRedactor extends Composite {
   }
 
   private static final Sorter findRedactedRepresentationSorter = new Sorter(new SortParameter(RodaConstants.REPRESENTATION_ID, false));
+
+  private static String generateTimestamp() {
+    DateTimeFormat fmt = DateTimeFormat.getFormat("yyyy-MM-dd'T'HH-mm");
+    return fmt.format(new Date());
+  }
+
+  private static String buildFilename(String originalId, String suffix) {
+    String effectiveSuffix = (suffix == null || suffix.isEmpty())
+        ? generateTimestamp()
+        : suffix;
+    int lastDot = originalId.lastIndexOf('.');
+    String base = (lastDot >= 0) ? originalId.substring(0, lastDot) : originalId;
+    String ext  = (lastDot >= 0) ? originalId.substring(lastDot)    : "";
+    return base + "_" + effectiveSuffix + ext;
+  }
 
   private boolean initialized;
 
@@ -211,32 +228,34 @@ public class PDFRedactor extends Composite {
       return preSavePromise.getPromise();
     });
 
-    pdfRedactorPanel.setSaveCallback((Blob pdfData, AbortSignal signal) ->
+    pdfRedactorPanel.setSaveCallback((Blob pdfData, AbortSignal signal, String suffix) ->
       getOrCreateRedactedRepresentation(aipId).then((representation) -> {
         List<String> path = new ArrayList<>(file.getPath());
 
         String uploadUrl = RestUtils.createFileUploadUri(aipId, representation.getId(), path, "Maskerad PDF sparad");
 
-        FormData formData = new FormData();
-        formData.append("resource", pdfData, file.getId());
+          String newFilename = buildFilename(file.getId(), suffix);
 
-        RequestInit requestInit = RequestInit.create();
-        requestInit.setMethod("POST");
-        requestInit.setBody(formData);
-        requestInit.setSignal(signal);
+          FormData formData = new FormData();
+          formData.append("resource", pdfData, newFilename);
 
-        return fetch(uploadUrl, requestInit).then(response -> {
-          if (response.ok) {
-            Toast.showInfo(messages.redactPdfToastTitle(), messages.redactPdfSaveSuccessDescription());
-            return Promise.resolve(response);
-          } else if (response.status == RodaConstants.HTTP_RESPONSE_CODE_REQUEST_CONFLICT) {
-            Toast.showError(messages.redactPdfToastTitle(), messages.fileAlreadyExists());
-            return Promise.reject(response);
-          } else {
-            Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
-            return Promise.reject(response);
-          }
-        });
+          RequestInit requestInit = RequestInit.create();
+          requestInit.setMethod("POST");
+          requestInit.setBody(formData);
+          requestInit.setSignal(signal);
+
+          return fetch(uploadUrl, requestInit).then(response -> {
+            if (response.ok) {
+              Toast.showInfo(messages.redactPdfToastTitle(), messages.redactPdfSaveSuccessDescription());
+              return Promise.resolve(response);
+            } else if (response.status == RodaConstants.HTTP_RESPONSE_CODE_REQUEST_CONFLICT) {
+              // Resolve (inte reject) — React visar inline-feltext vid 409, ingen Toast
+              return Promise.resolve(response);
+            } else {
+              Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
+              return Promise.reject(response);
+            }
+          });
         }).catch_(error -> {
           Toast.showError(messages.redactPdfToastTitle(), messages.redactPdfSaveErrorDescription());
           return Promise.reject(error);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
@@ -13,7 +13,7 @@ import jsinterop.annotations.JsType;
 public class PDFRedactorObject {
   @JsFunction
   public interface SaveCallback {
-    Promise<?> onInvoke(Blob pdfData, AbortSignal signal);
+    Promise<?> onInvoke(Blob pdfData, AbortSignal signal, String suffix);
   }
 
   @JsFunction
@@ -36,4 +36,3 @@ public class PDFRedactorObject {
   @JsMethod
   public static native void setPreSaveCallback(PreSaveCallback callback);
 }
-


### PR DESCRIPTION
## Summary

- Allows saving multiple redacted versions of the same PDF file by appending a user-defined suffix to the filename
- Adds a suffix input field to the existing PDF save dialog — no extra dialog or interaction step
- Empty suffix automatically generates a timestamp (`YYYY-MM-DDTHH-mm`)
- On 409 filename conflict, the dialog stays open with an inline error message instead of a generic toast

## Details

- `eterna-pdf-redactor` plugin: suffix input field in `ExportContext.tsx`, updated `setSaveCallback` signature to `(Blob, AbortSignal, suffix: string)` in `main.tsx`
- `PDFRedactorObject.java`: `SaveCallback.onInvoke` extended with `String suffix` parameter
- `PDFRedactor.java`: `buildFilename()` builds `[basename]_[suffix].[ext]`; `generateTimestamp()` used as fallback; 409 resolves via `Promise.resolve(response)` so React can show inline conflict error

## Depends on

Stacked on top of #319 (redaction reason at save time). Base branch is `feat/pdf-redaction-reason`.

## Test plan

- [ ] Open a PDF, apply redactions, click Save — suffix field appears in the dialog
- [ ] Enter a suffix (e.g. `v1`) and save → file saved as `originalname_v1.pdf`
- [ ] Save again with the same suffix → inline error "En version med detta namn finns redan", dialog stays open
- [ ] Save with empty suffix → file saved as `originalname_2026-04-27T14-30.pdf`
- [ ] Type invalid characters (e.g. `/`) → red validation error immediately, Save button disabled
- [ ] Verify reason dialog (from #319) still appears before the suffix dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Uppdateringar i denna utgåva

* **Nya funktioner**
  * Stöd för versionssuffix vid PDF-export. Användare kan ange ett eget suffix eller låta systemet generera en tidsstämpel automatiskt.
  * Möjlighet att lagra flera redigerade versioner av samma originaldokument med olika suffix.

* **Felkorrigeringar**
  * Förbättrad hantering av dubbletter av suffix med felmeddelande i dialogrutan.
  * Uppdaterad loggning som endast registrerar lyckade uppladdningar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->