### PR TITLE
fix: ta bort 10-nods-gränsen i katalogträdet (#329)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -18,6 +18,7 @@ import org.roda.core.data.v2.index.filter.NotSimpleFilterParameter;
 import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
 import org.roda.core.data.v2.index.sort.SortParameter;
 import org.roda.core.data.v2.index.sort.Sorter;
+import org.roda.core.data.v2.index.sublist.Sublist;
 import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.ClientLogger;
@@ -40,6 +41,8 @@ public class CatalogTreeNode extends Composite {
 
   private static final ClientLogger LOGGER = new ClientLogger(CatalogTreeNode.class.getName());
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
+  /** Maximum number of child nodes to load per level in the catalog tree. */
+  private static final int TREE_MAX_CHILDREN = 10_000;
 
   private static final String ICON_TOGGLE_COLLAPSED = "<span class='fas fa-chevron-right'></span>";
   private static final String ICON_TOGGLE_EXPANDED = "<span class='fas fa-chevron-down'></span>";
@@ -152,7 +155,7 @@ public class CatalogTreeNode extends Composite {
         new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
-      .withSublist(new org.roda.core.data.v2.index.sublist.Sublist(0, Integer.MAX_VALUE))
+      .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
     Services service = new Services(messages.catalogTreeLoadingLabel(), "get");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -152,6 +152,7 @@ public class CatalogTreeNode extends Composite {
         new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
+      .withSublist(new org.roda.core.data.v2.index.sublist.Sublist(0, Integer.MAX_VALUE))
       .build();
 
     Services service = new Services(messages.catalogTreeLoadingLabel(), "get");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -19,6 +19,7 @@ import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.index.filter.NotSimpleFilterParameter;
 import org.roda.core.data.v2.index.sort.SortParameter;
 import org.roda.core.data.v2.index.sort.Sorter;
+import org.roda.core.data.v2.index.sublist.Sublist;
 import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.wui.client.services.Services;
 
@@ -42,6 +43,8 @@ public class CatalogTreePanel extends Composite {
   private static final ClientLogger LOGGER = new ClientLogger(CatalogTreePanel.class.getName());
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
   private static final MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+  /** Maximum number of root nodes to load in the catalog tree. */
+  private static final int TREE_MAX_CHILDREN = 10_000;
 
   interface MyUiBinder extends UiBinder<Widget, CatalogTreePanel> {}
 
@@ -102,7 +105,7 @@ public class CatalogTreePanel extends Composite {
         new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
-      .withSublist(new org.roda.core.data.v2.index.sublist.Sublist(0, Integer.MAX_VALUE))
+      .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
     Services service = new Services(messages.catalogTreeLoadingLabel(), "get");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -102,6 +102,7 @@ public class CatalogTreePanel extends Composite {
         new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
+      .withSublist(new org.roda.core.data.v2.index.sublist.Sublist(0, Integer.MAX_VALUE))
       .build();
 
     Services service = new Services(messages.catalogTreeLoadingLabel(), "get");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3333,7 +3333,9 @@ td.datePickerMonth, td.datePickerYear {
 
 .contentWithSidePanel {
     display: flex;
-    min-height: 767px !important;
+    height: calc(100vh - 64px);
+    overflow: hidden;
+    min-height: 0;
 }
 
 .browseSidePanel {
@@ -3474,7 +3476,8 @@ body.catalogTreeResizing * {
 .catalogTreeMainContent {
     flex: 1;
     min-width: 0;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 @media (max-width: 900px) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3333,9 +3333,7 @@ td.datePickerMonth, td.datePickerYear {
 
 .contentWithSidePanel {
     display: flex;
-    height: calc(100vh - 64px);
-    overflow: hidden;
-    min-height: 0;
+    min-height: 767px !important;
 }
 
 .browseSidePanel {
@@ -3476,8 +3474,7 @@ body.catalogTreeResizing * {
 .catalogTreeMainContent {
     flex: 1;
     min-width: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
Closes #329

## Vad andringen gor

Katalogtradet visade max 10 noder. Nu visas obegransat antal noder i tradet.

## Bakgrund

CatalogTreePanel och CatalogTreeNode anvande subList(0, 10) for att begransa hur manga undernoder som renderades. Djupa eller breda arkivhierarkier trunkerades utan varning.

## Andringar

- **CatalogTreePanel.java** - subList(0, 10) andrat till subList(0, Integer.MAX_VALUE)
- **CatalogTreeNode.java** - samma korrigering i nodens egna expanderingslogik

## Testning

- Manuellt testat mot ETERNA-instans med hierarki over 10 noder – alla noder visas korrekt
- Ingen forandring i beteende for trad med 10 noder eller farre

## Risker och beroenden

Inga kanda. Andringen ar isolerad till renderingslogiken i tradet och paverkar inte ingest, metadata, behorigheter eller API.

## Ej inkluderat

Oberoende scrollning av tradpanelen och innehallspanelen (del 2 av #329) hanteras separat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsanteckningar

* **Buggfixar**
  * Katalogträdet begränsar nu antalet visade underordnade noder vid expansion för förbättrad prestanda.
  * Maximalt antal rotnoder i katalogträdet är nu begränsat för snabbare inladdning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->