### PR TITLE
chore: update license headers to ETERNA-earkiv/ETERNA URL

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/SecureString.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/SecureString.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/descriptionlevels/DescriptionLevel.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/descriptionlevels/DescriptionLevel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.descriptionlevels;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AcquireLockTimeoutException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AcquireLockTimeoutException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AlreadyHasInstanceIdentifier.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AlreadyHasInstanceIdentifier.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AuthenticationDeniedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AuthenticationDeniedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AuthorizationDeniedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/AuthorizationDeniedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalHoldAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalHoldAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalHoldNotValidException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalHoldNotValidException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalRuleAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalRuleAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalRuleNotValidException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalRuleNotValidException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalScheduleAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalScheduleAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalScheduleNotValidException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/DisposalScheduleNotValidException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/EmailAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/EmailAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/EmailUnverifiedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/EmailUnverifiedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/GenericException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/GenericException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/GroupAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/GroupAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/IllegalOperationException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/IllegalOperationException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InactiveUserException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InactiveUserException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InstanceIdNotUpdated.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InstanceIdNotUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InvalidParameterException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InvalidParameterException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InvalidTokenException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/InvalidTokenException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/IsStillUpdatingException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/IsStillUpdatingException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobAlreadyStartedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobAlreadyStartedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobInErrorException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobInErrorException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobIsStoppingException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobIsStoppingException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobStateNotPendingException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/JobStateNotPendingException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LockingException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LockingException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LogEntryJsonParseException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LogEntryJsonParseException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LoggerException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/LoggerException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/MarketException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/MarketException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/MultipleGenericException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/MultipleGenericException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotFoundException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotFoundException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotImplementedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotImplementedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotLockableAtTheTimeException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotLockableAtTheTimeException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotSupportedException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotSupportedException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotificationException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/NotificationException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/ObserverException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/ObserverException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RODAException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RODAException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RODAServiceException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RODAServiceException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RequestNotValidException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RequestNotValidException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RetentionPeriodCalculationException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RetentionPeriodCalculationException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/ReturnWithExceptions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/ReturnWithExceptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RoleAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/RoleAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/SolrRetryException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/SolrRetryException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/TechnicalMetadataNotFoundException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/TechnicalMetadataNotFoundException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/UserAlreadyExistsException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/exceptions/UserAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.exceptions;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/JsonUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/JsonUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/RepresentationInformationUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/RepresentationInformationUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/SelectedItemsUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/SelectedItemsUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URLUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URLUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/XMLUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/XMLUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/YamlUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/YamlUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.utils;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ConsumesOutputStream.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ConsumesOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ConsumesSkipableOutputStream.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ConsumesSkipableOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/DefaultConsumesOutputStream.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/DefaultConsumesOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/EntityResponse.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/EntityResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/IsModelObject.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/IsModelObject.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/IsRODAObject.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/IsRODAObject.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LinkingObjectUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LinkingObjectUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LiteOptionalWithCause.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LiteOptionalWithCause.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LiteRODAObject.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/LiteRODAObject.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ModelInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ModelInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/NamedIndexedModel.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/NamedIndexedModel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/SerializableOptional.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/SerializableOptional.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/SerializationProxy.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/SerializationProxy.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/StreamResponse.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/StreamResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/Void.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/Void.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKey.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKey.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.accessKey;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKeyStatus.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKeyStatus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.accessKey;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKeys.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/AccessKeys.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.accessKey;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/CreateAccessKeyRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessKey/CreateAccessKeyRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.accessKey;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessToken/AccessToken.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/accessToken/AccessToken.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.accessToken;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/aip/AssessmentRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/aip/AssessmentRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.aip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/aip/MoveRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/aip/MoveRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.aip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/Metrics.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/Metrics.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/ObjectPermission.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/ObjectPermission.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/ObjectPermissionResult.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/ObjectPermissionResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/OptionalWithCause.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/OptionalWithCause.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/Pair.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/Pair.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/RODAObjectList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/common/RODAObjectList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.common;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DestroyedSelectionState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DestroyedSelectionState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationAIPEntry.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationAIPEntry.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationCreateRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationCreateRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationForm.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationForm.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmationState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmations.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/confirmation/DisposalConfirmations.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.confirmation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHold.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHold.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.hold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHoldAssociation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHoldAssociation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.hold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHoldState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHoldState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.hold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHolds.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/hold/DisposalHolds.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.hold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalConfirmationAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalConfirmationAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalDestructionAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalDestructionAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalHoldAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalHoldAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalHoldsAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalHoldsAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalScheduleAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalScheduleAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveHoldAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveHoldAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveHoldsAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveHoldsAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveScheduleAIPMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/metadata/DisposalTransitiveScheduleAIPMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/ConditionType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/ConditionType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.rule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/DisposalRule.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/DisposalRule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.rule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/DisposalRules.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/rule/DisposalRules.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.rule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalActionCode.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalActionCode.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalSchedule.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalSchedule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalScheduleState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalScheduleState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalSchedules.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/DisposalSchedules.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/RetentionPeriodCalculation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/RetentionPeriodCalculation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/RetentionPeriodIntervalCode.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/disposal/schedule/RetentionPeriodIntervalCode.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.disposal.schedule;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/CreateFolderRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/CreateFolderRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.file;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/MoveFilesRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/MoveFilesRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.file;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/RenameFolderRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/file/RenameFolderRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.file;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/DeleteRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/DeleteRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/LongResponse.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/LongResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/MetadataValue.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/MetadataValue.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/StringResponse.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/StringResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/UpdatePermissionsRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/UpdatePermissionsRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsAllRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsAllRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsFilterRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsFilterRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsListRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsListRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsNoneRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsNoneRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.generics.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/CountRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/CountRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/FindRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/FindRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexResult.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexRunnable.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexRunnable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexedFileRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexedFileRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexedRepresentationRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IndexedRepresentationRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IsIndexed.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/IsIndexed.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/SuggestRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/SuggestRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/Collapse.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/Collapse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.collapse;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/HintEnum.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/HintEnum.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.collapse;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/MinMax.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/MinMax.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.collapse;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/NullPolicyEnum.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/collapse/NullPolicyEnum.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.collapse;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetFieldResult.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetFieldResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetValue.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/FacetValue.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/Facets.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/Facets.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/RangeFacetParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/RangeFacetParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/SimpleFacetParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/facet/SimpleFacetParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.facet;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/AllFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/AllFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/AndFiltersParameters.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/AndFiltersParameters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/BasicSearchFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/BasicSearchFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/ChildOfFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/ChildOfFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/DateIntervalFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/DateIntervalFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/DateRangeFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/DateRangeFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/EmptyKeyFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/EmptyKeyFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/Filter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/Filter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/FilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/FilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/FiltersParameters.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/FiltersParameters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/LikeFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/LikeFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/LongRangeFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/LongRangeFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/NotSimpleFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/NotSimpleFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/OneOfManyFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/OneOfManyFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/OrFiltersParameters.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/OrFiltersParameters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/ParentWhichFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/ParentWhichFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/RangeFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/RangeFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/SimpleFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/SimpleFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/StringRangeFilterParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/filter/StringRangeFilterParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.filter;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItems.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItems.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsAll.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsAll.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsFilter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsNone.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/select/SelectedItemsNone.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.select;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sort/SortParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sort/SortParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.sort;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sort/Sorter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sort/Sorter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.sort;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sublist/Sublist.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/sublist/Sublist.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.index.sublist;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIP.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPDisposalScheduleAssociationType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPDisposalScheduleAssociationType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPFormat.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPFormat.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPLink.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPLink.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPs.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/AIPs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIP.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPFile.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPFile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPFiles.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPFiles.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPs.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/DIPs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/File.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/File.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/FileLink.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/FileLink.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Files.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Files.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasDisposal.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasDisposal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasId.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasId.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasIdT.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasIdT.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasInstanceID.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasInstanceID.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasInstanceName.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasInstanceName.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasPermissionFilters.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasPermissionFilters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasPermissions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasPermissions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasStateFilter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/HasStateFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedAIP.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedAIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedDIP.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedDIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedFile.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedFile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedRepresentation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/IndexedRepresentation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Permissions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Permissions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Relationship.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Relationship.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/RepresentationLink.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/RepresentationLink.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/RepresentationState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/RepresentationState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representations.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representations.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/SIPInformation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/SIPInformation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/SetsUUID.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/SetsUUID.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ShallowFile.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ShallowFile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ShallowFiles.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/ShallowFiles.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/StoragePath.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/StoragePath.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/TransferredResource.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/TransferredResource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/TransferredResources.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/TransferredResources.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/DisassociateDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/DisassociateDisposalHoldRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.disposalhold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/LiftDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/LiftDisposalHoldRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.disposalhold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/UpdateDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/UpdateDisposalHoldRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.disposalhold;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ConfiguredDescriptiveMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ConfiguredDescriptiveMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ConfiguredDescriptiveMetadataList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ConfiguredDescriptiveMetadataList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/CreateDescriptiveMetadataRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/CreateDescriptiveMetadataRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataInfos.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataInfos.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataMixIn.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataMixIn.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataPreview.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataPreview.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataPreviewRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataPreviewRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataRequestForm.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataRequestForm.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataRequestXML.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataRequestXML.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataVersions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/DescriptiveMetadataVersions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/FileFormat.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/FileFormat.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/Fixity.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/Fixity.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/IndexedPreservationAgent.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/IndexedPreservationAgent.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/IndexedPreservationEvent.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/IndexedPreservationEvent.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/LinkingIdentifier.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/LinkingIdentifier.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/OtherMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/OtherMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/OtherMetadataList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/OtherMetadataList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationEventsLinkingObjects.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationEventsLinkingObjects.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationMetadataList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/PreservationMetadataList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ResourceVersion.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/ResourceVersion.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/SelectedType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/SelectedType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/SupportedMetadataValue.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/SupportedMetadataValue.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataInfos.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataInfos.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataMixIn.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadataMixIn.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TypeOptionsInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TypeOptionsInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.metadata;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/redaction/SaveRedactionRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/redaction/SaveRedactionRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ip.redaction;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/AipIdPluginParameterRenderingHints.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/AipIdPluginParameterRenderingHints.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Certificate.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Certificate.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CertificateInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CertificateInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CreateJobRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CreateJobRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/IndexedJob.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/IndexedJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/IndexedReport.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/IndexedReport.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Job.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Job.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobMixIn.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobMixIn.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobParallelism.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobParallelism.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobPriority.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobPriority.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobStats.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobStats.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobUserDetails.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/JobUserDetails.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Jobs.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Jobs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/LicenseInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/LicenseInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/MarketInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/MarketInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfoList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfoList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfoRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginInfoRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginProperties.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginProperties.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/PluginType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/RenderingHints.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/RenderingHints.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Report.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Report.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/ReportUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/ReportUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Reports.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Reports.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Vendor.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Vendor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.jobs;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/AuditLogRequestHeaders.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/AuditLogRequestHeaders.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/ClientLogCreateRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/ClientLogCreateRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntries.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntries.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntry.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntry.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntryParameter.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntryParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntryState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/log/LogEntryState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.log;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/Notification.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/Notification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.notifications;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/NotificationAcknowledgeRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/NotificationAcknowledgeRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.notifications;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/NotificationState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/NotificationState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.notifications;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/Notifications.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/notifications/Notifications.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.notifications;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfile.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfileOutcomeType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfileOutcomeType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ConversionProfiles.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/DropdownPluginParameterItem.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/DropdownPluginParameterItem.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/DropdownPluginParameterItems.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/DropdownPluginParameterItems.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ObjectClassFields.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ObjectClassFields.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ReindexPluginObject.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ReindexPluginObject.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ReindexPluginObjects.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/ReindexPluginObjects.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/SharedProperties.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/properties/SharedProperties.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.properties;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/ChangeRepresentationStatesRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/ChangeRepresentationStatesRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.representation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/ChangeTypeRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/ChangeTypeRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.representation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/RepresentationTypeOptions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/representation/RepresentationTypeOptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.representation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/ExtrasHandler.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/ExtrasHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RelationObjectType.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RelationObjectType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationCreateRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationCreateRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationCustomForm.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationCustomForm.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFamily.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFamily.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFamilyOptions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFamilyOptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFilterRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationFilterRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationList.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationRelation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationRelation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationRelationOptions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationRelationOptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationSupport.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ri/RepresentationInformationSupport.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.ri;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/IncidenceStatus.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/IncidenceStatus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/IndexedRisk.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/IndexedRisk.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/Risk.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/Risk.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskIncidence.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskIncidence.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskIncidences.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskIncidences.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskMitigationProperties.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskMitigationProperties.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskMitigationTerms.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskMitigationTerms.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskVersions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/RiskVersions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/Risks.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/Risks.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/SeverityLevel.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/SeverityLevel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/api/incidences/UpdateRiskIncidences.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/risks/api/incidences/UpdateRiskIncidences.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.risks.api.incidences;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/EntitySummary.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/EntitySummary.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/RODAInstance.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/RODAInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/SynchronizingStatus.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/SynchronizingStatus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/AttachmentState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/AttachmentState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/BundleState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/BundleState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/CentralEntities.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/CentralEntities.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/Issue.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/Issue.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/PackageState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/PackageState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/RemoteActions.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/RemoteActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/RemovedEntity.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/RemovedEntity.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/v2/BundleManifest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/v2/BundleManifest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/v2/PackageState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/bundle/v2/PackageState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.bundle.v2;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/CreateDistributedInstanceRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/CreateDistributedInstanceRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.central;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/CreateLocalInstanceRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/CreateLocalInstanceRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.central;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/DistributedInstance.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/DistributedInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.central;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/DistributedInstances.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/DistributedInstances.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.central;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/UpdateDistributedInstanceRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/central/UpdateDistributedInstanceRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.central;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/local/LocalInstance.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/local/LocalInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.synchronization.local;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/Group.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/Group.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAGroups.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAGroups.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAMember.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAMember.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAUsers.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RODAUsers.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RodaPrincipal.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/RodaPrincipal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/User.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/User.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/ChangeUserStatusRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/ChangeUserStatusRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateGroupRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateGroupRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateUserExtraFormFields.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateUserExtraFormFields.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateUserRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/CreateUserRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/LoginRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/LoginRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/RegisterUserRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/RegisterUserRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/ResetPasswordRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/ResetPasswordRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/UpdateUserRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/UpdateUserRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.user.requests;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationException.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.validation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationIssue.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationIssue.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.validation;
 

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationReport.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/validation/ValidationReport.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.data.v2.validation;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/Base64.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/Base64.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/ClassLoaderUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/ClassLoaderUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CommandException.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CommandException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CommandUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CommandUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CompoundClassLoader.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/CompoundClassLoader.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/FileUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/FileUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/HTTPUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/HTTPUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/IdUtils.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/IdUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/RESTClientUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/RESTClientUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/ZipUtility.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/ZipUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.util;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/CorporaConstants.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/CorporaConstants.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/TestsHelper.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/TestsHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/ConfigurationManagerTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/ConfigurationManagerTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/JsonUtilsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/JsonUtilsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/MetadataFileUtilsEscapeTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/MetadataFileUtilsEscapeTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/ReportAssertUtils.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/ReportAssertUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/RodaCoreFactoryTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/RodaCoreFactoryTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/SeleniumUtils.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/SeleniumUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/common/monitor/MonitorIndexTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/common/monitor/MonitorIndexTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.monitor;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/config/TestConfig.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/config/TestConfig.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalConfirmationTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalConfirmationTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.disposal;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalHoldTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalHoldTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.disposal;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalRuleTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalRuleTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.disposal;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalScheduleTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/disposal/DisposalScheduleTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.disposal;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/FilterTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/FilterTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexTestUtils.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexTestUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/PermissionsRecursiveTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/PermissionsRecursiveTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/PermissionsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/PermissionsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/SolrRetryTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/SolrRetryTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/SolrUtilsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/SolrUtilsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/model/LiteRODAObjectsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/model/LiteRODAObjectsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/model/ModelServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/model/ModelServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/model/TransactionalModelServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/model/TransactionalModelServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/AIPCorruptionRiskAssessmentTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/AIPCorruptionRiskAssessmentTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/BagitSIPPluginsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/BagitSIPPluginsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/DeleteRodaObjectPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/DeleteRodaObjectPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/EARKSIPPluginsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/EARKSIPPluginsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/FailureIngestPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/FailureIngestPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/InternalPluginsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/InternalPluginsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MinimalIngestPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MinimalIngestPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MovePluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MovePluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MultiplePluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/MultiplePluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PartialSuccessIngestPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PartialSuccessIngestPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PluginReportContentTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PluginReportContentTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PluginStateTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/PluginStateTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/ReindexFilePluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/ReindexFilePluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/SearchExportPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/SearchExportPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/UserPermissionsPluginTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/UserPermissionsPluginTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/DummyPlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/DummyPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatAlwaysFailsDuringExecuteMethod.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatAlwaysFailsDuringExecuteMethod.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringExecuteMethod.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringExecuteMethod.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringInit.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringInit.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringXMethod.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatFailsDuringXMethod.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatStopsItself.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatStopsItself.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatTestsLocking.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/PluginThatTestsLocking.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/dummies/DummyListPlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/dummies/DummyListPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.dummies;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/multiple/MultiplePlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/multiple/MultiplePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/FailureOnMandatoryStepAfterPartialSuccessIngestPlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/FailureOnMandatoryStepAfterPartialSuccessIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.v2;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/FailureOnMandatoryStepIngestPlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/FailureOnMandatoryStepIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.v2;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/PartialSuccessIngestPlugin.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/base/v2/PartialSuccessIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.v2;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/orchestrate/JobsTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/plugins/orchestrate/JobsTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/security/LdapUtilityTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/security/LdapUtilityTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.security;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/security/LdapUtilityTestHelper.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/security/LdapUtilityTestHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.security;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/AbstractStorageServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/AbstractStorageServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/RandomMockContentPayload.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/RandomMockContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/StorageTestUtils.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/StorageTestUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/TransactionalStorageServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/TransactionalStorageServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.fs;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/protocol/ProtocolManagerTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/protocol/ProtocolManagerTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.protocol;
 

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/transactions/TransactionLogConsolidatorTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/transactions/TransactionLogConsolidatorTest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transactions;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaBootstrap.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaBootstrap.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaPropertiesReloadStrategy.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaPropertiesReloadStrategy.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/SchemasCacheLoader.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/SchemasCacheLoader.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/ConfigurableEmailUtility.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/ConfigurableEmailUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/ConfigurationResourceBundle.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/ConfigurationResourceBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/DownloadUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/DownloadUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/FileFormatUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/FileFormatUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/HandlebarsUtility.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/HandlebarsUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/JwtUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/JwtUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/MarketUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/MarketUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/Messages.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/Messages.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/MetadataFileUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/MetadataFileUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/MetadataUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/MetadataUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  * The contents of this file are subject to the license and copyright

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/ProvidesInputStream.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/ProvidesInputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/ReturnWithExceptionsWrapper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/ReturnWithExceptionsWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaEntityResolver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaEntityResolver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaURIFileResolver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaURIFileResolver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/SelectedItemsUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/SelectedItemsUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/ServiceException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/ServiceException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/SyncUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/SyncUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/TokenManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/TokenManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/XMLUtility.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/XMLUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadata.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.characterization.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadataElement.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadataElement.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.characterization.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadataField.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/characterization/model/TechnicalMetadataField.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.characterization.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/dips/DIPUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/dips/DIPUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.dips;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/iterables/CloseableIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/iterables/CloseableIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/iterables/CloseableIterables.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/iterables/CloseableIterables.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/ReindexTransferredResourcesRunnable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/ReindexTransferredResourcesRunnable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.monitor;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TaskBlocker.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TaskBlocker.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.monitor;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferUpdateStatus.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferUpdateStatus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.monitor;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferredResourcesScanner.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferredResourcesScanner.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.monitor;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/EmailNotificationProcessor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/EmailNotificationProcessor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/FileNotificationProcessor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/FileNotificationProcessor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/HTTPNotificationProcessor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/HTTPNotificationProcessor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/NotificationProcessor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/notifications/NotificationProcessor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/DeadLetterActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/DeadLetterActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/Messages.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/Messages.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/PekkoBaseActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/PekkoBaseActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/PekkoUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/PekkoUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/AbstractMessage.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/AbstractMessage.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/AbstractEventMessage.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/AbstractEventMessage.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupCreated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupCreated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupDeleted.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupDeleted.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventGroupUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserCreated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserCreated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserDeleted.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserDeleted.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/events/EventUserUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobCleanup.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobCleanup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobInfoUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobInfoUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobInitEnded.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobInitEnded.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobPartialUpdate.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobPartialUpdate.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobSourceObjectsUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobSourceObjectsUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStateDetailsUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStateDetailsUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStateUpdated.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStateUpdated.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStop.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobStop.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerAcquireLock.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerAcquireLock.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerJobEnded.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerJobEnded.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerNotLockableAtTheTime.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerNotLockableAtTheTime.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReleaseAllLocks.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReleaseAllLocks.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReleaseLock.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReleaseLock.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReplyToAcquireLock.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReplyToAcquireLock.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReplyToReleaseLock.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerReplyToReleaseLock.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerTick.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/jobs/JobsManagerTick.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.jobs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginAfterAllExecuteIsDone.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginAfterAllExecuteIsDone.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginAfterAllExecuteIsReady.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginAfterAllExecuteIsReady.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginBeforeAllExecuteIsDone.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginBeforeAllExecuteIsDone.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginBeforeAllExecuteIsReady.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginBeforeAllExecuteIsReady.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginExecuteIsDone.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginExecuteIsDone.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginExecuteIsReady.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginExecuteIsReady.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginMethodIsDone.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginMethodIsDone.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginMethodIsReady.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/pekko/messages/plugins/PluginMethodIsReady.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.pekko.messages.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/BundleManifestCreator.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/BundleManifestCreator.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.synchronization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/ImportUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/ImportUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.synchronization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/JsonListHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/synchronization/JsonListHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.synchronization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/tools/ZipEntryInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/tools/ZipEntryInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.tools;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/tools/ZipTools.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/tools/ZipTools.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.tools;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/validation/Input.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/validation/Input.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.validation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/validation/ResourceResolver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/validation/ResourceResolver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.validation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/validation/ValidationUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/validation/ValidationUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.common.validation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/config/ConfigurationManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/config/ConfigurationManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/config/DirectoryInitializer.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/config/DirectoryInitializer.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/config/LdapConfig.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/config/LdapConfig.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/config/MicrometerConfig.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/config/MicrometerConfig.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/config/SpringContext.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/config/SpringContext.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.config;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/OperationState.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/OperationState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/OperationType.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/OperationType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionLog.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionLog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionStoragePathConsolidatedOperation.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionStoragePathConsolidatedOperation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionalModelOperationLog.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionalModelOperationLog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionalStoragePathOperationLog.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/entity/transaction/TransactionalStoragePathOperationLog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.entity.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/AbstractEventsHandler.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/AbstractEventsHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/EventsHandler.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/EventsHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/EventsManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/EventsManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/EventsNotifier.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/EventsNotifier.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/CRDTSerializer.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/CRDTSerializer.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/CRDTWrapper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/CRDTWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/PekkoEventsHandlerAndNotifier.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/PekkoEventsHandlerAndNotifier.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/PekkoEventsHandlerAndNotifierActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/events/pekko/PekkoEventsHandlerAndNotifierActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.events.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexingAdditionalInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexingAdditionalInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/AbstractSolrCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/AbstractSolrCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/CopyField.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/CopyField.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/DynamicField.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/DynamicField.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/Field.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/Field.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SchemaBuilder.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SchemaBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrBootstrapUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrBootstrapUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrCollectionRegistry.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrCollectionRegistry.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/AIPCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DIPCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DIPCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DIPFileCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DIPFileCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DisposalConfirmationCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/DisposalConfirmationCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/JobCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/JobCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/JobReportCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/JobReportCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/LogEntryCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/LogEntryCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/MemberCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/MemberCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/NotificationCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/NotificationCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/PreservationAgentCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/PreservationAgentCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/PreservationEventCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/PreservationEventCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RepresentationCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RepresentationCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RepresentationInformationCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RepresentationInformationCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RiskCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RiskCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RiskIncidenceCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/RiskIncidenceCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/TransferredResourceCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/TransferredResourceCollection.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.schema.collections;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IndexResultIterator.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IndexResultIterator.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IndexUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IndexUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IterableIndexResult.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/IterableIndexResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/RetryPolicyBuilder.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/RetryPolicyBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrXMLLoader.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrXMLLoader.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/ZkController.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/ZkController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.index.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/migration/MigrationAction.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/migration/MigrationAction.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.migration;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/migration/MigrationManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/migration/MigrationManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.migration;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/migration/model/PreservationMetadataFileToVersion2.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/migration/model/PreservationMetadataFileToVersion2.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.migration.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/migration/model/RepresentationToVersion2.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/migration/model/RepresentationToVersion2.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.migration.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/migration/model/RiskToVersion2.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/migration/model/RiskToVersion2.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.migration.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/LiteRODAObjectFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/LiteRODAObjectFactory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObservable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObservable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObserver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/TransactionalModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/TransactionalModelService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/AIPDescriptiveMetadataIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/AIPDescriptiveMetadataIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/AIPPreservationMetadataIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/AIPPreservationMetadataIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/DIPFileIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/DIPFileIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/FileIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/FileIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/LogEntryFileSystemIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/LogEntryFileSystemIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/LogEntryStorageIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/LogEntryStorageIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationDescriptiveMetadataIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationDescriptiveMetadataIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationPreservationMetadataIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/iterables/RepresentationPreservationMetadataIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.iterables;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedAIPLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedAIPLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDIPFileLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDIPFileLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDIPLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDIPLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDescriptiveMetadataLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDescriptiveMetadataLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalConfirmationLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalConfirmationLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalHoldLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalHoldLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalRule.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalRule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalSchedule.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDisposalSchedule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDistributedInstance.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedDistributedInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedFileLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedFileLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedGroupLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedGroupLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedJobLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedJobLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedNotificationLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedNotificationLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedPreservationMetadataLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedPreservationMetadataLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedReportLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedReportLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRepresentationInformationLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRepresentationInformationLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRepresentationLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRepresentationLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRiskIncidenceLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRiskIncidenceLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRiskLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedRiskLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedTransferredResourceLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedTransferredResourceLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedUserLite.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/lites/ParsedUserLite.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.lites;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapGroup.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapGroup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapRole.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapRole.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapUser.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapUser.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapUtility.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/LdapUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ModelUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ModelUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/Pbkdf2PasswordEncoderImpl.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/Pbkdf2PasswordEncoderImpl.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ResourceListUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ResourceListUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ResourceParseUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/ResourceParseUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/utils/UserUtility.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/utils/UserUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.model.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/AbstractAIPComponentsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/AbstractAIPComponentsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/AbstractPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/AbstractPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/Plugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/Plugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManagerException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManagerException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginMessagesControl.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginMessagesControl.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginOrchestrator.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginOrchestrator.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAObjectProcessingLogic.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAObjectProcessingLogic.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAObjectsProcessingLogic.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAObjectsProcessingLogic.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAProcessingLogic.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/RODAProcessingLogic.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/SecurityManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/SecurityManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AVGAntiVirus.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AVGAntiVirus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntiVirus.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntiVirus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntiVirusException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntiVirusException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/ClamAntiVirus.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/ClamAntiVirus.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/VirusCheckResult.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/VirusCheckResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.antivirus;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.characterization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/PremisSkeletonPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.characterization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.characterization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.characterization;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
@@ -1,7 +1,9 @@
 /**
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE file at the root of the source
- * tree
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.conversion;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/CreateDisposalConfirmationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/CreateDisposalConfirmationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DeleteDisposalConfirmationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DeleteDisposalConfirmationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DestroyRecordsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DestroyRecordsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DisposalConfirmationPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/DisposalConfirmationPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/PermanentlyDeleteRecordsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/PermanentlyDeleteRecordsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/RestoreRecordsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/confirmation/RestoreRecordsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.confirmation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/ApplyDisposalHoldToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/ApplyDisposalHoldToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.hold;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/DisassociateDisposalHoldFromAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/DisassociateDisposalHoldFromAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.hold;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/DisposalHoldPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/DisposalHoldPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.hold;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/LiftDisposalHoldPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/hold/LiftDisposalHoldPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.hold;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.rules;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.rules;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/AssociateDisposalScheduleToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/AssociateDisposalScheduleToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.schedule;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/DisassociateDisposalScheduleToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/DisassociateDisposalScheduleToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.schedule;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/DisposalSchedulePluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/schedule/DisposalSchedulePluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.disposal.schedule;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/IngestHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/IngestHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/PermissionUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/PermissionUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPRemovePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/ConfigurableIngestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/ConfigurableIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/DefaultIngestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/DefaultIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/MinimalIngestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/MinimalIngestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/AutoAcceptIngestStep.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/AutoAcceptIngestStep.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2.steps;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStep.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStep.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2.steps;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStepBundle.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStepBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2.steps;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStepsUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/v2/steps/IngestStepsUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.ingest.v2.steps;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ActionLogCleanerPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ActionLogCleanerPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/AddRepresentationInformationFilterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/AddRepresentationInformationFilterPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRepresentationStatusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRepresentationStatusPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeTypePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeTypePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/CleanUnfinishedJobsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/CleanUnfinishedJobsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/CleanupFailedIngestAIPsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/CleanupFailedIngestAIPsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRODAObjectPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRODAObjectPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRodaObjectPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRodaObjectPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ExportAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ExportAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/FixAncestorsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/FixAncestorsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/MoveOrphansToParentNodePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/MoveOrphansToParentNodePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/MovePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/MovePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/UpdatePermissionsPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/UpdatePermissionsPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexActionLogPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexActionLogPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAllRodaEntitiesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAllRodaEntitiesPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDIPFilePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDIPFilePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDisposalConfirmationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexDisposalConfirmationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexFilePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexFilePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexIncidencePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexJobPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexNotificationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAIPEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAIPEventPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAgentPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAgentPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationRepositoryEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationRepositoryEventPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRepresentationInformationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRepresentationInformationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRepresentationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRepresentationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRiskPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaEntityPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaEntityPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaMemberPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaMemberPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexTransferredResourcePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexTransferredResourcePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.maintenance.reindex;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/DefaultMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/DefaultMultipleStepPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/MultipleStepBundle.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/MultipleStepBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/MutipleStepUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/MutipleStepUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/NoObjectsMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/NoObjectsMultipleStepPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/Step.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/multiple/Step.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.multiple;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/AbstractJobNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/AbstractJobNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/EmailGenericNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/EmailGenericNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/EmailIngestNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/EmailIngestNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/FileGenericNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/FileGenericNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/GenericJobNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/GenericJobNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/HttpGenericNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/HttpGenericNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/JobNotification.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/notifications/JobNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.notifications;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/CopyOriginalMETS.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/CopyOriginalMETS.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.plugins.base.originalmets;
 
 import jakarta.xml.bind.JAXBException;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/CreateLogicalMETS.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/CreateLogicalMETS.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.plugins.base.originalmets;
 
 import java.nio.file.Files;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/OriginalMETSUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/OriginalMETSUtils.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.plugins.base.originalmets;
 
 import java.nio.file.Path;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/UpdateOriginalMETS.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/originalmets/UpdateOriginalMETS.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.plugins.base.originalmets;
 
 import jakarta.xml.bind.JAXBException;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/AIPCorruptionRiskAssessmentPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/AIPCorruptionRiskAssessmentPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/AppraisalPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/AppraisalPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/DescriptiveMetadataValidationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/InventoryReportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/InventoryReportPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/InventoryReportPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/InventoryReportPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.preservation;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskAssociationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskAssociationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.risks;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskIncidenceRemoverPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskIncidenceRemoverPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.risks;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/UpdateIncidencesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/UpdateIncidencesPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.risks;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/security/AbstractSecurityConfiguration.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/security/AbstractSecurityConfiguration.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.security;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/security/SecurityPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/security/SecurityPluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.security;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPEventPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierDIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierDIPPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierJobPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierNotificationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierPreservationAgentPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierPreservationAgentPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepositoryEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepositoryEventPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepresentationInformationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepresentationInformationPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskIncidencePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/RegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/RegisterPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.instance;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/AipPackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/AipPackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/DipPackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/DipPackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/JobPackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/JobPackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/PreservationAgentPackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/PreservationAgentPackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RepositoryEventPackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RepositoryEventPackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RiskIncidencePackagePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RiskIncidencePackagePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RodaEntityPackagesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/packages/RodaEntityPackagesPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.packages;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/BuildSyncManifestPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/BuildSyncManifestPlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.proccess;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/ImportSyncBundlePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/ImportSyncBundlePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.proccess;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/RequestSyncBundlePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/RequestSyncBundlePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.proccess;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/SendSyncBundlePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/SendSyncBundlePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.proccess;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/SynchronizeInstancePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/proccess/SynchronizeInstancePlugin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.base.synchronization.proccess;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/CompositeX509TrustManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/CompositeX509TrustManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.certificate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/PluginCertificateException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/PluginCertificateException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.certificate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/PluginCertificateUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/certificate/PluginCertificateUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.certificate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/IngestJobPluginInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/IngestJobPluginInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobPluginInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobPluginInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobPluginInfoInterface.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobPluginInfoInterface.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobsHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/JobsHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/MultipleJobPluginInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/MultipleJobPluginInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/PekkoEmbeddedPluginOrchestrator.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/PekkoEmbeddedPluginOrchestrator.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/SimpleJobPluginInfo.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/SimpleJobPluginInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoBackgroundJobActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoBackgroundJobActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoBackgroundWorkerActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoBackgroundWorkerActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobStateInfoActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobStateInfoActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobsManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoJobsManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoLimitedJobActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoLimitedJobActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoWorkerActor.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/PekkoWorkerActor.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/mailbox/PrioritizedMailbox.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/mailbox/PrioritizedMailbox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko.mailbox;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/mailbox/PrioritizedMessage.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/orchestrate/pekko/mailbox/PrioritizedMessage.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.plugins.orchestrate.pekko.mailbox;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/AbstractProtocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/AbstractProtocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/Protocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/Protocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolManagerException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/ProtocolManagerException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/FileProtocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/FileProtocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/HttpProtocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/HttpProtocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/HttpsProtocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/HttpsProtocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/RODAProtocol.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/protocols/protocols/RODAProtocol.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.protocols.protocols;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapGroupRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapGroupRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.ldap;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapRoleRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapRoleRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.ldap;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapUserRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/ldap/LdapUserRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.ldap;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionLogRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionLogRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionStoragePathConsolidatedOperationsRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionStoragePathConsolidatedOperationsRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionalModelOperationLogRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionalModelOperationLogRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionalStoragePathRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/transaction/TransactionalStoragePathRepository.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.repository.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/security/LoadSecurityConfigCondition.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/security/LoadSecurityConfigCondition.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.security;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/security/SecurityObservable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/security/SecurityObservable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.security;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/security/SecurityObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/security/SecurityObserver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.security;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/AbstractEntity.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/AbstractEntity.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/AbstractResource.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/AbstractResource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/Binary.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/Binary.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/BinaryConsumesOutputStream.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/BinaryConsumesOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/BinaryVersion.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/BinaryVersion.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/Container.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/Container.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/ContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/ContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultBinary.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultBinary.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultBinaryVersion.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultBinaryVersion.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultContainer.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultContainer.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultDirectory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultDirectory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultStoragePath.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultStoragePath.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultTransactionalStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DefaultTransactionalStorageService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/DirectResourceAccess.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/DirectResourceAccess.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/Directory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/Directory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/EmptyClosableIterable.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/EmptyClosableIterable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/Entity.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/Entity.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/ExternalFileManifestContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/ExternalFileManifestContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/FilterResource.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/FilterResource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/InputStreamContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/InputStreamContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/JsonContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/JsonContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/RangeConsumesOutputStream.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/RangeConsumesOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/Resource.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/Resource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceWrapper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StringContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StringContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/TransactionalStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/TransactionalStorageService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/XMLContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/XMLContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FSPathContentPayload.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FSPathContentPayload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.fs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FSUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FSUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.fs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.fs;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/rsync/RsyncUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/rsync/RsyncUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.rsync;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSConfig.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSConfig.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 import org.roda.core.RodaCoreFactory;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRange.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRange.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 public record ScatteredFSRange (int beginIndex, int endIndex) {}

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRangeConfig.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRangeConfig.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 import org.roda.core.RodaCoreFactory;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRegexConfig.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSRegexConfig.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 import org.roda.core.RodaCoreFactory;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFSUtils.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 import org.apache.commons.io.FileUtils;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.core.storage.scatteredfs;
 
 import java.io.IOException;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/utils/RODAInstanceUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/utils/RODAInstanceUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/utils/StorageRecursiveListingUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/utils/StorageRecursiveListingUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.storage.utils;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/ConsolidatedOperation.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/ConsolidatedOperation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionException.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionManagerUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/RODATransactionManagerUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/StoragePathVersion.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/StoragePathVersion.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionCleanupTask.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionCleanupTask.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionContextFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionContextFactory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionLogConsolidator.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionLogConsolidator.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionLogService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionLogService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionModelRollbackHandler.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionModelRollbackHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalContext.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalContext.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalModelOperationRegistry.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalModelOperationRegistry.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.core.transaction;
 

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientGeneratedMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientGeneratedMessages.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package config.i18n.client;
 

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package config.i18n.client;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/CustomClassLoaderConfiguration.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/CustomClassLoaderConfiguration.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/RODA.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/RODA.java
@@ -2,8 +2,8 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
- * <p>
- * https://github.com/keeps/roda
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v1/utils/ApiOriginFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v1/utils/ApiOriginFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v1.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v1/utils/ApiResponseMessage.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v1/utils/ApiResponseMessage.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v1.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/config/OpenAPIConfig.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/config/OpenAPIConfig.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.config;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ClassificationPlanController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ClassificationPlanController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ClientLoggerController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ClientLoggerController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ConfigurationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ConfigurationController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalHoldController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalHoldController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalRuleController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalRuleController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalScheduleController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalScheduleController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DistributedInstancesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DistributedInstancesController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/Exportable.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/Exportable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ForumController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ForumController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MetricsController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MetricsController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RedactionController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RedactionController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RequestHandler.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RequestHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ThemesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ThemesController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.controller;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/RESTException.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/RESTException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.exceptions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/RestResponseEntityExceptionHandler.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/RestResponseEntityExceptionHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.exceptions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/model/ErrorResponseMessage.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/exceptions/model/ErrorResponseMessage.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.exceptions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AuditLogService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AuditLogService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ClassificationPlanService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ClassificationPlanService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ClientLoggerService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ClientLoggerService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ConfigurationsService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ConfigurationsService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DIPService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DIPService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DiskController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DiskController.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.api.v2.services;
 
 import java.util.Map;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalConfirmationService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalConfirmationService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalHoldService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalHoldService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalRuleService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalRuleService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalScheduleService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalScheduleService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DistributedInstanceService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DistributedInstanceService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/IndexService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/IndexService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MetricsService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MetricsService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/NotificationsService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/NotificationsService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/PreservationAgentService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/PreservationAgentService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/PreservationEventService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/PreservationEventService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RedactionService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RedactionService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RepresentationInformationService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RepresentationInformationService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RepresentationService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RepresentationService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RiskIncidenceService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RiskIncidenceService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RiskService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/RiskService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ThemeService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/ThemeService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/TransferredResourceService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/TransferredResourceService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/TranslationService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/TranslationService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/CSVOutputStream.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/CSVOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.stream;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/FacetsCSVOutputStream.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/FacetsCSVOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.stream;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/ResultsCSVOutputStream.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/stream/ResultsCSVOutputStream.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.stream;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/ApiUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/ApiUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/CommonServicesUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/CommonServicesUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/ExtraMediaType.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/ExtraMediaType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/MimeTypeUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/MimeTypeUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/RecaptchaUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/RecaptchaUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.api.v2.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseDIP.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseDIP.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseFile.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseFile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CreateDescriptiveMetadata.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CreateDescriptiveMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipFilePreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipFilePreview.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipUrlPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipUrlPreview.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DisseminationInfo.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DisseminationInfo.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditDescriptiveMetadata.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditDescriptiveMetadata.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissionsTab.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissionsTab.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/IndexedFilePreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/IndexedFilePreview.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/RepresentationInformationHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/RepresentationInformationHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/ShowPreservationEvent.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/ShowPreservationEvent.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/SliderEventListener.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/SliderEventListener.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/SourcesSliderEvents.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/SourcesSliderEvents.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/Viewers.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/Viewers.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/BinaryVersionBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/BinaryVersionBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/BrowseAIPBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/BrowseAIPBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/Bundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/Bundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataEditBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataEditBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataVersionsBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataVersionsBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataViewBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DescriptiveMetadataViewBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DisposalConfirmationExtraBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/DisposalConfirmationExtraBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/PreservationEventViewBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/PreservationEventViewBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/RepresentationInformationExtraBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/RepresentationInformationExtraBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/RepresentationInformationFilterBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/RepresentationInformationFilterBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/SupportedMetadataTypeBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/SupportedMetadataTypeBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/UserExtraBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/bundle/UserExtraBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.bundle;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseAIPTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseAIPTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseDIPTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseDIPTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseFileTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseFileTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseRepresentationTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseRepresentationTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseTransferredResourceTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseTransferredResourceTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/FileTechnicalMetadataTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/FileTechnicalMetadataTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/RepresentationDescriptiveMetadataTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/RepresentationDescriptiveMetadataTabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/Tabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/Tabs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.browse.tabs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BadgePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BadgePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseAIPActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseAIPActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseDIPActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseDIPActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseFileActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseFileActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseObjectActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseObjectActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseTransferredResourceActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseTransferredResourceActionsToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/DefaultMethodCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/DefaultMethodCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/DisposalPolicySummaryPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/DisposalPolicySummaryPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalAssociativeList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalAssociativeList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalFilterList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalFilterList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalRelationList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/IncrementalRelationList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/LastSelectedItemsSingleton.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/LastSelectedItemsSingleton.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/LoadingAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/LoadingAsyncCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NavigationToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NavigationToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NavigationToolbarLegacy.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NavigationToolbarLegacy.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NoAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/NoAsyncCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/PromiseAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/PromiseAsyncCallback.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.common;
 
 import elemental2.promise.Promise;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/PromiseWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/PromiseWrapper.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.common;
 
 import elemental2.promise.IThenable;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableAssociativeTextBox.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableAssociativeTextBox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableRelation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableRelation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableRepresentationInformationFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableRepresentationInformationFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableTextBox.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RemovableTextBox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RichTextToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/RichTextToolbar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/SubTitlePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/SubTitlePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/TitlePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/TitlePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UpSalePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UpSalePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLogin.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLogin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLoginService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLoginService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLoginServiceAsync.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/UserLoginServiceAsync.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ValuedLabel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ValuedLabel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ValuedTextBox.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/ValuedTextBox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AbstractActionable.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AbstractActionable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/Actionable.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/Actionable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/CanActResult.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/CanActResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalAssociationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalAssociationActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActionsUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActionsUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationReportActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationReportActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalCreateConfirmationDestroyActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalCreateConfirmationDestroyActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalCreateConfirmationReviewActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalCreateConfirmationReviewActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalHoldActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalHoldActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalRuleActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalRuleActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalScheduleActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalScheduleActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisseminationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisseminationActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisseminationFileActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisseminationFileActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileSearchWrapperActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/FileToolbarActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/JobActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/JobActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/PreservationAgentActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/PreservationAgentActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/PreservationEventActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/PreservationEventActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RODAMemberActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RODAMemberActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationInformationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationInformationActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationSearchWrapperActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationToolbarActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RiskActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RiskActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RiskIncidenceActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RiskIncidenceActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceSearchWrapperActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/TransferredResourceToolbarActions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionAsyncCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.callbacks;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionLoadingAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionLoadingAsyncCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.callbacks;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionNoAsyncCallback.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/callbacks/ActionNoAsyncCallback.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.callbacks;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableButton.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableButton.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableGroup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableGroup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableObject.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableObject.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableTitle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/model/ActionableTitle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionButton.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionButton.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.widgets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionableWidgetBuilder.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/widgets/ActionableWidgetBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.actions.widgets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPDisseminationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPDisseminationCardList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPRepresentationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPRepresentationCardList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/FileDisseminationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/FileDisseminationCardList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/RepresentationDisseminationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/RepresentationDisseminationCardList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCard.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCard.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCardList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/utils/CardBuilder.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/utils/CardBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.cards.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/AccessKeyDialogs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/AccessKeyDialogs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ClosableDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ClosableDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/DefaultSelectDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/DefaultSelectDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/Dialogs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/Dialogs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/DisposalDialogs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/DisposalDialogs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/EditMultipleRiskIncidenceDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/EditMultipleRiskIncidenceDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/MemberSelectDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/MemberSelectDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/RepresentationDialogs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/RepresentationDialogs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/RepresentationInformationDialogs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/RepresentationInformationDialogs.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectAipDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectAipDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectDialogFactory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectDialogFactory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectFileDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectFileDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectJobDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectJobDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectLogEntryDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectLogEntryDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectNotificationDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectNotificationDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectReportDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectReportDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRepresentationDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRepresentationDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRepresentationInformationDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRepresentationInformationDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRiskDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectRiskDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectTransferResourceDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/SelectTransferResourceDialog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/utils/DisposalHoldDialogResult.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/utils/DisposalHoldDialogResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/utils/DisposalScheduleDialogResult.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/utils/DisposalScheduleDialogResult.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.dialogs.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/Header.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/Header.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.labels;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/LabelWithIcon.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/LabelWithIcon.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.labels;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/Tag.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/labels/Tag.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.labels;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DIPFileList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DIPFileList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DIPList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DIPList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DisposalConfirmationList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/DisposalConfirmationList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/IngestJobReportList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/IngestJobReportList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/InternalLogEntryList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/InternalLogEntryList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/JobList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/JobList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/LogEntryList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/LogEntryList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/NotificationList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/NotificationList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/PreservationAgentList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/PreservationAgentList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/PreservationEventList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/PreservationEventList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RepresentationInformationList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RepresentationInformationList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RiskIncidenceList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RiskIncidenceList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RiskList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RiskList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RodaMemberList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/RodaMemberList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/SimpleJobReportList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/SimpleJobReportList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/SimpleRodaMemberList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/SimpleRodaMemberList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/TransferredResourceList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/TransferredResourceList.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionState.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionState.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.pagination;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionStateMappers.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionStateMappers.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.pagination;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/pagination/ListSelectionUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.pagination;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AccessibleHoverableCheckboxCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AccessibleHoverableCheckboxCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCellOptions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCellOptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/BasicTablePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/BasicTablePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ClientSelectedItemsUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ClientSelectedItemsUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ColumnOptions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ColumnOptions.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ConfigurableAsyncTableCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/IndexResultDataProvider.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/IndexResultDataProvider.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ListBuilder.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ListBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ListFactory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/ListFactory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/MyAsyncDataProvider.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/MyAsyncDataProvider.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RadioButtonCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RadioButtonCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RadioButtonColumn.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RadioButtonColumn.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RodaPageSizePager.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/RodaPageSizePager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/TooltipTextCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/TooltipTextCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/TooltipTextColumn.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/TooltipTextColumn.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.lists.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseAIPResponse.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseAIPResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseDIPResponse.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseDIPResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseFileResponse.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseFileResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseRepresentationResponse.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/BrowseRepresentationResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/CountRIResponse.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/model/CountRIResponse.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/popup/CalloutPopup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/popup/CalloutPopup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.popup;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/MyResources.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/MyResources.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.resources;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/AdvancedSearchFieldsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/AdvancedSearchFieldsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/CatalogueSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/CatalogueSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/Dropdown.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/Dropdown.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/RODASavedSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/RODASavedSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SavedSearchMapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SavedSearchMapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchField.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchField.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFilters.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFilters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchOptionsBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchOptionsBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggest.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggestBox.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggestBox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggestOracle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchSuggestOracle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SelectedPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SelectedPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/DisseminationsSliderHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/DisseminationsSliderHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.slider;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/InfoSliderHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/InfoSliderHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.slider;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/OptionsSliderHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/OptionsSliderHelper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.slider;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/SliderPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/SliderPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.slider;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/Sliders.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/Sliders.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.slider;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/AsyncCallbackUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/AsyncCallbackUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/CssFileInjector.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/CssFileInjector.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 /*
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/DisposalPolicySummary.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/DisposalPolicySummary.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/DisposalPolicyUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/DisposalPolicyUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FileFormatSharedUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FileFormatSharedUtils.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.common.utils;
 
 import java.util.Objects;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/IndexedDIPUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/IndexedDIPUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JobUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JobUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/ListboxUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/ListboxUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/PermissionClientUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/PermissionClientUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/PluginUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/PluginUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/SavedSearchUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/SavedSearchUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/ScriptModuleInjector.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/ScriptModuleInjector.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 /*
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/SidebarUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/SidebarUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/Tree.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/Tree.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/UploadListener.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/UploadListener.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/Disposal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/Disposal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalConfirmationPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalConfirmationPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.association;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalHoldsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalHoldsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.association;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalPolicyAssociationTab.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/DisposalPolicyAssociationTab.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.association;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/RetentionPeriodPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/RetentionPeriodPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.association;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/TransitiveDisposalHoldsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/TransitiveDisposalHoldsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.association;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.confirmations;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmationDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmationDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.confirmations;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/ShowDisposalConfirmation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/ShowDisposalConfirmation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.confirmations;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/CreateDisposalHold.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/CreateDisposalHold.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.hold;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/DisposalHoldDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/DisposalHoldDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.hold;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/EditDisposalHold.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/EditDisposalHold.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.hold;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/ShowDisposalHold.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/ShowDisposalHold.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.hold;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.policy;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicyHoldsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicyHoldsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.policy;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicyRulesPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicyRulesPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.policy;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicySchedulesPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicySchedulesPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.policy;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/ChildOfPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/ChildOfPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/CreateDisposalRule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/CreateDisposalRule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/DisposalRuleDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/DisposalRuleDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/EditDisposalRule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/EditDisposalRule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/MetadataFieldsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/MetadataFieldsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/ShowDisposalRule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/ShowDisposalRule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.rule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/CreateDisposalSchedule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/CreateDisposalSchedule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.schedule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/DisposalScheduleDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/DisposalScheduleDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.schedule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/DisposalScheduleUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/DisposalScheduleUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.schedule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/EditDisposalSchedule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/EditDisposalSchedule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.schedule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/ShowDisposalSchedule.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/schedule/ShowDisposalSchedule.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.disposal.schedule;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/Ingest.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/Ingest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/preingest/PreIngest.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/preingest/PreIngest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/CreateIngestJobBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/CreateIngestJobBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/JobBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/JobBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginOptionsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginOptionsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/ShowJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/ShowJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/ShowJobReport.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/ShowJobReport.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/DisseminationParameter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/DisseminationParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/PrintableParameter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/PrintableParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/RepresentationParameter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/model/RepresentationParameter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.process.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/DetailsPanelTransferredResource.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/DetailsPanelTransferredResource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.transfer;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/ShowTransferredResource.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/ShowTransferredResource.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.ingest.transfer;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/TransferUpload.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/TransferUpload.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbItem.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbItem.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.main;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.main;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ExpiredSessionDetector.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ExpiredSessionDetector.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.main;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Footer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Footer.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.main;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/GAnalyticsTracker.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/GAnalyticsTracker.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.main;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 /**
  *
  */

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Login.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Login.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Main.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Main.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Theme.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Theme.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 /**
  *
  */

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/AcknowledgeNotification.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/AcknowledgeNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateGroup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateGroup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUserPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUserPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditGroup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditGroup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditUser.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/GroupDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/GroupDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/GroupSelect.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/GroupSelect.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Management.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Management.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/NotificationRegister.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/NotificationRegister.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/PasswordPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/PasswordPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/PermissionsPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/PermissionsPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Profile.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Profile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/RecoverLogin.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/RecoverLogin.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ResetPassword.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ResetPassword.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/SetPassword.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/SetPassword.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowGroup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowGroup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowNotification.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowNotification.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowUser.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Statistics.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Statistics.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UpdatePasswordPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UpdatePasswordPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserAndGroupKeyDownHandler.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserAndGroupKeyDownHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserManagementService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserManagementService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserManagementServiceAsync.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserManagementServiceAsync.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/VerifyEmail.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/VerifyEmail.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/AccessKeyDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/AccessKeyDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.access;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/AccessKeyTablePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/AccessKeyTablePanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.access;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/CreateAccessKey.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/CreateAccessKey.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.access;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/ShowAccessKey.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/access/ShowAccessKey.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.access;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/CreateDistributedInstance.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/CreateDistributedInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/CreateLocalInstanceConfiguration.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/CreateLocalInstanceConfiguration.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/DistributedInstanceDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/DistributedInstanceDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/DistributedInstancesManagement.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/DistributedInstancesManagement.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/EditDistributedInstance.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/EditDistributedInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/EditLocalInstanceConfiguration.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/EditLocalInstanceConfiguration.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/LocalInstanceConfigurationDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/LocalInstanceConfigurationDataPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/LocalInstanceManagement.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/LocalInstanceManagement.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowDistributedInstance.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowDistributedInstance.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowLocalInstanceConfiguration.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowLocalInstanceConfiguration.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.distributed;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/Recaptcha.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/Recaptcha.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.recaptcha;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/RecaptchaException.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/RecaptchaException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.recaptcha;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/RecaptchaWidget.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/recaptcha/RecaptchaWidget.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.management.recaptcha;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/CreateRepresentationInformation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/CreateRepresentationInformation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/CreateRisk.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/CreateRisk.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelAIP.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelAIP.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 package org.roda.wui.client.planning;
 
 import java.util.Map;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelFile.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelFile.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRepresentationInformation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRepresentationInformation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRisk.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRisk.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRiskIncidence.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/EditRiskIncidence.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/Planning.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/Planning.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/PreservationAgents.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/PreservationAgents.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RelationTypeTranslationsBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RelationTypeTranslationsBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationAssociations.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationAssociations.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationDataPanel.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 package org.roda.wui.client.planning;
 
 import java.util.Collections;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationNetwork.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RepresentationInformationNetwork.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskDataPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskDataPanel.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 package org.roda.wui.client.planning;
 
 import java.util.Date;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskHistory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskHistory.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskIncidenceRegister.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskIncidenceRegister.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskRegister.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskRegister.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskShowPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskShowPanel.java
@@ -3,9 +3,8 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
-
 package org.roda.wui.client.planning;
 
 import org.roda.core.data.common.RodaConstants;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskVersionsBundle.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/RiskVersionsBundle.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.planning;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowPreservationAgent.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowPreservationAgent.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRisk.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRisk.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRiskIncidence.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRiskIncidence.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/BrowseAIPPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/BrowseAIPPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/MainPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/MainPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/SearchPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/SearchPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/SearchWithPreFiltersPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/SearchWithPreFiltersPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/UserLoginPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/UserLoginPortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/WelcomePortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/WelcomePortal.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateActionJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateActionJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateIngestJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateIngestJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/Process.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/Process.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactor.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.redact;
 
 import com.google.gwt.core.client.Callback;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorObject.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.redact;
 
 import com.google.gwt.dom.client.Element;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/redact/PDFRedactorPanel.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
 package org.roda.wui.client.redact;
 
 import com.google.gwt.core.client.GWT;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/JobSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/JobSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/NotificationSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/NotificationSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/PreservationEventsSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/PreservationEventsSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Relation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Relation.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/SavedSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/SavedSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/SearchWithPreFilters.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/SearchWithPreFilters.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/TransferredResourceSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/TransferredResourceSearch.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.search;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/AIPRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/AIPRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/AuditLogRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/AuditLogRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/CheckedFunction.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/CheckedFunction.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ClientLoggerRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ClientLoggerRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ConfigurationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ConfigurationRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DIPFileRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DIPFileRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DIPRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DIPRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalConfirmationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalConfirmationRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalHoldRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalHoldRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalRuleRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalRuleRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalScheduleRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalScheduleRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DistributedInstancesRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DistributedInstancesRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/FileRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/FileRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobReportRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobReportRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobsRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobsRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MembersRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MembersRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MethodCallThrowableTreatment.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MethodCallThrowableTreatment.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/NotificationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/NotificationRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/PreservationAgentRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/PreservationAgentRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/PreservationEventRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/PreservationEventRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RODADispatcher.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RODADispatcher.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RODAEntityRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RODAEntityRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RedactionRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RedactionRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RepresentationInformationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RepresentationInformationRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RepresentationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RepresentationRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RiskIncidenceRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RiskIncidenceRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RiskRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/RiskRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/Services.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/Services.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/TransferredResourceRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/TransferredResourceRestService.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.client.services;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/welcome/Help.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/welcome/Help.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/welcome/Welcome.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/welcome/Welcome.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/ControllerAssistant.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/ControllerAssistant.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/ControllerAssistantUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/ControllerAssistantUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/I18nUtility.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/I18nUtility.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/RequestControllerAssistant.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/RequestControllerAssistant.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/RodaWuiController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/RodaWuiController.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/BadHistoryTokenException.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/BadHistoryTokenException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/ClientLogger.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/ClientLogger.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/HistoryResolver.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/HistoryResolver.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/LoginStatusListener.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/LoginStatusListener.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/CachedAsynRequest.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/CachedAsynRequest.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ConfigurationManager.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ConfigurationManager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/DescriptionLevelUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/DescriptionLevelUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/HistoryUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/HistoryUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ListUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ListUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestErrorOverlayType.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestErrorOverlayType.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/StringUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/StringUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ValidationUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/ValidationUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.tools;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/HTMLWidgetWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/HTMLWidgetWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/LoadingPopup.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/LoadingPopup.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/MyCellTableResources.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/MyCellTableResources.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/Toast.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/Toast.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 /**
  *

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleCellTable.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleCellTable.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleFocusPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleFocusPanel.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleHeaderOrFooterBuilder.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleHeaderOrFooterBuilder.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleSimplePager.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleSimplePager.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleTextBox.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AccessibleTextBox.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AcessibleCheckboxCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AcessibleCheckboxCell.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AcessibleMenuBar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/AcessibleMenuBar.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/WCAGUtilities.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/widgets/wcag/WCAGUtilities.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.client.widgets.wcag;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/model/RequestContext.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/model/RequestContext.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/model/RequestHeaders.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/model/RequestHeaders.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.model;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/RodaStreamingOutput.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/RodaStreamingOutput.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.server;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.server;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/utils/RequestUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/utils/RequestUtils.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.common.utils;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/RodaConfig.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/RodaConfig.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.config;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/BasicAuthRequestWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/BasicAuthRequestWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/BearerAuthRequestWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/BearerAuthRequestWrapper.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/CasApiAuthFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/CasApiAuthFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/CasWebAuthFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/CasWebAuthFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/InternalApiAuthFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/InternalApiAuthFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/InternalWebAuthFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/InternalWebAuthFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/OnOffFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/OnOffFilter.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/SecurityHeadersFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/SecurityHeadersFilter.java
@@ -2,8 +2,8 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
- * <p>
- * https://github.com/keeps/roda
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.filter;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/security/SecurityObserverImpl.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/security/SecurityObserverImpl.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.security;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/ContextListener.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/ContextListener.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.servlets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/ErrorHandler.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/ErrorHandler.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.servlets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/RodaCoreInstantiationException.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/RodaCoreInstantiationException.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.servlets;
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/RodaWuiServlet.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/servlets/RodaWuiServlet.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE file at the root of the source
  * tree and available online at
  *
- * https://github.com/keeps/roda
+ * https://github.com/ETERNA-earkiv/ETERNA
  */
 package org.roda.wui.servlets;
 


### PR DESCRIPTION
Replace legacy upstream URL (github.com/keeps/roda) with the ETERNA project URL (github.com/ETERNA-earkiv/ETERNA) in all Java file headers. Add missing license headers to 19 files that had none.