### PR TITLE
refactor: lock UI to sv_SE and merge user menu into nav bar

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/common/Messages.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/Messages.java
@@ -117,10 +117,7 @@ public class Messages {
       if (baseName == null) {
         throw new NullPointerException();
       }
-      // 20160712 hsilva: the following line is needed otherwise default locale
-      // is used and this can be incoherent with other parts of the code where
-      // the default locale is ENGLISH
-      Locale defaultLocale = Locale.ENGLISH;
+      Locale defaultLocale = Locale.of("sv", "SE");
       return locale.equals(defaultLocale) ? null : defaultLocale;
     }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginMessagesControl.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginMessagesControl.java
@@ -24,10 +24,7 @@ public class PluginMessagesControl extends Control {
     if (baseName == null) {
       throw new NullPointerException();
     }
-    // 20160712 hsilva: the following line is needed otherwise default locale
-    // is used and this can be incoherent with other parts of the code where
-    // the default locale is ENGLISH
-    Locale defaultLocale = Locale.ENGLISH;
+    Locale defaultLocale = Locale.of("sv", "SE");
     return locale.equals(defaultLocale) ? null : defaultLocale;
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/RodaWUI.gwt.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/RodaWUI.gwt.xml
@@ -10,22 +10,8 @@
 	<source path="api" />
 
 	<!-- I18N -->
-	<extend-property name="locale" values="en" />
-	<!--
-	<extend-property name="locale" values="pt_PT" />
-	<extend-property name="locale" values="es" />
-	<extend-property name="locale" values="hr" />
-	<extend-property name="locale" values="hu" />
-	-->
 	<extend-property name="locale" values="sv_SE" />
-	<!--
-	<extend-property name="locale" values="de_AT" />
-	-->
-	<set-property-fallback name="locale" value="sv_SE" />
-
-	<!-- Locale -->
-	<set-configuration-property name="locale.useragent" value="Y" />
-	<set-configuration-property name="locale.searchorder" value="queryparam,cookie,meta,useragent" />
+	<set-property name="locale" value="sv_SE" />
 
 	<!-- GSS -->
 	<set-configuration-property name="CssResource.enableGss" value="true" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/RodaWUIPortal.gwt.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/RodaWUIPortal.gwt.xml
@@ -11,19 +11,8 @@
 	<source path="client" />
 
 	<!-- I18N -->
-	<extend-property name="locale" values="en" />
-	<!--
-	<extend-property name="locale" values="pt_PT" />
-	<extend-property name="locale" values="es" />
-	<extend-property name="locale" values="hr" />
-	<extend-property name="locale" values="hu" />
-	-->
 	<extend-property name="locale" values="sv_SE" />
-	<set-property-fallback name="locale" value="sv_SE" />
-
-	<!-- Locale -->
-	<set-configuration-property name="locale.useragent" value="Y" />
-	<set-configuration-property name="locale.searchorder" value="queryparam,cookie,meta,useragent" />
+	<set-property name="locale" value="sv_SE" />
 
 	<!-- GSS -->
 	<set-configuration-property name="CssResource.enableGss" value="true" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
@@ -133,6 +133,10 @@ public class Header extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
   }
 
+  public AcessibleMenuBar getNavigationMenu() {
+    return navigationMenu;
+  }
+
   public void init() {
     bannerLogo.add(new HTMLWidgetWrapper("Banner.html"));
     homeLinkArea.addClickHandler(event -> HistoryUtils.newHistory(Welcome.RESOLVER));

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Main.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Main.java
@@ -119,8 +119,8 @@ public class Main extends Composite implements EntryPoint {
     RootPanel.get().addStyleName("roda");
 
     // Initialize
-    userMenu.init();
     header.init();
+    userMenu.init(header.getNavigationMenu());
     contentPanel.init();
     onHistoryChanged(History.getToken());
     History.addValueChangeHandler(event -> onHistoryChanged(event.getValue()));

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.java
@@ -11,14 +11,11 @@
  */
 package org.roda.wui.client.main;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.roda.core.data.v2.user.User;
 import org.roda.wui.client.common.UserLogin;
-import org.roda.wui.client.common.utils.JavascriptUtils;
 import org.roda.wui.client.management.Profile;
 import org.roda.wui.client.management.Register;
 import org.roda.wui.common.client.ClientLogger;
@@ -27,11 +24,9 @@ import org.roda.wui.common.client.widgets.wcag.AcessibleMenuBar;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.MenuBar;
@@ -53,13 +48,8 @@ public class UserMenu extends Composite {
   interface MyUiBinder extends UiBinder<Widget, UserMenu> {
   }
 
-  @UiField
-  AcessibleMenuBar menu;
-
-  private AcessibleMenuBar userMenu;
-  private AcessibleMenuBar languagesMenu;
-
-  private String selectedLanguage;
+  private AcessibleMenuBar profileDropdown;
+  private final List<MenuItem> activeItems = new ArrayList<>();
 
   /**
    * User menu constructor
@@ -69,17 +59,13 @@ public class UserMenu extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
   }
 
-  public void init() {
-    userMenu = new AcessibleMenuBar(true);
-    userMenu.addStyleName("userMenuColors");
-    MenuItem profile = userMenu.addItem(messages.loginProfile(), createCommand(Profile.RESOLVER.getHistoryPath()));
+  public void init(AcessibleMenuBar navMenu) {
+    profileDropdown = new AcessibleMenuBar(true);
+    profileDropdown.addStyleName("userMenuColors");
+    MenuItem profile = profileDropdown.addItem(messages.loginProfile(), createCommand(Profile.RESOLVER.getHistoryPath()));
     profile.addStyleName("profile_user_item");
-    MenuItem login = userMenu.addItem(messages.loginLogout(), () -> UserLogin.getInstance().logout());
-    login.addStyleName("login_user_item");
-
-    languagesMenu = new AcessibleMenuBar(true);
-    languagesMenu.addStyleName("userMenuColors");
-    setLanguageMenu();
+    MenuItem logout = profileDropdown.addItem(messages.loginLogout(), () -> UserLogin.getInstance().logout());
+    logout.addStyleName("login_user_item");
 
     UserLogin.getInstance().getAuthenticatedUser(new AsyncCallback<User>() {
 
@@ -90,11 +76,11 @@ public class UserMenu extends Composite {
 
       @Override
       public void onSuccess(User user) {
-        updateVisibles(user);
+        updateVisibles(navMenu, user);
       }
     });
 
-    UserLogin.getInstance().addLoginStatusListener(this::updateVisibles);
+    UserLogin.getInstance().addLoginStatusListener(user -> updateVisibles(navMenu, user));
   }
 
   private ScheduledCommand createCommand(final List<String> path) {
@@ -105,38 +91,44 @@ public class UserMenu extends Composite {
     return () -> UserLogin.getInstance().login();
   }
 
-  private void updateVisibles(User user) {
-    menu.clearItems();
+  private void updateVisibles(AcessibleMenuBar navMenu, User user) {
+    for (MenuItem item : activeItems) {
+      navMenu.removeItem(item);
+    }
+    activeItems.clear();
 
-    // TODO make creating sync (not async)
-    // User
     if (user.isGuest()) {
       MenuItem loginItem = customMenuItem("fa fa-user", messages.loginLogin(), "navigationMenu-item-label", null,
         createLoginCommand());
       loginItem.addStyleName("user_menu_item");
-      menu.addItem(loginItem);
+      navMenu.addItem(loginItem);
+      activeItems.add(loginItem);
 
       MenuItem registerItem = customMenuItem("fa fa-user-plus", messages.loginRegister(),
         "navigationMenu-item-label navigationMenu-register", null, createCommand(Register.RESOLVER.getHistoryPath()));
       registerItem.addStyleName("user_menu_item_register");
-      menu.addItem(registerItem);
+      navMenu.addItem(registerItem);
+      activeItems.add(registerItem);
     } else {
-      MenuItem userItem = customMenuItem("fa fa-user", user.getName(), "navigationMenu-item-label", userMenu, null);
+      String name = user.getName();
+      String displayName = name.isEmpty() ? name
+        : Character.toUpperCase(name.charAt(0)) + name.substring(1);
+      SafeHtmlBuilder b = new SafeHtmlBuilder();
+      b.append(SafeHtmlUtils.fromSafeConstant("<i class='fa fa-user'></i>"));
+      b.appendEscaped(displayName);
+      MenuItem userItem = new MenuItem(b.toSafeHtml(), profileDropdown);
+      userItem.addStyleName("navigationMenu-item");
+      userItem.addStyleName("navigationMenu-item-label");
       userItem.addStyleName("user_menu_item");
-      menu.addItem(userItem);
+      navMenu.addItem(userItem);
+      activeItems.add(userItem);
     }
-
-    MenuItem languageMenuItem = customMenuItem("fa fa-globe", selectedLanguage, "navigationMenu-item-label", languagesMenu, null);
-    languageMenuItem.addStyleName("navigationMenu-item-language");
-    menu.addItem(languageMenuItem);
   }
 
   private MenuItem customMenuItem(String icon, String label, String styleNames, MenuBar subMenu,
     ScheduledCommand command) {
     SafeHtmlBuilder b = new SafeHtmlBuilder();
-    String iconHTML = "<i class='" + icon + "'></i>";
-
-    b.append(SafeHtmlUtils.fromSafeConstant(iconHTML));
+    b.append(SafeHtmlUtils.fromSafeConstant("<i class='" + icon + "'></i>"));
     if (label != null) {
       b.append(SafeHtmlUtils.fromSafeConstant(label));
     }
@@ -155,42 +147,4 @@ public class UserMenu extends Composite {
     return menuItem;
   }
 
-  private void setLanguageMenu() {
-    String locale = LocaleInfo.getCurrentLocale().getLocaleName();
-
-    // Getting supported languages and their display name
-    Map<String, String> supportedLanguages = new HashMap<>();
-
-    for (String localeName : LocaleInfo.getAvailableLocaleNames()) {
-      if (!"default".equals(localeName)) {
-        supportedLanguages.put(localeName, LocaleInfo.getLocaleNativeDisplayName(localeName));
-      }
-    }
-
-    languagesMenu.clearItems();
-
-    for (final Entry<String, String> entry : supportedLanguages.entrySet()) {
-      final String key = entry.getKey();
-      final String value = entry.getValue();
-
-      if (key.equals(locale)) {
-        SafeHtmlBuilder b = new SafeHtmlBuilder();
-        String iconHTML = "<i class='fa fa-check'></i>";
-
-        b.append(SafeHtmlUtils.fromSafeConstant(value));
-        b.append(SafeHtmlUtils.fromSafeConstant(iconHTML));
-
-        MenuItem languageMenuItem = new MenuItem(b.toSafeHtml());
-        languageMenuItem.addStyleName("navigationMenu-item-language-selected");
-        languageMenuItem.addStyleName("navigationMenu-item-language");
-        languagesMenu.addItem(languageMenuItem);
-        selectedLanguage = value;
-      } else {
-        MenuItem languageMenuItem = new MenuItem(SafeHtmlUtils.fromSafeConstant(value),
-          () -> JavascriptUtils.changeLocale(key));
-        languagesMenu.addItem(languageMenuItem);
-        languageMenuItem.addStyleName("navigationMenu-item-language");
-      }
-    }
-  }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/UserMenu.ui.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
-<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui"
-	xmlns:wcag="urn:import:org.roda.wui.common.client.widgets.wcag">
-
-	<g:FlowPanel styleName="userMenu userMenuColors">
-		<wcag:AcessibleMenuBar ui:field="menu" />
-	</g:FlowPanel>
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+    <g:FlowPanel />
 </ui:UiBinder>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
@@ -72,7 +72,7 @@ public class ServerTools {
         locale = Locale.of(localeArgs[0], localeArgs[1], localeArgs[2]);
       }
     } else {
-      locale = Locale.ENGLISH;
+      locale = Locale.of("sv", "SE");
     }
 
     return locale;

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -161,24 +161,24 @@ body .wui-toast {
 }
 
 /* === Fixed headers ===
-   body::before är 6px röd list (z-index:9999) — userMenu måste börja vid top:6px.
-   bannerHeader.top och contentPanel padding-top sätts dynamiskt av theme.js. */
-.userMenu {
-  position: fixed;
-  top: 6px;
-  left: 0;
-  right: 0;
-  z-index: 100;
-  background-color: #333;
-}
+   body::before är 6px röd list (z-index:9999).
+   bannerHeader.top sätts till 6px av theme.js.
+   contentPanel padding-top sätts dynamiskt av theme.js. */
 .bannerHeader {
   position: fixed !important;
   left: 0;
   right: 0;
   z-index: 99;
 }
-.main .bannerHeader {
-  top: 32px;
+/* Loginikon: 20px, mellanrum till etiketttext, vertikal justering */
+.bannerHeader .user_menu_item i.fa-user {
+  font-size: 12px;
+  margin-right: 6px;
+  vertical-align: middle;
+  line-height: 0px;
+}
+.bannerHeader td.gwt-MenuItem.user_menu_item {
+  vertical-align: middle;
 }
 
 /* Undvik oönskad fokus-ring på GWT:s menyradar
@@ -607,10 +607,13 @@ body .wui-toast {
 
 /* === ETERNA login (facelift 2026-04) === */
 
-/* Dölj headern när loginsidan visas (den har egen layout med ETERNA-logga) */
-.main:has(.eterna-login) .bannerHeader,
-.main:has(.eterna-login) .userMenu {
+/* Dölj headern när loginsidan visas — userMenu är inne i bannerHeader, räcker med en regel */
+.main:has(.eterna-login) .bannerHeader {
   display: none;
+}
+/* Nollställ padding-top som theme.js sätter dynamiskt — sätts innan GWT renderat login */
+.main:has(.eterna-login) .contentPanel {
+  padding-top: 0 !important;
 }
 
 .eterna-login {

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
@@ -1,37 +1,33 @@
-// === Fixed headers: place bannerHeader directly below userMenu ===
-// userMenu: top:6px in CSS (clears the 6px red stripe from body::before).
-// bannerHeader.top is set here once userMenu has a real rendered height.
+// === Fixed header ===
+// bannerHeader sits directly below the 6px red stripe (body::before).
+// contentPanel padding-top is set once bannerHeader height has stabilised.
 (function () {
     function applyFixedHeaders() {
-        const userMenu     = document.querySelector('.userMenu');
         const bannerHeader = document.querySelector('.bannerHeader');
         const contentPanel = document.querySelector('.contentPanel');
-        if (!userMenu || !bannerHeader || !contentPanel) return;
+        if (!bannerHeader || !contentPanel) return;
+
+        bannerHeader.style.top = '6px';
 
         let lastBottom = 0;
         function measure() {
-            const umBottom = Math.round(userMenu.getBoundingClientRect().bottom);
-            // Retry until the value is above the red-stripe height AND has stabilised
-            if (umBottom <= 6 || umBottom !== lastBottom) {
-                lastBottom = umBottom;
+            void bannerHeader.offsetHeight;
+            const bhBottom = Math.round(bannerHeader.getBoundingClientRect().bottom);
+            if (bhBottom <= 6 || bhBottom !== lastBottom) {
+                lastBottom = bhBottom;
                 setTimeout(measure, 50);
                 return;
             }
-            bannerHeader.style.top = umBottom + 'px';
-            void bannerHeader.offsetHeight;
-            const bhBottom = Math.round(bannerHeader.getBoundingClientRect().bottom);
             contentPanel.style.paddingTop = bhBottom + 'px';
         }
         measure();
     }
 
-    // Start polling as soon as elements appear in DOM
     const headerObserver = new MutationObserver(() => {
-        if (document.querySelector('.userMenu') &&
-            document.querySelector('.bannerHeader') &&
+        if (document.querySelector('.bannerHeader') &&
             document.querySelector('.contentPanel')) {
             headerObserver.disconnect();
-            setTimeout(applyFixedHeaders, 0); // defer past current mutation batch
+            setTimeout(applyFixedHeaders, 0);
         }
     });
 


### PR DESCRIPTION
Remove language switcher, fix default locale to Swedish (sv_SE) across Messages, PluginMessagesControl, ServerTools, and GWT module configs. Collapse standalone userMenu element into the navigation bar by passing the nav MenuBar reference into UserMenu.init(), eliminating the fixed userMenu CSS layer and simplifying theme.js header measurement logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Uppdateringar

* **Nya funktioner**
  * Navigeringsmenyn är nu åtkomlig från huvudkomponenten

* **Ändringar**
  * Standardspråk ändrat från engelska till svenska i hela applikationen
  * Användarmenyn har omstrukturerats för bättre integrering med huvudnavigationen
  * Språkväljaren har tagits bort från användarmenyn
  * Layoutjusteringar för sidhuvud och innehållspanel för bättre responsivitet

<!-- end of auto-generated comment: release notes by coderabbit.ai -->