### PR TITLE
fix: skroll i trädstruktur och innehåll separat (#337)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.ui.xml
@@ -7,7 +7,7 @@
 
 	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
-	<g:FlowPanel styleName="contentWithSidePanel">
+	<g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
 		<g:FlowPanel ui:field="catalogTreeContainer" />
 		<g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
 		<g:FocusPanel ui:field="keyboardFocus" addStyleNames="catalogTreeMainContent">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.ui.xml
@@ -6,7 +6,7 @@
 
 	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
-	<g:FlowPanel styleName="contentWithSidePanel">
+	<g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
 		<g:FlowPanel ui:field="catalogTreeContainer" />
 		<g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
 		<g:FocusPanel addStyleNames="catalogTreeMainContent">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3477,12 +3477,34 @@ body.catalogTreeResizing * {
     overflow: hidden;
 }
 
+/* #337: Trädpanel ska stå still medan höger sida skrollar för sig.
+   Begränsar layoutens höjd till viewport (minus sticky bannerHeader 64px),
+   så att .catalogTreePanel (intern scroll i .catalogTreeBodyScroll) håller
+   sin position och .catalogTreeMainContent kan ha egen y-scroll. */
+.catalogTreeLayout {
+    height: calc(100vh - 64px);
+    min-height: 0 !important;
+    overflow: hidden;
+}
+
+.catalogTreeLayout .catalogTreeMainContent {
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
 @media (max-width: 900px) {
     .catalogTreePanel {
         display: none;
     }
     .catalogTreeResizeHandle {
         display: none;
+    }
+    .catalogTreeLayout {
+        height: auto;
+        overflow: visible;
+    }
+    .catalogTreeLayout .catalogTreeMainContent {
+        overflow: visible;
     }
 }
 


### PR DESCRIPTION
## Summary
- Sidans dokument-scroll skrollade både katalogträdet och innehållet ihop. Trädet ska stå still medan höger sida skrollar för sig.
- Ny scope-klass `.catalogTreeLayout` på root-`FlowPanel` i `BrowseAIP.ui.xml` och `BrowseTop.ui.xml`.
- CSS i `main.gss`: `height: calc(100vh - 64px)` (kompenserar för sticky `.bannerHeader`), `min-height: 0 !important` (override `.contentWithSidePanel`), `overflow: hidden`. `.catalogTreeMainContent` får `overflow-y: auto`. Media-query `@media (max-width: 900px)` återställer normalt page-scroll på smala skärmar (där `.catalogTreePanel` redan är dolt).

**Risk:** hårdkodat 64px-offset spårar `.bannerHeader { height: 64px }` på rad 2492 i samma fil. Om bannerHeader-höjden ändras i framtiden måste offsetten i `.catalogTreeLayout` uppdateras — kommentar finns i `main.gss` ovanför regeln.

Inga DB-/Solr-/API-ändringar. Inga nya beroenden. Endast CSS + UI XML.

Closes #337

## Test plan
- [x] `mvn -pl roda-ui/roda-wui -am install -DskipTests` — exit 0
- [x] `mvn -pl roda-ui/roda-wui -am gwt:compile -Pdebug-main` + `copy_gwt_rpc.sh` — exit 0
- [x] Spring Boot startar och svarar HTTP 200 på `/`
- [x] Manuellt testat på `BrowseAIP`-vy (öppnad AIP) — träd står still, höger sida skrollar för sig
- [x] Manuellt testat på `BrowseTop`-vy (katalogroten / Alla samlingar)
- [x] Manuellt testat på smal skärm (under 900px) — normalt page-scroll


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Stil**
  * Förbättrad katalogträdlayout på AIP- och toppbrowsesidorna med justerad höjdkontroll relativt sidhuvudet och optimerat scrollbeteende för katalogträdets innehål.
  * Responsiv designuppdatering för småskärmiga enheter (≤900px) med förbättrad layout- och scrollhantering för att säkerställa optimal användbarheten på mobila enheter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->