### PR TITLE
feat: add query routing from welcome search to catalogue

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/CatalogueSearch.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/CatalogueSearch.java
@@ -144,6 +144,10 @@ public class CatalogueSearch extends Composite {
     searchWrapper.refreshCurrentList();
   }
 
+  public void setQuery(String query) {
+    searchWrapper.setQuery(query);
+  }
+
   private boolean calculateRedirectOnSingleResult(List<String> historyTokens, Map<String, Filter> classFilters,
     boolean redirectOnSingleResult) {
     if (historyTokens.get(0).startsWith("$")) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPanel.java
@@ -233,6 +233,11 @@ public class SearchPanel<T extends IsIndexed> extends Composite implements HasVa
     searchInputBox.setText("");
   }
 
+  public void setQuery(String query) {
+    searchInputBox.setText(query == null ? "" : query);
+    doSearch();
+  }
+
   @UiHandler("searchAdvancedFieldOptionsAdd")
   void handleSearchAdvancedAdd(ClickEvent e) {
     advancedSearchFieldsPanel.addSearchFieldPanel();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchWrapper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchWrapper.java
@@ -161,6 +161,18 @@ public class SearchWrapper extends Composite {
     return searchPanelSelectionDropdown.setSelectedValue(objectClassSimpleName, true);
   }
 
+  public void setQuery(String query) {
+    String currentClass = searchPanelSelectionDropdown != null
+      ? searchPanelSelectionDropdown.getSelectedValue()
+      : listClassForSingleSearchPanel;
+    if (currentClass != null) {
+      SearchPanel<?> searchPanel = components.getSearchPanel(currentClass);
+      if (searchPanel != null) {
+        searchPanel.setQuery(query);
+      }
+    }
+  }
+
   public void refreshAllLists() {
     components.forEachList(list -> list.refresh());
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
@@ -33,6 +33,8 @@ import com.google.gwt.user.client.ui.Widget;
  */
 public class Search extends Composite {
 
+  private static final String QUERY_HANDLER = "q";
+
   public static final HistoryResolver RESOLVER = new HistoryResolver() {
 
     @Override
@@ -43,6 +45,9 @@ public class Search extends Composite {
           SavedSearch.resolveToNewInstance(historyTokens, callback);
         } else if (RodaConstants.SEARCH_WITH_PREFILTER_HANDLER.equals(searchType)) {
           SearchWithPreFilters.resolveToNewInstance(historyTokens, callback);
+        } else if (QUERY_HANDLER.equals(searchType)) {
+          String query = historyTokens.get(1);
+          getInstance().resolveWithQuery(query, callback);
         } else {
           getInstance().resolve(callback);
         }
@@ -97,6 +102,11 @@ public class Search extends Composite {
   }
 
   public void resolve(AsyncCallback<Widget> callback) {
+    callback.onSuccess(this);
+  }
+
+  public void resolveWithQuery(String query, AsyncCallback<Widget> callback) {
+    catalogueSearch.setQuery(query);
     callback.onSuccess(this);
   }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/WelcomeHero.html
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/WelcomeHero.html
@@ -3,14 +3,6 @@
   <h1 class="eterna-welcome__greeting">Welcome to ETERNA</h1>
 
   <div class="eterna-welcome__search" role="search">
-    <div class="eterna-welcome__search-scope">
-      <label for="eterna-welcome-scope-en">In the archive</label>
-      <select id="eterna-welcome-scope-en" aria-label="Search scope">
-        <option value="all">All</option>
-        <option value="catalogue">Catalogue</option>
-        <option value="deliveries">Deliveries</option>
-      </select>
-    </div>
     <input class="eterna-welcome__search-input" type="search" id="eterna-welcome-q-en"
            placeholder="Search the archive…" aria-label="Search" autocomplete="off" />
     <a class="btn-eterna-primary" href="#search" id="eterna-welcome-submit-en">Search</a>

--- a/roda-ui/roda-wui/src/main/resources/config/theme/WelcomeHero_sv_SE.html
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/WelcomeHero_sv_SE.html
@@ -3,14 +3,6 @@
   <h1 class="eterna-welcome__greeting">Välkommen till ETERNA</h1>
 
   <div class="eterna-welcome__search" role="search">
-    <div class="eterna-welcome__search-scope">
-      <label for="eterna-welcome-scope">I arkivet</label>
-      <select id="eterna-welcome-scope" aria-label="Sökområde">
-        <option value="all">Allt</option>
-        <option value="catalogue">Katalog</option>
-        <option value="deliveries">Leveranser</option>
-      </select>
-    </div>
     <input class="eterna-welcome__search-input" type="search" id="eterna-welcome-q"
            placeholder="Sök i arkivet…" aria-label="Sök" autocomplete="off" />
     <a class="btn-eterna-primary" href="#search" id="eterna-welcome-submit">Sök</a>

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
@@ -157,9 +157,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     filter: {
-                        parameters: [{ type: 'BasicSearchFilterParameter', name: '*', value: q }]
+                        parameters: [{ type: 'BasicSearchFilterParameter', name: 'search', value: q }]
                     },
-                    sublist: { firstElementIndex: 0, maximumElementCount: 7 }
+                    onlyActive: true,
+                    sublist: { firstElementIndex: 0, maximumElementCount: 6 }
                 })
             })
             .then(r => r.ok ? r.json() : null)
@@ -183,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 html += '</ul>';
                 const total = data.totalCount || data.total || objects.length;
                 if (total > objects.length) {
-                    html += '<a class="eterna-welcome__results-more" href="#search?query='
+                    html += '<a class="eterna-welcome__results-more" href="#search/q/'
                         + encodeURIComponent(q) + '">'
                         + (isSv ? 'Visa alla ' + total + ' tr\u00e4ffar \u2192' : 'Show all ' + total + ' results \u2192')
                         + '</a>';


### PR DESCRIPTION
<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Förbättringar av välkomstsidans sökning</h2><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Sammanfattning</h3><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Frånkopplad inline-sökning på välkomstsidan</strong><span> </span>— sökformuläret i hero-sektionen är borttaget. Sökning körs nu direkt i katalogen via GWT-routing.</li><li><strong>Query-routing till katalogen</strong><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">#search/q/&lt;term&gt;</code><span> </span>dirigerar nu söktermen direkt in i<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CatalogueSearch</code>, så användaren landar i det riktiga sökvyläget med förfyllt sökfält.</li><li><strong>Sökkvalitet</strong><span> </span>— filtret byts från wildcard (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">*</code>) till<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">search</code><span> </span>(fulltextsökning),<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onlyActive: true</code><span> </span>läggs till, och antalet förhandsresultat sänks från 7 till 6.</li><li><strong>Förenklat header-layout</strong><span> </span>— användarmeny slås ihop med navigeringsfältet. Det separata<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">userMenu</code>-elementet tas bort, CSS-lagret förenklas och header-mätlogiken i<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">theme.js</code><span> </span>rensas.</li><li><strong>Låst locale till sv_SE</strong><span> </span>— språkväxlaren tas bort. Svenska sätts som standardspråk i<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Messages</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PluginMessagesControl</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ServerTools</code><span> </span>och GWT-modulkonfigurationen.</li></ul><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Berörda filer</h3>
Fil | Förändring
-- | --
CatalogueSearch.java | Ny setQuery()-metod
SearchWrapper.java | Ny setQuery() som delegerar till aktiv SearchPanel
SearchPanel.java | Exponerar setQuery()
Search.java | Ny resolveWithQuery() + q-handler i history-tokens
WelcomeHero.html / _sv_SE.html | Tar bort inline-sökformuläret
theme.js | Bättre sökfilter, färre förhandsresultat (6), #search/q/-länk
UserMenu.java / Header.java | Sammanfogar användarmeny med nav
theme.css | Städar bort userMenu-specifik CSS
Messages.java / ServerTools.java / *.gwt.xml | Fixar defaultlokalen till sv_SE

<h3 style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testplan</h3><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Sök från välkomstsidan → resultatlistan visar max 6 träffar</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Klicka "Visa alla X träffar" → landar på söksidan med termen förfylld</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Navigera direkt till<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">#search/q/nyckelord</code><span> </span>→ sökfältet är ifyllt</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Verifiera att användarmeny syns korrekt i navigeringsfältet</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Verifiera att gränssnittet presenteras på svenska efter inloggning</li></ul>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Viktiga uppdateringar

* **Nya funktioner**
  * Förbättrad sökfunktionalitet för frågestyrning.

* **Förbättringar**
  * Förenklat välkomstsökgränssnitt genom borttagning av omfattningsväljare.
  * Uppdaterad sökfiltrering för att prioritera aktiva objekt.
  * Minskad maximal visning av sökresultat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->