### PR TITLE
i18n: svenska översättningar för konverteringspluginens parameterpanel

### DIFF
--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2633,6 +2633,14 @@ public interface ClientMessages extends Messages {
 
   String conversionProfileDescription();
 
+  String conversionOutcomeLabel();
+
+  String conversionOutcomeDescription();
+
+  String outcomeTypeRepresentation();
+
+  String outcomeTypeDissemination();
+
   /* Audit logs */
   String relatedAuditLogs();
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
@@ -159,13 +159,13 @@ public class PluginParameterPanel extends Composite {
 
   private void createConversionLayout() {
     conversionPanel = true;
-    Label parameterName = new Label(parameter.getName());
+    Label parameterName = new Label(messages.conversionOutcomeLabel());
     final ListBox dropdown = new ListBox();
     dropdown.addStyleName(FORM_SELECTBOX);
     dropdown.addStyleName(FORM_TEXTBOX_SMALL);
 
-    dropdown.addItem("Representation", ConversionProfileOutcomeType.REPRESENTATION.toString());
-    dropdown.addItem("Dissemination", ConversionProfileOutcomeType.DISSEMINATION.toString());
+    dropdown.addItem(messages.outcomeTypeRepresentation(), ConversionProfileOutcomeType.REPRESENTATION.toString());
+    dropdown.addItem(messages.outcomeTypeDissemination(), ConversionProfileOutcomeType.DISSEMINATION.toString());
 
     value = dropdown.getSelectedValue();
     FlowPanel innerPanel = new FlowPanel();
@@ -213,7 +213,7 @@ public class PluginParameterPanel extends Composite {
 
     dropdown.setTitle(OBJECT_BOX);
     layout.add(parameterName);
-    addHelp();
+    addHelp(layout, messages.conversionOutcomeDescription());
     layout.add(dropdown);
     layout.add(innerPanel);
   }

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1819,6 +1819,10 @@ changeRepresentationStatusToPreservationTitle: Change the representation status 
 changeRepresentationStatusToPreservationDescription:
 conversionProfileTitle: Conversion Profile
 conversionProfileDescription: Conversion profile options
+conversionOutcomeLabel: Outcome
+conversionOutcomeDescription: A conversion can create a representation or a dissemination. Please choose which option to output
+outcomeTypeRepresentation: Representation
+outcomeTypeDissemination: Dissemination
 # Action permission reasons
 reasonAffectedAIPUnderAppraisal: One or more affected AIPs are still under appraisal
 reasonAIPUnderAppraisal: One or more affected AIPs are still under appraisal

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1771,4 +1771,21 @@ catalogTreeTitle: Katalog
 catalogTreeFilterPlaceholder: Filtrera...
 catalogTreeLoadingLabel: Laddar...
 catalogTreeLoadError: Kunde inte hämta innehåll
+# Conversion plugin
+representationTypeTitle: Representationstyp
+representationTypeDescription: Tilldela en typ när en ny representation skapas
+changeRepresentationStatusToPreservationTitle: Ändra representationsstatus till bevaranderepresentation?
+changeRepresentationStatusToPreservationDescription:
+disseminationTitle: Spridningstitel
+disseminationTitleDescription: Titeln som den skapade spridningen får.
+disseminationDescriptionTitle: Spridningsbeskrivning
+disseminationDescriptionDescription: Beskrivningen som den skapade spridningen får.
+disseminationTitleDefaultValue: Spridningstitel
+disseminationDescriptionDefaultValue: Spridningsbeskrivning
+conversionProfileTitle: Konverteringsprofil
+conversionProfileDescription: Alternativ för konverteringsprofil
+conversionOutcomeLabel: Utfall
+conversionOutcomeDescription: En konvertering kan skapa en representation eller en spridning. Välj vilket alternativ som ska utgöra resultatet.
+outcomeTypeRepresentation: Representation
+outcomeTypeDissemination: Spridning
 catalogTreeRetry: Försök igen


### PR DESCRIPTION
## Sammanfattning

- Ersätter hårdkodade engelska strängar (`"Representation"`, `"Dissemination"`, `"Outcome"` m.fl.) i `PluginParameterPanel.java` med i18n-anrop
- Lägger till 4 nya metoder i `ClientMessages.java` (`conversionOutcomeLabel`, `conversionOutcomeDescription`, `outcomeTypeRepresentation`, `outcomeTypeDissemination`)
- Lägger till engelska standardvärden i `ClientMessages.properties`
- Lägger till svenska översättningar i `ClientMessages_sv_SE.properties` för alla saknade nycklar i konverteringsvyn

## Testplan

- [ ] Öppna "Ny process" och välj ett konverteringsplugin (t.ex. Bildkonverterare)
- [ ] Verifiera att "Utfall", "Konverteringsprofil", "Representationstyp" och "Ändra representationsstatus till bevaranderepresentation?" visas på svenska
- [ ] Verifiera att dropdown-alternativen "Representation" och "Spridning" visas korrekt