### PR TITLE
feat: info icon toggle for browse page description

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
@@ -158,6 +158,7 @@ public class BrowseTop extends Composite {
     Anchor infoIcon = new Anchor();
     infoIcon.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIcon.addStyleName("description-toggle-icon");
+    infoIcon.setTitle("Klicka för att fälla ut hjälpen");
     infoIcon.addClickHandler(event -> browseDescription.setVisible(!browseDescription.isVisible()));
     title.add(infoIcon);
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
@@ -26,19 +26,18 @@ import org.roda.wui.client.common.lists.utils.ListBuilder;
 import org.roda.wui.client.common.search.SearchWrapper;
 import org.roda.wui.client.ingest.transfer.TransferUpload;
 import org.roda.wui.common.client.HistoryResolver;
-import org.roda.wui.common.client.tools.DescriptionLevelUtils;
 import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.widgets.HTMLWidgetWrapper;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -154,6 +153,13 @@ public class BrowseTop extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
 
     browseDescription.add(new HTMLWidgetWrapper("BrowseDescription.html"));
+    browseDescription.setVisible(false);
+
+    Anchor infoIcon = new Anchor();
+    infoIcon.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIcon.addStyleName("description-toggle-icon");
+    infoIcon.addClickHandler(event -> browseDescription.setVisible(!browseDescription.isVisible()));
+    title.add(infoIcon);
 
     initTreeResize();
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
@@ -76,6 +76,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import com.google.gwt.user.client.ui.Anchor;
 
 public class EditPermissions extends Composite {
 
@@ -106,6 +107,12 @@ public class EditPermissions extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
     buttonApplyToAll.setVisible(IndexedAIP.class.getName().equals(objectClass));
     editPermissionsDescription.add(new HTMLWidgetWrapper("EditMultiplePermissionsDescription.html"));
+    editPermissionsDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> editPermissionsDescription.setVisible(!editPermissionsDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public EditPermissions(String objectClass, HasPermissions object) {
@@ -126,6 +133,12 @@ public class EditPermissions extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
     buttonApplyToAll.setVisible(IndexedAIP.class.getName().equals(objectClass));
     editPermissionsDescription.add(new HTMLWidgetWrapper("EditPermissionsDescription.html"));
+    editPermissionsDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> editPermissionsDescription.setVisible(!editPermissionsDescription.isVisible()));
+    title.add(infoIconTitle);
     createPermissionPanelList();
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditPermissions.java
@@ -111,6 +111,7 @@ public class EditPermissions extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> editPermissionsDescription.setVisible(!editPermissionsDescription.isVisible()));
     title.add(infoIconTitle);
   }
@@ -137,6 +138,7 @@ public class EditPermissions extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> editPermissionsDescription.setVisible(!editPermissionsDescription.isVisible()));
     title.add(infoIconTitle);
     createPermissionPanelList();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
@@ -54,6 +54,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -122,6 +124,8 @@ public class PreservationEvents extends Composite {
   @UiField
   FlowPanel pageDescription;
   @UiField
+  TitlePanel title;
+  @UiField
   NavigationToolbarLegacy navigationToolbar;
   private String aipId;
   private String representationUUID;
@@ -161,6 +165,12 @@ public class PreservationEvents extends Composite {
     }
 
     pageDescription.add(new HTMLWidgetWrapper("PreservationEventsDescription.html"));
+    pageDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> pageDescription.setVisible(!pageDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   /**

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.java
@@ -169,6 +169,7 @@ public class PreservationEvents extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> pageDescription.setVisible(!pageDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/PreservationEvents.ui.xml
@@ -11,7 +11,7 @@
 			visible="false" />
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.preservationEventsTitle}" iconClass="IndexedPreservationEvent" />
+				<common:TitlePanel text="{messages.preservationEventsTitle}" iconClass="IndexedPreservationEvent" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="pageDescription" />
 				<search:PreservationEventsSearch ui:field="eventsSearch" addStyleNames="searchResults" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
@@ -89,6 +89,7 @@ public class DisposalConfirmations extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> disposalConfirmationDescription.setVisible(!disposalConfirmationDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.java
@@ -31,6 +31,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Miguel Guimarães <mguimaraes@keep.pt>
@@ -63,6 +65,8 @@ public class DisposalConfirmations extends Composite {
   private static DisposalConfirmations.MyUiBinder uiBinder = GWT.create(DisposalConfirmations.MyUiBinder.class);
   @UiField
   FlowPanel disposalConfirmationDescription;
+  @UiField
+  TitlePanel title;
   @UiField(provided = true)
   SearchWrapper searchWrapper;
 
@@ -81,6 +85,12 @@ public class DisposalConfirmations extends Composite {
     searchWrapper = new SearchWrapper(false).createListAndSearchPanel(disposalConfirmationListBuilder);
     initWidget(uiBinder.createAndBindUi(this));
     disposalConfirmationDescription.add(new HTMLWidgetWrapper("DisposalConfirmationDescription.html"));
+    disposalConfirmationDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> disposalConfirmationDescription.setVisible(!disposalConfirmationDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   /**

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-disposal-confirmation" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="content" ui:field="contentFlowPanel">
-				<common:TitlePanel text="{messages.disposalConfirmationsTitle}" iconClass="DisposalConfirmations" />
+				<common:TitlePanel text="{messages.disposalConfirmationsTitle}" iconClass="DisposalConfirmations" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="disposalConfirmationDescription" />
 				<commonsearch:SearchWrapper ui:field="searchWrapper" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
@@ -99,6 +99,7 @@ public class DisposalDestroyedRecords extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> disposalDestroyedRecordsDescription.setVisible(!disposalDestroyedRecordsDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.java
@@ -32,6 +32,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
@@ -70,6 +72,8 @@ public class DisposalDestroyedRecords extends Composite {
 
   @UiField
   FlowPanel disposalDestroyedRecordsDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   SearchWrapper disposalDestroyedRecordsSearch;
@@ -91,6 +95,12 @@ public class DisposalDestroyedRecords extends Composite {
 
     initWidget(uiBinder.createAndBindUi(this));
     disposalDestroyedRecordsDescription.add(new HTMLWidgetWrapper("DisposalDestroyedRecordsDescription.html"));
+    disposalDestroyedRecordsDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> disposalDestroyedRecordsDescription.setVisible(!disposalDestroyedRecordsDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   /**

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalDestroyedRecords.ui.xml
@@ -7,7 +7,7 @@
 	<g:FlowPanel styleName="wui-disposal-destroyed-records" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content" ui:field="content">
-				<common:TitlePanel text="{messages.disposalDestroyedRecordsTitle}" iconClass="DisposalDestroyedRecords" />
+				<common:TitlePanel text="{messages.disposalDestroyedRecordsTitle}" iconClass="DisposalDestroyedRecords" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="disposalDestroyedRecordsDescription">
 				</g:FlowPanel>
 				<commonsearch:SearchWrapper ui:field="disposalDestroyedRecordsSearch" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
@@ -45,6 +45,8 @@ import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Miguel Guimarães <mguimaraes@keep.pt>
@@ -101,6 +103,8 @@ public class CreateDisposalConfirmation extends Composite {
 
   @UiField
   FlowPanel createDisposalConfirmationDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField
   RadioButton destroyScheduleOpt;
@@ -138,6 +142,12 @@ public class CreateDisposalConfirmation extends Composite {
     configureDisposalAction();
 
     createDisposalConfirmationDescription.add(new HTMLWidgetWrapper("CreateDisposalConfirmationDescription.html"));
+    createDisposalConfirmationDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> createDisposalConfirmationDescription.setVisible(!createDisposalConfirmationDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public static CreateDisposalConfirmation getInstance() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.java
@@ -146,6 +146,7 @@ public class CreateDisposalConfirmation extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> createDisposalConfirmationDescription.setVisible(!createDisposalConfirmationDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/confirmations/CreateDisposalConfirmation.ui.xml
@@ -8,7 +8,7 @@
 
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content" ui:field="content">
-				<common:TitlePanel text="{messages.createDisposalConfirmationTitle}" iconClass="DisposalConfirmations" />
+				<common:TitlePanel text="{messages.createDisposalConfirmationTitle}" iconClass="DisposalConfirmations" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="createDisposalConfirmationDescription" />
 				<g:FlowPanel addStyleNames="disposal-confirmation-select">
 					<g:RadioButton name="disposalAction" ui:field="destroyScheduleOpt" checked="true" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
@@ -43,6 +43,8 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
@@ -94,6 +96,8 @@ public class DisposalPolicy extends Composite {
 
   @UiField
   FlowPanel disposalPolicyDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField
   FlowPanel contentFlowPanel;
@@ -265,6 +269,12 @@ public class DisposalPolicy extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
     initSidebar();
     disposalPolicyDescription.add(new HTMLWidgetWrapper("DisposalPolicyDescription.html"));
+    disposalPolicyDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> disposalPolicyDescription.setVisible(!disposalPolicyDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public void resolve(List<String> historyTokens, AsyncCallback<Widget> callback) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.java
@@ -273,6 +273,7 @@ public class DisposalPolicy extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> disposalPolicyDescription.setVisible(!disposalPolicyDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/policy/DisposalPolicy.ui.xml
@@ -7,7 +7,7 @@
 	<g:FlowPanel styleName="wui-disposal-policy" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel ui:field="contentFlowPanel" addStyleNames="col_10 content">
-				<common:TitlePanel text="{messages.disposalPolicyTitle}" iconClass="DisposalPolicy" />
+				<common:TitlePanel text="{messages.disposalPolicyTitle}" iconClass="DisposalPolicy" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="disposalPolicyDescription" />
 				<g:FlowPanel ui:field="disposalSchedulesDescription" />
 				<u:DisposalPolicySchedulesPanel ui:field="disposalPolicySchedulesPanel" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
@@ -208,6 +208,7 @@ public class OrderDisposalRules extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> orderDisposalRulesDescription.setVisible(!orderDisposalRulesDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
@@ -46,6 +46,8 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
@@ -87,6 +89,8 @@ public class OrderDisposalRules extends Composite {
   private final DisposalRules disposalRules;
   @UiField
   FlowPanel orderDisposalRulesDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField
   FlowPanel orderDisposalRulesTablePanel;
@@ -200,6 +204,12 @@ public class OrderDisposalRules extends Composite {
 
   private void createDescription() {
     orderDisposalRulesDescription.add(new HTMLWidgetWrapper("OrderDisposalRulesDescription.html"));
+    orderDisposalRulesDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> orderDisposalRulesDescription.setVisible(!orderDisposalRulesDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   private void createDisposalRulesPanel() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.ui.xml
@@ -9,7 +9,7 @@
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_10" ui:field="content">
 				<g:FlowPanel addStyleNames="content">
-					<common:TitlePanel text="{messages.disposalRulesTitle}" iconClass="DisposalRule" />
+					<common:TitlePanel text="{messages.disposalRulesTitle}" iconClass="DisposalRule" ui:field="title" />
 					<g:FlowPanel addStyleNames="page-description" ui:field="orderDisposalRulesDescription" />
 					<g:FlowPanel addStyleNames="row full_width skip_padding">
 						<g:FlowPanel ui:field="orderDisposalRulesTablePanel">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
@@ -140,6 +140,7 @@ public class IngestAppraisal extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> ingestAppraisalDescription.setVisible(!ingestAppraisalDescription.isVisible()));
     title.add(infoIconTitle);
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.java
@@ -43,6 +43,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -87,6 +89,8 @@ public class IngestAppraisal extends Composite {
 
   @UiField
   FlowPanel ingestAppraisalDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   SearchWrapper searchWrapper;
@@ -132,6 +136,12 @@ public class IngestAppraisal extends Composite {
 
     initWidget(uiBinder.createAndBindUi(this));
     ingestAppraisalDescription.add(new HTMLWidgetWrapper("IngestAppraisalDescription.html"));
+    ingestAppraisalDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> ingestAppraisalDescription.setVisible(!ingestAppraisalDescription.isVisible()));
+    title.add(infoIconTitle);
 
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/appraisal/IngestAppraisal.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="ingestAppraisal" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.ingestAppraisalTitle}" icon="fas fa-clipboard-check" />
+				<common:TitlePanel text="{messages.ingestAppraisalTitle}" icon="fas fa-clipboard-check" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="ingestAppraisalDescription">
 				</g:FlowPanel>
 				<commonsearch:SearchWrapper ui:field="searchWrapper" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
@@ -53,6 +53,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria <lfaria@keep.pt>
@@ -188,6 +189,11 @@ public class IngestTransfer extends Composite {
     objectToolbar.setObjectAndBuild(resource, null, null);
 
     ingestTransferDescription.add(new HTMLWidgetWrapper("IngestTransferDescription.html"));
+    Anchor infoIconIngesttransfertitle = new Anchor();
+    infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
+    infoIconIngesttransfertitle.addClickHandler(event -> ingestTransferDescription.setVisible(!ingestTransferDescription.isVisible()));
+    ingestTransferTitle.add(infoIconIngesttransfertitle);
 
     draw();
   }
@@ -204,6 +210,11 @@ public class IngestTransfer extends Composite {
     // navigationToolbar.setHeader(messages.oneOfAObject(TransferredResource.class.getName())); //TODO: Add header
 
     ingestTransferDescription.add(new HTMLWidgetWrapper("IngestTransferDescription.html"));
+    Anchor infoIconIngesttransfertitle = new Anchor();
+    infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
+    infoIconIngesttransfertitle.addClickHandler(event -> ingestTransferDescription.setVisible(!ingestTransferDescription.isVisible()));
+    ingestTransferTitle.add(infoIconIngesttransfertitle);
 
     draw();
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
@@ -193,6 +193,7 @@ public class IngestTransfer extends Composite {
     Anchor infoIconIngesttransfertitle = new Anchor();
     infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
+    infoIconIngesttransfertitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconIngesttransfertitle.addClickHandler(event -> ingestTransferDescription.setVisible(!ingestTransferDescription.isVisible()));
     ingestTransferTitle.add(infoIconIngesttransfertitle);
 
@@ -215,6 +216,7 @@ public class IngestTransfer extends Composite {
     Anchor infoIconIngesttransfertitle = new Anchor();
     infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
+    infoIconIngesttransfertitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconIngesttransfertitle.addClickHandler(event -> ingestTransferDescription.setVisible(!ingestTransferDescription.isVisible()));
     ingestTransferTitle.add(infoIconIngesttransfertitle);
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/transfer/IngestTransfer.java
@@ -189,6 +189,7 @@ public class IngestTransfer extends Composite {
     objectToolbar.setObjectAndBuild(resource, null, null);
 
     ingestTransferDescription.add(new HTMLWidgetWrapper("IngestTransferDescription.html"));
+    ingestTransferDescription.setVisible(false);
     Anchor infoIconIngesttransfertitle = new Anchor();
     infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
@@ -210,6 +211,7 @@ public class IngestTransfer extends Composite {
     // navigationToolbar.setHeader(messages.oneOfAObject(TransferredResource.class.getName())); //TODO: Add header
 
     ingestTransferDescription.add(new HTMLWidgetWrapper("IngestTransferDescription.html"));
+    ingestTransferDescription.setVisible(false);
     Anchor infoIconIngesttransfertitle = new Anchor();
     infoIconIngesttransfertitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconIngesttransfertitle.addStyleName("description-toggle-icon");
@@ -223,7 +225,6 @@ public class IngestTransfer extends Composite {
     if (resource == null) {
       itemTitle.setVisible(false);
       ingestTransferTitle.setVisible(true);
-      ingestTransferDescription.setVisible(true);
       itemDates.setText("");
       download.setVisible(false);
       navigationToolbar.setVisible(false);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
@@ -32,6 +32,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 public class MemberManagement extends Composite {
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
@@ -82,6 +84,8 @@ public class MemberManagement extends Composite {
 
   @UiField
   FlowPanel memberManagementDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   SearchWrapper searchWrapper;
@@ -98,6 +102,12 @@ public class MemberManagement extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
 
     memberManagementDescription.add(new HTMLWidgetWrapper("MemberManagementDescription.html"));
+    memberManagementDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> memberManagementDescription.setVisible(!memberManagementDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   private void refresh() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.java
@@ -106,6 +106,7 @@ public class MemberManagement extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> memberManagementDescription.setVisible(!memberManagementDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/MemberManagement.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-management-user" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.usersAndGroupsTitle}" iconClass="Group" />
+				<common:TitlePanel text="{messages.usersAndGroupsTitle}" iconClass="Group" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="memberManagementDescription" />
 				<commonsearch:SearchWrapper ui:field="searchWrapper" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
@@ -35,6 +35,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -87,6 +89,8 @@ public class UserLog extends Composite {
 
   @UiField
   FlowPanel userLogDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   SearchWrapper searchWrapper;
@@ -99,6 +103,12 @@ public class UserLog extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
 
     userLogDescription.add(new HTMLWidgetWrapper("UserLogDescription.html"));
+    userLogDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> userLogDescription.setVisible(!userLogDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public void resolve(List<String> historyTokens, AsyncCallback<Widget> callback) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.java
@@ -107,6 +107,7 @@ public class UserLog extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> userLogDescription.setVisible(!userLogDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/UserLog.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-log" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.activityLogTitle}" iconClass="LogEntry" />
+				<common:TitlePanel text="{messages.activityLogTitle}" iconClass="LogEntry" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="userLogDescription" />
 				<commonsearch:SearchWrapper ui:field="searchWrapper" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
@@ -36,6 +36,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -71,6 +73,8 @@ public class ActionProcess extends Composite {
 
   @UiField
   FlowPanel preservationProcessDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   JobSearch jobSearch;
@@ -90,6 +94,12 @@ public class ActionProcess extends Composite {
 
     initWidget(uiBinder.createAndBindUi(this));
     preservationProcessDescription.add(new HTMLWidgetWrapper("PreservationProcessDescription.html"));
+    preservationProcessDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> preservationProcessDescription.setVisible(!preservationProcessDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   /**

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.java
@@ -98,6 +98,7 @@ public class ActionProcess extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> preservationProcessDescription.setVisible(!preservationProcessDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/ActionProcess.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-job-list" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content" ui:field="contentFlowPanel">
-				<common:TitlePanel text="{messages.preservationActionsTitle}" iconClass="Job" />
+				<common:TitlePanel text="{messages.preservationActionsTitle}" iconClass="Job" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="preservationProcessDescription" />
 				<search:JobSearch ui:field="jobSearch" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
@@ -122,6 +122,7 @@ public class IngestProcess extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> ingestProcessDescription.setVisible(!ingestProcessDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.java
@@ -39,6 +39,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -94,6 +96,8 @@ public class IngestProcess extends Composite {
 
   @UiField
   FlowPanel ingestProcessDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   JobSearch jobSearch;
@@ -114,6 +118,12 @@ public class IngestProcess extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
 
     ingestProcessDescription.add(new HTMLWidgetWrapper("IngestProcessDescription.html"));
+    ingestProcessDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> ingestProcessDescription.setVisible(!ingestProcessDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public void resolve(List<String> historyTokens, AsyncCallback<Widget> callback) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/IngestProcess.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-ingest-list" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content" ui:field="contentFlowPanel">
-				<common:TitlePanel text="{messages.ingestProcessTitle}" iconClass="Job" />
+				<common:TitlePanel text="{messages.ingestProcessTitle}" iconClass="Job" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="ingestProcessDescription" />
 				<search:JobSearch ui:field="jobSearch" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
@@ -34,6 +34,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -74,6 +76,8 @@ public class InternalProcess extends Composite {
 
   @UiField
   FlowPanel internalProcessDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   JobSearch jobSearch;
@@ -88,6 +92,12 @@ public class InternalProcess extends Composite {
 
     initWidget(uiBinder.createAndBindUi(this));
     internalProcessDescription.add(new HTMLWidgetWrapper("InternalProcessDescription.html"));
+    internalProcessDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> internalProcessDescription.setVisible(!internalProcessDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   /**

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.java
@@ -96,6 +96,7 @@ public class InternalProcess extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> internalProcessDescription.setVisible(!internalProcessDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/InternalProcess.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="wui-ingest-list" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.internalProcessTitle}" iconClass="Job" />
+				<common:TitlePanel text="{messages.internalProcessTitle}" iconClass="Job" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="internalProcessDescription" />
 				<search:JobSearch ui:field="jobSearch" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
@@ -95,6 +95,7 @@ public class Search extends Composite {
     Anchor infoIconTitle = new Anchor();
     infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
     infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.setTitle("Klicka för att fälla ut hjälpen");
     infoIconTitle.addClickHandler(event -> searchDescription.setVisible(!searchDescription.isVisible()));
     title.add(infoIconTitle);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.java
@@ -26,6 +26,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.roda.wui.client.common.TitlePanel;
+import com.google.gwt.user.client.ui.Anchor;
 
 /**
  * @author Luis Faria
@@ -76,6 +78,8 @@ public class Search extends Composite {
 
   @UiField
   FlowPanel searchDescription;
+  @UiField
+  TitlePanel title;
 
   @UiField(provided = true)
   CatalogueSearch catalogueSearch;
@@ -87,6 +91,12 @@ public class Search extends Composite {
 
     initWidget(uiBinder.createAndBindUi(this));
     searchDescription.add(new HTMLWidgetWrapper("SearchDescription.html"));
+    searchDescription.setVisible(false);
+    Anchor infoIconTitle = new Anchor();
+    infoIconTitle.getElement().setInnerHTML("<i class=\"fa fa-info-circle\"></i>");
+    infoIconTitle.addStyleName("description-toggle-icon");
+    infoIconTitle.addClickHandler(event -> searchDescription.setVisible(!searchDescription.isVisible()));
+    title.add(infoIconTitle);
   }
 
   public static Search getInstance() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/search/Search.ui.xml
@@ -8,7 +8,7 @@
 	<g:FlowPanel styleName="search" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
 			<g:FlowPanel addStyleNames="col_12 content">
-				<common:TitlePanel text="{messages.searchTitle}" icon="fas fa-search" />
+				<common:TitlePanel text="{messages.searchTitle}" icon="fas fa-search" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="searchDescription" />
 				<commonsearch:CatalogueSearch ui:field="catalogueSearch" />
 			</g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1736,3 +1736,21 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .representationSection .thumbnailCardTitle::after {
     display: none !important;
 }
+
+/* Description toggle */
+.page-description {
+    padding-right: 266px;
+}
+
+.description-toggle-icon {
+    margin-left: 8px;
+    font-size: 1em;
+    vertical-align: super;
+    cursor: pointer;
+    color: #666;
+    text-decoration: none !important;
+}
+
+.description-toggle-icon:hover {
+    color: #333;
+}


### PR DESCRIPTION
## Summary

- Replaces always-visible help text on the Katalog/Browse page with a collapsed-by-default description block
- Adds a `fa-info-circle` icon next to the "Katalog" heading that toggles the description visible/hidden on click
- Description is right-padded (`266px`) to align with the table column, not the action sidebar

## Test plan

- [ ] Navigate to #browse — description should be hidden on load
- [ ] Click the info icon — description expands
- [ ] Click again — description collapses
- [ ] Verify description width aligns with the table (not the full page width)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsinformation

* **Nya funktioner**
  * Lagt till växelbara beskrivningsavsnitt på flera sidor. En infosymbol låter användare visa eller dölja ytterligare beskrivningstext efter behov.

* **Stil**
  * Tillagd CSS-styling för beskrivningsvexlingskontroller med lämplig avstånd och visuella effekter vid hovring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->