### PR TITLE
fix: premis skeleton använder korrekt representations-ID vid återanvändning (#343)

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
@@ -525,6 +525,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
       ConversionContext context = new ConversionContext(aipId, representation.getId(),
           newRepresentationID, reportItem, newRepresentations);
+      boolean filesConverted = false;
 
       try (CloseableIterable<OptionalWithCause<File>> allFiles = model.listFilesUnder(representation.getAipId(),
           representation.getId(), true)) {
@@ -532,8 +533,10 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
         ConversionResult result = processFilesForConversion(index, model, storage, allFiles, cachedJob, context, report);
 
+        filesConverted = !result.alteredFiles.isEmpty();
+
         // add unchanged files to the new representation
-        if (!result.alteredFiles.isEmpty()) {
+        if (filesConverted) {
           if (createDIP) {
             createNewFilesOnDIP(storage, model, new ArrayList<>(), context.newRepresentationId, notify);
           } else {
@@ -560,7 +563,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
         report.addReport(reportItem);
       }
 
-      if (!createDIP) {
+      if (!createDIP && filesConverted) {
         try {
           Representation rep = model.retrieveRepresentation(representation.getAipId(), context.newRepresentationId);
           createPremisSkeletonOnRepresentation(model, representation.getAipId(), rep, cachedJob.getUsername());
@@ -598,6 +601,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           }
         } else {
           ConversionContext context = null;
+          boolean fileConverted = false;
           try {
             LOGGER.debug("Processing file {}", file.getId());
 
@@ -627,6 +631,8 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
               ConversionResult result = processFilesForConversion(index, model, storage, files, cachedJob, context, report);
 
+              fileConverted = !result.alteredFiles.isEmpty();
+
               if (!result.state.equals(PluginState.SUCCESS)) {
                 reportState = PluginState.FAILURE;
                 jobPluginInfo.incrementObjectsProcessedWithFailure();
@@ -655,7 +661,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           createEvent(model, index, file.getAipId(), file.getRepresentationId(), file.getPath(), file.getId(),
               outputFormat, reportState, Arrays.asList(file), new ArrayList<>(), notifyEvent, cachedJob);
 
-          if (!createDIP && context != null) {
+          if (!createDIP && context != null && fileConverted) {
             try {
               Representation rep = model.retrieveRepresentation(file.getAipId(), context.newRepresentationId);
               createPremisSkeletonOnRepresentation(model, file.getAipId(), rep, cachedJob.getUsername());

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
@@ -158,11 +158,16 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
     final PluginState state;
     final List<File> alteredFiles;
     final List<File> newFiles;
+    final boolean somethingConverted;
+    final String targetRepresentationId;
 
-    ConversionResult(PluginState state, List<File> alteredFiles, List<File> newFiles) {
+    ConversionResult(PluginState state, List<File> alteredFiles, List<File> newFiles,
+        boolean somethingConverted, String targetRepresentationId) {
       this.state = state;
       this.alteredFiles = alteredFiles;
       this.newFiles = newFiles;
+      this.somethingConverted = somethingConverted;
+      this.targetRepresentationId = targetRepresentationId;
     }
   }
 
@@ -292,6 +297,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
     PluginState pluginResultState = PluginState.SUCCESS;
     ValidationReport validationReport = new ValidationReport();
     boolean hasUnacceptedFormatFiles = false;
+    boolean shallowConverted = false;
     List<File> alteredFiles = new ArrayList<>();
     List<File> newFiles = new ArrayList<>();
     List<DIPFile> newDIPFiles = new ArrayList<>();
@@ -304,9 +310,13 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
         if (!file.isDirectory()) {
           if (FSUtils.isManifestOfExternalFiles(file.getId())) {
-            processShallowFile(index, file, cachedJob, context.newRepresentationId, model, pluginResultState,
-                context.reportItem, true, storage, newFileId, newDIPFiles, newFiles,
+            String shallowRepId = processShallowFile(index, file, cachedJob, context.newRepresentationId, model,
+                pluginResultState, context.reportItem, true, storage, newFileId, newDIPFiles, newFiles,
                 pluginResultState, report);
+            if (shallowRepId != null) {
+              shallowConverted = true;
+              context.newRepresentationId = shallowRepId;
+            }
           } else {
             IndexedFile ifile = index.retrieve(IndexedFile.class, IdUtils.getFileId(file),
                 RodaConstants.FILE_FORMAT_FIELDS_TO_RETURN);
@@ -408,7 +418,9 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           "Source files include formats that are not accepted by this plugin and the plugin was not set to ignore these files. The conversion was not run.");
     }
 
-    return new ConversionResult(pluginResultState, alteredFiles, newFiles);
+    String targetRepresentationId = alteredFiles.isEmpty() ? null : context.newRepresentationId;
+    return new ConversionResult(pluginResultState, alteredFiles, newFiles,
+        !alteredFiles.isEmpty() || shallowConverted, targetRepresentationId);
   }
 
   @Override
@@ -448,6 +460,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
         ConversionContext context = new ConversionContext(aip.getId(), null, // No specific source representation
             newRepresentationID, aipReportItem, newRepresentations);
 
+        String aipTargetRepId = null;
         try {
           CloseableIterable<OptionalWithCause<File>> allFiles = CloseableIterables
               .fromList(allFilesFromAllRepresentations);
@@ -457,6 +470,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           // accumulate results for AIP-level event creation
           alteredFiles.addAll(result.alteredFiles);
           newFiles.addAll(result.newFiles);
+          aipTargetRepId = result.targetRepresentationId;
 
         } catch (RuntimeException | NotFoundException | GenericException | RequestNotValidException
             | AuthorizationDeniedException | IOException | AlreadyExistsException | PluginException e) {
@@ -467,9 +481,9 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           report.addReport(aipReportItem);
           PluginHelper.updatePartialJobReport(this, model, aipReportItem, true, cachedJob);
 
-          if (!createDIP && !alteredFiles.isEmpty()) {
+          if (!createDIP && aipTargetRepId != null) {
             try {
-              Representation rep = model.retrieveRepresentation(aip.getId(), context.newRepresentationId);
+              Representation rep = model.retrieveRepresentation(aip.getId(), aipTargetRepId);
               createPremisSkeletonOnRepresentation(model, aip.getId(), rep, cachedJob.getUsername());
             } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
                 | ValidationException | IOException e) {
@@ -526,6 +540,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
       ConversionContext context = new ConversionContext(aipId, representation.getId(),
           newRepresentationID, reportItem, newRepresentations);
       boolean filesConverted = false;
+      String resultTargetRepId = null;
 
       try (CloseableIterable<OptionalWithCause<File>> allFiles = model.listFilesUnder(representation.getAipId(),
           representation.getId(), true)) {
@@ -533,14 +548,16 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
         ConversionResult result = processFilesForConversion(index, model, storage, allFiles, cachedJob, context, report);
 
-        filesConverted = !result.alteredFiles.isEmpty();
+        filesConverted = result.somethingConverted;
+        resultTargetRepId = result.targetRepresentationId;
 
-        // add unchanged files to the new representation
-        if (filesConverted) {
+        // add unchanged files to the new representation (no-op with empty list, guarded
+        // by non-null targetRepresentationId so shallow-only cases are skipped)
+        if (filesConverted && resultTargetRepId != null) {
           if (createDIP) {
-            createNewFilesOnDIP(storage, model, new ArrayList<>(), context.newRepresentationId, notify);
+            createNewFilesOnDIP(storage, model, new ArrayList<>(), resultTargetRepId, notify);
           } else {
-            createNewFilesOnRepresentation(storage, model, new ArrayList<>(), context.newRepresentationId, cachedJob.getUsername(),
+            createNewFilesOnRepresentation(storage, model, new ArrayList<>(), resultTargetRepId, cachedJob.getUsername(),
                 notify);
           }
         }
@@ -563,9 +580,9 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
         report.addReport(reportItem);
       }
 
-      if (!createDIP && filesConverted) {
+      if (!createDIP && resultTargetRepId != null) {
         try {
-          Representation rep = model.retrieveRepresentation(representation.getAipId(), context.newRepresentationId);
+          Representation rep = model.retrieveRepresentation(representation.getAipId(), resultTargetRepId);
           createPremisSkeletonOnRepresentation(model, representation.getAipId(), rep, cachedJob.getUsername());
         } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
             | ValidationException | IOException e) {
@@ -601,7 +618,6 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           }
         } else {
           ConversionContext context = null;
-          boolean fileConverted = false;
           try {
             LOGGER.debug("Processing file {}", file.getId());
 
@@ -631,13 +647,23 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
               ConversionResult result = processFilesForConversion(index, model, storage, files, cachedJob, context, report);
 
-              fileConverted = !result.alteredFiles.isEmpty();
+              String fileTargetRepId = result.targetRepresentationId;
 
               if (!result.state.equals(PluginState.SUCCESS)) {
                 reportState = PluginState.FAILURE;
                 jobPluginInfo.incrementObjectsProcessedWithFailure();
               } else {
                 jobPluginInfo.incrementObjectsProcessedWithSuccess();
+              }
+
+              if (!createDIP && fileTargetRepId != null) {
+                try {
+                  Representation rep = model.retrieveRepresentation(file.getAipId(), fileTargetRepId);
+                  createPremisSkeletonOnRepresentation(model, file.getAipId(), rep, cachedJob.getUsername());
+                } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
+                    | ValidationException | IOException e) {
+                  LOGGER.error("Error running premis skeleton on new representation: {}", e.getMessage());
+                }
               }
             }
 
@@ -660,16 +686,6 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           boolean notifyEvent = true;
           createEvent(model, index, file.getAipId(), file.getRepresentationId(), file.getPath(), file.getId(),
               outputFormat, reportState, Arrays.asList(file), new ArrayList<>(), notifyEvent, cachedJob);
-
-          if (!createDIP && context != null && fileConverted) {
-            try {
-              Representation rep = model.retrieveRepresentation(file.getAipId(), context.newRepresentationId);
-              createPremisSkeletonOnRepresentation(model, file.getAipId(), rep, cachedJob.getUsername());
-            } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
-                | ValidationException | IOException e) {
-              LOGGER.error("Error running premis skeleton on new representation: {}", e.getMessage());
-            }
-          }
         }
       } catch (NotFoundException | GenericException | RequestNotValidException | AuthorizationDeniedException e) {
         reportState = PluginState.FAILURE;
@@ -740,13 +756,14 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
     }
   }
 
-  private void processShallowFile(IndexService index, File file, Job cachedJob, String newRepresentationID,
+  private String processShallowFile(IndexService index, File file, Job cachedJob, String newRepresentationID,
       ModelService model, PluginState pluginResultState, Report reportItem, boolean notify, StorageService storage,
       String newFileId, List<DIPFile> newDIPFiles, List<File> newFiles, PluginState reportState, Report report)
       throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException,
       PluginException {
 
     Map<String, String> changedRepresentationsOnAIPs = new HashMap<>();
+    String lastCreatedRepresentationId = null;
 
     for (OptionalWithCause<File> fileShallows : model.listExternalFilesUnder(file)) {
       for (File file1 : Arrays.asList(fileShallows.get())) {
@@ -854,6 +871,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
                   reportItem.setSourceAndOutcomeObjectId(reportItem.getSourceObjectId(), IdUtils.getFileId(f));
                   changedRepresentationsOnAIPs.put(file1.getRepresentationId(), file1.getAipId());
                 }
+                lastCreatedRepresentationId = newRepresentationID;
 
                 Report fileReportItem = PluginHelper.initPluginReportItem(this, file1.getId(), File.class,
                     AIPState.ACTIVE);
@@ -922,6 +940,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
       }
     }
 
+    return lastCreatedRepresentationId;
   }
 
   private boolean doPluginExecute(String fileFormat, String filePronom, String fileMimetype, List<String> applicableTo,

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/conversion/AbstractConvertPlugin.java
@@ -137,7 +137,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
   private static class ConversionContext {
     final String aipId;
     final String sourceRepresentationId;
-    final String newRepresentationId;
+    String newRepresentationId;
     final Report reportItem;
     final List<String> newRepresentations;
 
@@ -351,6 +351,8 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
                         context.newRepresentationId,
                         representationType, cachedJob.getUsername(), markAsPreservation);
 
+                    context.newRepresentationId = actualRepresentationId;
+
                     if (!context.newRepresentations.contains(actualRepresentationId)) {
                       context.newRepresentations.add(actualRepresentationId);
                     }
@@ -467,7 +469,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
           if (!createDIP && !alteredFiles.isEmpty()) {
             try {
-              Representation rep = model.retrieveRepresentation(aip.getId(), newRepresentationID);
+              Representation rep = model.retrieveRepresentation(aip.getId(), context.newRepresentationId);
               createPremisSkeletonOnRepresentation(model, aip.getId(), rep, cachedJob.getUsername());
             } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
                 | ValidationException | IOException e) {
@@ -521,21 +523,21 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
         reportItem.setOutcomeObjectClass(DIP.class.getName());
       }
 
+      ConversionContext context = new ConversionContext(aipId, representation.getId(),
+          newRepresentationID, reportItem, newRepresentations);
+
       try (CloseableIterable<OptionalWithCause<File>> allFiles = model.listFilesUnder(representation.getAipId(),
           representation.getId(), true)) {
         LOGGER.debug("Processing representation {}", representation);
-
-        ConversionContext context = new ConversionContext(aipId, representation.getId(),
-            newRepresentationID, reportItem, newRepresentations);
 
         ConversionResult result = processFilesForConversion(index, model, storage, allFiles, cachedJob, context, report);
 
         // add unchanged files to the new representation
         if (!result.alteredFiles.isEmpty()) {
           if (createDIP) {
-            createNewFilesOnDIP(storage, model, new ArrayList<>(), newRepresentationID, notify);
+            createNewFilesOnDIP(storage, model, new ArrayList<>(), context.newRepresentationId, notify);
           } else {
-            createNewFilesOnRepresentation(storage, model, new ArrayList<>(), newRepresentationID, cachedJob.getUsername(),
+            createNewFilesOnRepresentation(storage, model, new ArrayList<>(), context.newRepresentationId, cachedJob.getUsername(),
                 notify);
           }
         }
@@ -560,7 +562,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
 
       if (!createDIP) {
         try {
-          Representation rep = model.retrieveRepresentation(representation.getAipId(), newRepresentationID);
+          Representation rep = model.retrieveRepresentation(representation.getAipId(), context.newRepresentationId);
           createPremisSkeletonOnRepresentation(model, representation.getAipId(), rep, cachedJob.getUsername());
         } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
             | ValidationException | IOException e) {
@@ -595,6 +597,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
             executeOnFile(index, model, report, jobPluginInfo, Arrays.asList(fileShallows.get()), cachedJob);
           }
         } else {
+          ConversionContext context = null;
           try {
             LOGGER.debug("Processing file {}", file.getId());
 
@@ -617,7 +620,7 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
                 }
               };
 
-              ConversionContext context = new ConversionContext(file.getAipId(), file.getRepresentationId(),
+              context = new ConversionContext(file.getAipId(), file.getRepresentationId(),
                   newRepresentationID, reportItem, newRepresentations);
               // Note: For executeOnFile, we don't set createPerFileContainer anymore since
               // containers are created lazily
@@ -652,9 +655,9 @@ public abstract class AbstractConvertPlugin<T extends IsRODAObject> extends Abst
           createEvent(model, index, file.getAipId(), file.getRepresentationId(), file.getPath(), file.getId(),
               outputFormat, reportState, Arrays.asList(file), new ArrayList<>(), notifyEvent, cachedJob);
 
-          if (!createDIP) {
+          if (!createDIP && context != null) {
             try {
-              Representation rep = model.retrieveRepresentation(file.getAipId(), newRepresentationID);
+              Representation rep = model.retrieveRepresentation(file.getAipId(), context.newRepresentationId);
               createPremisSkeletonOnRepresentation(model, file.getAipId(), rep, cachedJob.getUsername());
             } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException
                 | ValidationException | IOException e) {


### PR DESCRIPTION
## Sammanfattning

- `ConversionContext.newRepresentationId` gjordes icke-final och uppdateras nu i `processFilesForConversion` när `determineRepresentationId` returnerar ett befintligt representations-ID
- `executeOnAIP`, `executeOnRepresentation` och `executeOnFile` använder nu `context.newRepresentationId` i premis skeleton-anropen istället för det ursprungliga (potentiellt aldrig skapade) UUID:t
- Premis skeleton körs nu bara när filer faktiskt konverterades (`filesConverted`/`fileConverted`-flaggor)

## Rotorsak

När `AbstractConvertPlugin` återanvände en befintlig preservation-representation uppdaterades aldrig `newRepresentationID` i det yttre scopet. Finally-blocket anropade `model.retrieveRepresentation(...)` med det ursprungliga UUID:t som aldrig skapades i storage → `NotFoundException` → konverterade filer indexerades inte och syntes inte i UI:et.

## Test plan

- [ ] Kör konverteringsplugin (t.ex. Image Converter) på ett AIP som redan har en preservation-representation av måltypen
- [ ] Verifiera att loggarna inte längre visar `Error running premis skeleton on new representation: Could not find representation: <uuid>`
- [ ] Verifiera att den konverterade representationen indexeras korrekt och syns i UI:et

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Utgåva

* **Buggfixar**
  * Förbättrad hantering av filkonverteringar för att korrekt spåra och återanvända målrepresentationer.
  * Optimerad skapande av metadataskelelett för att endast köra när faktisk konvertering inträffar.

* **Prestandaförbättringar**
  * Reducerad onödig bearbetning under konverteringsprocesser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->