### PR TITLE
feat: konfigurerbar synlighet för huvudmeny via roda-wui.properties

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -186,6 +186,15 @@ public final class RodaConstants {
   public static final String UI_SERVICE_MULTI_METHOD_AUTHENTICATION_LIST = "ui.service.multi.method.authentication.item[]";
   public static final String UI_SERVICE_DROPFOLDER_ACTIVE = "ui.service.dropfolder.active";
 
+  public static final String UI_MAINMENU_HIDE_HOME = "ui.mainmenu.hide.home";
+  public static final String UI_MAINMENU_HIDE_BROWSE = "ui.mainmenu.hide.browse";
+  public static final String UI_MAINMENU_HIDE_SEARCH = "ui.mainmenu.hide.search";
+  public static final String UI_MAINMENU_HIDE_INGEST = "ui.mainmenu.hide.ingest";
+  public static final String UI_MAINMENU_HIDE_ADMINISTRATION = "ui.mainmenu.hide.administration";
+  public static final String UI_MAINMENU_HIDE_DISPOSAL = "ui.mainmenu.hide.disposal";
+  public static final String UI_MAINMENU_HIDE_PLANNING = "ui.mainmenu.hide.planning";
+  public static final String UI_MAINMENU_HIDE_HELP = "ui.mainmenu.hide.help";
+
   public static final String UI_SERVICE_MONITORING_DEFAULT_URL = "https://www.roda-enterprise.com";
   public static final String UI_SERVICE_CAS_DEFAULT_URL = "https://www.roda-enterprise.com";
   public static final String UI_SERVICE_MARKETPLACE_DEFAULT_URL = "https://marketplace.roda-community.org";

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Header.java
@@ -272,52 +272,68 @@ public class Header extends Composite {
     // TODO make creating sync (not async)
 
     // Home
-    updateResolverTopItemVisibility(Welcome.RESOLVER, about, 0);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_HOME)) {
+      updateResolverTopItemVisibility(Welcome.RESOLVER, about, 0);
+    }
 
     // Dissemination
-    updateResolverTopItemVisibility(BrowseTop.RESOLVER, disseminationBrowse, 1);
-    updateResolverTopItemVisibility(Search.RESOLVER, disseminationSearchBasic, 2);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_BROWSE)) {
+      updateResolverTopItemVisibility(BrowseTop.RESOLVER, disseminationBrowse, 1);
+    }
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_SEARCH)) {
+      updateResolverTopItemVisibility(Search.RESOLVER, disseminationSearchBasic, 2);
+    }
 
     // Ingest
-    updateResolverSubItemVisibility(IngestTransfer.RESOLVER, ingestTransfer);
-    updateResolverSubItemVisibility(IngestProcess.RESOLVER, ingestList);
-    updateResolverSubItemVisibility(IngestAppraisal.RESOLVER, ingestAppraisal);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_INGEST)) {
+      updateResolverSubItemVisibility(IngestTransfer.RESOLVER, ingestTransfer);
+      updateResolverSubItemVisibility(IngestProcess.RESOLVER, ingestList);
+      updateResolverSubItemVisibility(IngestAppraisal.RESOLVER, ingestAppraisal);
 
-    MenuItem ingestItem = new MenuItem(messages.title("ingest"), ingestMenu);
-    ingestItem.addStyleName("ingest_menu_item");
-    updateResolverTopItemVisibility(Ingest.RESOLVER, ingestItem, 3);
+      MenuItem ingestItem = new MenuItem(messages.title("ingest"), ingestMenu);
+      ingestItem.addStyleName("ingest_menu_item");
+      updateResolverTopItemVisibility(Ingest.RESOLVER, ingestItem, 3);
+    }
 
     // Administration
-    updateResolverSubItemVisibility(ActionProcess.RESOLVER, administrationActions);
-    updateResolverSubItemVisibility(InternalProcess.RESOLVER, administrationInternalActions);
-    updateResolverSubItemVisibility(MemberManagement.RESOLVER, administrationUser);
-    updateResolverSubItemVisibility(UserLog.RESOLVER, administrationLog);
-    updateResolverSubItemVisibility(NotificationRegister.RESOLVER, administrationNotifications);
-    updateResolverSubItemVisibility(Statistics.RESOLVER, administrationStatistics);
-    MenuItem adminItem = new MenuItem(messages.title("administration"), administrationMenu);
-    adminItem.addStyleName("administration_menu_item");
-    updateResolverTopItemVisibility(Management.RESOLVER, adminItem, 4);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_ADMINISTRATION)) {
+      updateResolverSubItemVisibility(ActionProcess.RESOLVER, administrationActions);
+      updateResolverSubItemVisibility(InternalProcess.RESOLVER, administrationInternalActions);
+      updateResolverSubItemVisibility(MemberManagement.RESOLVER, administrationUser);
+      updateResolverSubItemVisibility(UserLog.RESOLVER, administrationLog);
+      updateResolverSubItemVisibility(NotificationRegister.RESOLVER, administrationNotifications);
+      updateResolverSubItemVisibility(Statistics.RESOLVER, administrationStatistics);
+      MenuItem adminItem = new MenuItem(messages.title("administration"), administrationMenu);
+      adminItem.addStyleName("administration_menu_item");
+      updateResolverTopItemVisibility(Management.RESOLVER, adminItem, 4);
+    }
 
     // Disposal
-    updateResolverSubItemVisibility(DisposalPolicy.RESOLVER, disposalPolicy);
-    updateResolverSubItemVisibility(DisposalConfirmations.RESOLVER, disposalConfirmation);
-    updateResolverSubItemVisibility(DisposalDestroyedRecords.RESOLVER, disposalDestroyedRecords);
-    updateResolverSubItemVisibility(DisposalConfirmations.RESOLVER, overdueActions);
-    MenuItem disposalItem = new MenuItem(messages.title("disposal"), disposalMenu);
-    disposalItem.addStyleName("disposal_menu_item");
-    updateResolverTopItemVisibility(Disposal.RESOLVER, disposalItem, 5);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_DISPOSAL)) {
+      updateResolverSubItemVisibility(DisposalPolicy.RESOLVER, disposalPolicy);
+      updateResolverSubItemVisibility(DisposalConfirmations.RESOLVER, disposalConfirmation);
+      updateResolverSubItemVisibility(DisposalDestroyedRecords.RESOLVER, disposalDestroyedRecords);
+      updateResolverSubItemVisibility(DisposalConfirmations.RESOLVER, overdueActions);
+      MenuItem disposalItem = new MenuItem(messages.title("disposal"), disposalMenu);
+      disposalItem.addStyleName("disposal_menu_item");
+      updateResolverTopItemVisibility(Disposal.RESOLVER, disposalItem, 5);
+    }
 
     // Planning
-    updateResolverSubItemVisibility(RiskRegister.RESOLVER, planningRisk);
-    updateResolverSubItemVisibility(RepresentationInformationNetwork.RESOLVER, planningRepresentationInformation);
-    updateResolverSubItemVisibility(PreservationEvents.PLANNING_RESOLVER, planningEvent);
-    updateResolverSubItemVisibility(PreservationAgents.RESOLVER, planningAgent);
-    MenuItem planningItem = new MenuItem(messages.title("planning"), planningMenu);
-    planningItem.addStyleName("planning_menu_item");
-    updateResolverTopItemVisibility(Planning.RESOLVER, planningItem, 6);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_PLANNING)) {
+      updateResolverSubItemVisibility(RiskRegister.RESOLVER, planningRisk);
+      updateResolverSubItemVisibility(RepresentationInformationNetwork.RESOLVER, planningRepresentationInformation);
+      updateResolverSubItemVisibility(PreservationEvents.PLANNING_RESOLVER, planningEvent);
+      updateResolverSubItemVisibility(PreservationAgents.RESOLVER, planningAgent);
+      MenuItem planningItem = new MenuItem(messages.title("planning"), planningMenu);
+      planningItem.addStyleName("planning_menu_item");
+      updateResolverTopItemVisibility(Planning.RESOLVER, planningItem, 6);
+    }
 
     // Help
-    updateResolverTopItemVisibility(Help.RESOLVER, help, 7);
+    if (!ConfigurationManager.getBoolean(false, RodaConstants.UI_MAINMENU_HIDE_HELP)) {
+      updateResolverTopItemVisibility(Help.RESOLVER, help, 7);
+    }
   }
 
   private MenuItem customMenuItem(String icon, String label, String styleNames, MenuBar subMenu,

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2733,7 +2733,7 @@ ui.mainmenu.hide.search=false
 ui.mainmenu.hide.ingest=false
 ui.mainmenu.hide.administration=false
 ui.mainmenu.hide.disposal=false
-ui.mainmenu.hide.planning=false
+ui.mainmenu.hide.planning=true
 ui.mainmenu.hide.help=false
 
 

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -109,6 +109,9 @@ ui.sharedProperties.whitelist.configuration.property = ui.redaction.reason.manda
 # Administration menu
 ui.sharedProperties.whitelist.configuration.prefix = ui.service
 
+# Main menu visibility
+ui.sharedProperties.whitelist.configuration.prefix = ui.mainmenu
+
 # URLs
 ui.sharedProperties.whitelist.configuration.prefix = ui.url
 
@@ -2704,6 +2707,34 @@ ui.service.dropfolder.url=https://docs.roda-enterprise.com/05-plugins/01-ingest/
 ui.service.reporting.active=false
 ui.service.cas.active=false
 ui.service.dropfolder.active=false
+
+
+##########################################################################
+# Main menu visibility
+#
+# ui.mainmenu.hide.{menu}
+#   Boolean
+#   Set to true to hide the corresponding top-level menu item.
+#   Default: false (menu is visible)
+#
+#   Available keys:
+#     ui.mainmenu.hide.home
+#     ui.mainmenu.hide.browse
+#     ui.mainmenu.hide.search
+#     ui.mainmenu.hide.ingest
+#     ui.mainmenu.hide.administration
+#     ui.mainmenu.hide.disposal
+#     ui.mainmenu.hide.planning
+#     ui.mainmenu.hide.help
+##########################################################################
+ui.mainmenu.hide.home=false
+ui.mainmenu.hide.browse=false
+ui.mainmenu.hide.search=false
+ui.mainmenu.hide.ingest=false
+ui.mainmenu.hide.administration=false
+ui.mainmenu.hide.disposal=false
+ui.mainmenu.hide.planning=false
+ui.mainmenu.hide.help=false
 
 
 ##########################################################################


### PR DESCRIPTION
## Sammanfattning

Lägger till stöd för att dölja enskilda menyval i huvudmenyn via konfigurationsegenskaper i `roda-wui.properties`. Utan konfiguration visas alla menyer som tidigare — inga befintliga installationer påverkas.

## Ändringar

- **`RodaConstants.java`** — Åtta nya konstanter för `ui.mainmenu.hide.*`
- **`Header.java`** — Varje menyval kontrolleras mot konfigurationen innan det renderas
- **`roda-wui.properties`** — Prefixet `ui.mainmenu` whitelistat (tillgängligt för GWT-klienten), standardvärden `false` för alla nycklar samt dokumentation

## Användning

Lägg till i din lokala `roda-wui.properties` (eller `$RODA_HOME/config/roda-wui.properties`):

```properties
ui.mainmenu.hide.planning=true
ui.mainmenu.hide.disposal=true
```

Tillgängliga nycklar:

| Nyckel | Meny |
|--------|------|
| `ui.mainmenu.hide.home` | Hem |
| `ui.mainmenu.hide.browse` | Bläddra |
| `ui.mainmenu.hide.search` | Sök |
| `ui.mainmenu.hide.ingest` | Ingest |
| `ui.mainmenu.hide.administration` | Administration |
| `ui.mainmenu.hide.disposal` | Gallring |
| `ui.mainmenu.hide.planning` | Planering |
| `ui.mainmenu.hide.help` | Hjälp |

## Testplan

- [ ] Bygg `roda-common-data` och `roda-wui` utan fel
- [ ] Verifiera att alla menyer visas utan konfiguration (standardbeteende)
- [ ] Sätt `ui.mainmenu.hide.planning=true` och verifiera att "Planering" döljs
- [ ] Sätt `ui.mainmenu.hide.ingest=true` och verifiera att "Ingest" och dess undermenyer döljs
- [ ] Verifiera att behörighetskontrollen fortfarande fungerar för synliga menyer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nya funktioner**
  * Möjlighet att dölja eller visa huvudmenyalternativ genom konfiguration. Du kan nu välja vilka menydelar som ska visas: hem, bläddra, sökning, inmatning, administration, bortskaffning, planering och hjälp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->