### PR TITLE
fix: förbättra trädstrukturen (#349)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
@@ -51,10 +51,15 @@ import org.roda.wui.common.client.tools.ListUtils;
 import org.roda.wui.common.client.widgets.Toast;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.event.dom.client.MouseDownHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -102,6 +107,12 @@ public class BrowseRepresentation extends Composite {
       return "representation";
     }
   };
+  // Catalog tree
+  @UiField
+  FlowPanel catalogTreeContainer;
+  @UiField
+  FlowPanel treeResizeHandle;
+
   // Focus
   @UiField
   FocusPanel keyboardFocus;
@@ -138,6 +149,8 @@ public class BrowseRepresentation extends Composite {
     }
   };
 
+  private HandlerRegistration resizeHandlerReg;
+
   // FILES
   private final IndexedAIP aip;
 
@@ -146,6 +159,50 @@ public class BrowseRepresentation extends Composite {
   private final String aipId;
   private final String repId;
   private final String repUUID;
+
+  @Override
+  protected void onLoad() {
+    super.onLoad();
+    catalogTreeContainer.clear();
+    CatalogTreePanel treePanel = CatalogTreePanel.getInstance();
+    catalogTreeContainer.add(treePanel);
+    treePanel.revealAip(aipId);
+  }
+
+  private void initTreeResize() {
+    treeResizeHandle.addDomHandler(new MouseDownHandler() {
+      @Override
+      public void onMouseDown(MouseDownEvent event) {
+        event.preventDefault();
+        if (resizeHandlerReg != null) {
+          resizeHandlerReg.removeHandler();
+          resizeHandlerReg = null;
+        }
+        final int startX = event.getClientX();
+        final int startWidth = CatalogTreePanel.getInstance().getOffsetWidth();
+        Event.setCapture(treeResizeHandle.getElement());
+        Document.get().getBody().addClassName("catalogTreeResizing");
+
+        resizeHandlerReg = Event.addNativePreviewHandler(new Event.NativePreviewHandler() {
+          @Override
+          public void onPreviewNativeEvent(Event.NativePreviewEvent e) {
+            com.google.gwt.dom.client.NativeEvent ne = e.getNativeEvent();
+            if ("mousemove".equals(ne.getType())) {
+              int newWidth = Math.max(150, Math.min(480, startWidth + ne.getClientX() - startX));
+              CatalogTreePanel.getInstance().getElement().getStyle().setPropertyPx("width", newWidth);
+            } else if ("mouseup".equals(ne.getType())) {
+              Event.releaseCapture(treeResizeHandle.getElement());
+              Document.get().getBody().removeClassName("catalogTreeResizing");
+              if (resizeHandlerReg != null) {
+                resizeHandlerReg.removeHandler();
+                resizeHandlerReg = null;
+              }
+            }
+          }
+        });
+      }
+    }, MouseDownEvent.getType());
+  }
 
   public BrowseRepresentation(BrowseRepresentationResponse response) {
     this.representation = response.getIndexedRepresentation();
@@ -163,6 +220,7 @@ public class BrowseRepresentation extends Composite {
 
     // INIT
     initWidget(uiBinder.createAndBindUi(this));
+    initTreeResize();
 
     if (justActive) {
       initHandlers();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.ui.xml
@@ -7,8 +7,10 @@
 
     <ui:with field='messages' type='config.i18n.client.ClientMessages'/>
 
-    <g:FlowPanel styleName="contentWithSidePanel">
-        <g:FocusPanel ui:field="keyboardFocus">
+    <g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
+        <g:FlowPanel ui:field="catalogTreeContainer" />
+        <g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
+        <g:FocusPanel ui:field="keyboardFocus" addStyleNames="catalogTreeMainContent">
             <g:FlowPanel styleName="wui-browse-representation" addStyleNames="wrapper skip_padding">
                 <common:NavigationToolbar ui:field="navigationToolbar"/>
                 <common:BrowseRepresentationActionsToolbar ui:field="objectToolbar"

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -151,8 +151,7 @@ public class CatalogTreeNode extends Composite {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new SimpleFilterParameter(RodaConstants.AIP_PARENT_ID, aipId),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -101,8 +101,7 @@ public class CatalogTreePanel extends Composite {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new EmptyKeyFilterParameter(RodaConstants.AIP_PARENT_ID),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
@@ -6,9 +6,6 @@
     <ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
     <g:FlowPanel styleName="catalogTreePanel">
-        <g:FlowPanel styleName="catalogTreePanelHeader">
-            <g:Label text="{messages.catalogTreeTitle}" />
-        </g:FlowPanel>
         <g:FlowPanel styleName="catalogTreeFilter">
             <g:TextBox ui:field="filterInput" styleName="catalogTreeFilterInput" />
         </g:FlowPanel>


### PR DESCRIPTION
## Sammanfattning

Åtgärdar de tre punkterna i issue #349.

- **Ta bort KATALOG-rubrik** — Rubriken "Katalog" högst upp i sidopanelens trädstruktur är borttagen. Trädet börjar direkt med filtersökning och noder.
- **Trädet markeras vid navigering till ärende** — AIPs med nivå `item` (ärenden) var tidigare undantagna från trädet via ett filter, vilket innebar att rätt nod aldrig kunde markeras. Filtret är nu borttaget så att ärenden laddas in och markeras automatiskt när man navigerar till dem.
- **Trädet syns på representationssidan** — `BrowseRepresentation` saknade helt katalogträdets container. Trädet visas nu även när man öppnar en representation, med samma resize-handtag och automatisk nodselektion (`revealAip`) som på AIP-sidan.

## Ändrade filer

| Fil | Förändring |
|-----|-----------|
| `CatalogTreePanel.ui.xml` | Tog bort `catalogTreePanelHeader`-blocket |
| `CatalogTreePanel.java` | Tog bort `item`-filter i rotnodsladdning |
| `CatalogTreeNode.java` | Tog bort `item`-filter i barnladdning |
| `BrowseRepresentation.ui.xml` | Lade till `catalogTreeContainer`, `treeResizeHandle`, `catalogTreeLayout` |
| `BrowseRepresentation.java` | Lade till `onLoad()`, `initTreeResize()` och nödvändiga fält/importer |

## Testplan

- [x] Navigera till ett ärende (item-nivå AIP) — trädet ska synas och rätt nod ska vara markerad
- [x] Öppna en representation — trädet ska synas i vänsterpanelen med korrekt nod markerad
- [x] Verifiera att "KATALOG"-rubriken inte längre syns i trädet
- [x] Verifiera att resize-handtaget fungerar på representationssidan
- [x] Verifiera att trädet förblir korrekt synkroniserat vid bakåtnavigering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nya funktioner
* Katalogträdet kan nu ändra storlek interaktivt via horisontell dragning

## Förbättringar
* Utökad filtrering visar fler poster i katalogträdet
* Förenklat gränssnitt genom borttagning av redundant titelsektion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->