### PR TITLE
fix: öka teckenstorlek i PDF-maskning sparadialog

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1754,3 +1754,15 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .description-toggle-icon:hover {
     color: #333;
 }
+
+/* PDF-maskning: gör alla texter i sparadialogen lättare att läsa */
+.MuiDialog-root .MuiFormHelperText-root,
+.MuiDialog-root .MuiDialogContentText-root,
+.MuiDialog-root .MuiInputLabel-root,
+.MuiDialog-root .MuiInputBase-input {
+    font-size: 1.2rem !important;
+}
+
+.MuiDialog-root .MuiInputLabel-shrink {
+    font-size: 1rem !important;
+}


### PR DESCRIPTION
## Sammanfattning

Texten i sparadialogen för PDF-maskning var för liten och svår att läsa utan ansträngning. Detta gäller framför allt:

- Hjälptexten under suffixfältet ("Lämna tomt för automatisk tidsstämpel.")
- Beskrivningstexten ("Vill du spara en maskerad kopia?")
- Fältetiketten ("Suffix (valfritt)")
- Texten i inmatningsfältet

## Lösning

CSS-overrides i `theme.css` som höjer teckenstorleken för MUI-komponenter i dialoger från standard `0.75–1rem` till `1.2rem`. Den hopfällda etiketten (när fältet är aktivt) sätts till `1rem` för att inte störa layouten.

## Skärmbild (efter fix)

<img width="427" height="146" alt="image" src="https://github.com/user-attachments/assets/90a184a7-6f59-44c2-80a6-80c9bb429ed5" />


## Definition of done

- [x] Texten i sparadialogen för PDF-maskning är läsbar utan att användaren behöver anstränga sig
- [x] Maskningsfunktionen i övrigt fungerar som förväntat