### PR TITLE
fix: indexera PREMIS-användaragenter i Solr vid alla skapa/uppdatera-flöden

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -1435,7 +1435,7 @@ public class RodaCoreFactory {
           PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(), getModelService(), getIndexService(), true);
         } catch (ValidationException | NotFoundException | RequestNotValidException | AuthorizationDeniedException
           | AlreadyExistsException e) {
-          LOGGER.error("Could not create PREMIS agent for default users");
+          LOGGER.error("Could not create PREMIS agent for user '{}'", user.getName(), e);
         }
       }
     }

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
@@ -2537,6 +2537,12 @@ public class DefaultModelService implements ModelService {
   }
 
   @Override
+  public PreservationMetadata createOrUpdateUserAgentBinary(String username) throws RODAException {
+    return PremisV3Utils.createOrUpdatePremisUserAgentBinary(
+      username, this, RodaCoreFactory.getIndexService(), true);
+  }
+
+  @Override
   public User deActivateUser(String id, boolean activate, boolean notify)
     throws GenericException, AlreadyExistsException, NotFoundException, AuthorizationDeniedException {
     return deActivateUser(id, activate, notify, false);

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
@@ -2536,6 +2536,14 @@ public class DefaultModelService implements ModelService {
     }
   }
 
+  /**
+   * Creates or updates the PREMIS user agent binary for the given username,
+   * ensuring the agent is persisted and indexed in Solr.
+   *
+   * @param username the username of the agent to create or update
+   * @return the created or updated {@link PreservationMetadata}, or null if the username is blank
+   * @throws RODAException if an error occurs during creation or update
+   */
   @Override
   public PreservationMetadata createOrUpdateUserAgentBinary(String username) throws RODAException {
     return PremisV3Utils.createOrUpdatePremisUserAgentBinary(

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
@@ -1913,6 +1913,11 @@ public class DefaultTransactionalModelService implements TransactionalModelServi
   }
 
   @Override
+  public PreservationMetadata createOrUpdateUserAgentBinary(String username) throws RODAException {
+    return mainModelService.createOrUpdateUserAgentBinary(username);
+  }
+
+  @Override
   public User deActivateUser(String id, boolean activate, boolean notify)
     throws GenericException, AlreadyExistsException, NotFoundException, AuthorizationDeniedException {
     return mainModelService.deActivateUser(id, activate, notify);

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -430,6 +430,10 @@ public interface ModelService extends ModelObservable {
   CloseableIterable<OptionalWithCause<PreservationMetadata>> listPreservationAgents()
     throws RequestNotValidException, GenericException, AuthorizationDeniedException;
 
+  /** Creates or updates the PREMIS user agent binary for the given username,
+   * ensuring the agent is persisted and indexed in Solr. */
+  PreservationMetadata createOrUpdateUserAgentBinary(String username) throws RODAException;
+
   CloseableIterable<OptionalWithCause<PreservationMetadata>> listPreservationRepositoryEvents()
     throws RequestNotValidException, GenericException, AuthorizationDeniedException;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
@@ -1269,14 +1269,17 @@ public final class PluginHelper {
         throw new RequestNotValidException(
           "Could not get LITE for agent with ID: " + linkingIdentifierAgent.getValue());
       }
-      if (!model.existsInStorage(agentLite.get())) {
-        PreservationMetadata pm = PremisV3Utils.createOrUpdatePremisUserAgentBinary(agentName, model, index, true,
-          jobUserDetails);
-        if (pm != null) {
-          agentIds.add(linkingIdentifierAgent);
-        }
-      } else {
+      PreservationMetadata pm = PremisV3Utils.createOrUpdatePremisUserAgentBinary(agentName, model, index, true,
+        jobUserDetails);
+      if (pm != null) {
         agentIds.add(linkingIdentifierAgent);
+      } else if (model.existsInStorage(agentLite.get())) {
+        LOGGER.warn("PREMIS agent binary exists in storage but could not be created/updated (blank agent name?): {}",
+          linkingIdentifierAgent.getValue());
+        agentIds.add(linkingIdentifierAgent);
+      } else {
+        LOGGER.warn("PREMIS agent binary could not be created and does not exist in storage: {}",
+          linkingIdentifierAgent.getValue());
       }
     } catch (AlreadyExistsException e) {
       agentIds.add(linkingIdentifierAgent);

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginHelper.java
@@ -1273,13 +1273,18 @@ public final class PluginHelper {
         jobUserDetails);
       if (pm != null) {
         agentIds.add(linkingIdentifierAgent);
-      } else if (model.existsInStorage(agentLite.get())) {
-        LOGGER.warn("PREMIS agent binary exists in storage but could not be created/updated (blank agent name?): {}",
-          linkingIdentifierAgent.getValue());
-        agentIds.add(linkingIdentifierAgent);
       } else {
-        LOGGER.warn("PREMIS agent binary could not be created and does not exist in storage: {}",
-          linkingIdentifierAgent.getValue());
+        try {
+          index.retrieve(IndexedPreservationAgent.class, linkingIdentifierAgent.getValue(), Collections.emptyList());
+          LOGGER.warn("PREMIS agent binary could not be created/updated (blank agent name?) but exists in index: {}",
+            linkingIdentifierAgent.getValue());
+          agentIds.add(linkingIdentifierAgent);
+        } catch (NotFoundException e) {
+          LOGGER.warn("PREMIS agent binary could not be created and does not exist in index: {}",
+            linkingIdentifierAgent.getValue());
+        } catch (GenericException e) {
+          LOGGER.warn("Could not check Solr index for PREMIS agent: {}", linkingIdentifierAgent.getValue(), e);
+        }
       }
     } catch (AlreadyExistsException e) {
       agentIds.add(linkingIdentifierAgent);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -197,15 +198,15 @@ public class MembersController implements MembersRestService, Exportable {
       } catch (Exception e) {
         LOGGER.warn("Could not create PREMIS agent for CAS user '{}'", user.getName(), e);
       }
-    } else {
+    } else if (user != null) {
       // found user and authentication externally, so update user email, full name and
       // groups from cas principal attributes if they have changed
       if (attributes != null) {
-        if (attributes.get("email") instanceof String email && !user.getEmail().equals(attributes.get("email"))) {
+        if (attributes.get("email") instanceof String email && !Objects.equals(user.getEmail(), email)) {
           user.setEmail(email);
         }
         if (attributes.get("fullname") instanceof String fullname
-          && !user.getFullName().equals(attributes.get("fullname"))) {
+          && !Objects.equals(user.getFullName(), fullname)) {
           user.setFullName(fullname);
         }
         if (RodaCoreFactory.getRodaConfiguration().getBoolean(RodaConstants.CORE_EXTERNAL_AUTH_GROUP_MAPPING_ENABLED,
@@ -231,6 +232,8 @@ public class MembersController implements MembersRestService, Exportable {
       } catch (Exception e) {
         LOGGER.warn("Could not update PREMIS agent for CAS user '{}'", user.getName(), e);
       }
+    } else {
+      throw new AuthenticationDeniedException("CAS user could not be provisioned: no user found and no attributes released");
     }
 
     if (!user.isActive()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -209,13 +209,18 @@ public class MembersController implements MembersRestService, Exportable {
         }
         if (RodaCoreFactory.getRodaConfiguration().getBoolean(RodaConstants.CORE_EXTERNAL_AUTH_GROUP_MAPPING_ENABLED,
           false)) {
-          if (attributes.get(groupsAttribute) instanceof Collection<?> memberOf) {
-            Set<String> casGroups = new HashSet<>();
+          Object groupsValue = attributes.get(groupsAttribute);
+          Set<String> casGroups = new HashSet<>();
+          if (groupsValue instanceof Collection<?> memberOf) {
             for (Object group : memberOf) {
               if (group instanceof String groupString) {
                 casGroups.add(groupString);
               }
             }
+          } else if (groupsValue instanceof String singleGroup) {
+            casGroups.add(singleGroup);
+          }
+          if (!casGroups.isEmpty()) {
             Set<String> rodaGroups = mapCasGroupstoRODAGroups(casGroups);
             if (!Objects.equals(user.getGroups(), rodaGroups)) {
               user.setGroups(rodaGroups);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -217,7 +217,7 @@ public class MembersController implements MembersRestService, Exportable {
               }
             }
             Set<String> rodaGroups = mapCasGroupstoRODAGroups(casGroups);
-            if (!user.getGroups().equals(rodaGroups)) {
+            if (!Objects.equals(user.getGroups(), rodaGroups)) {
               user.setGroups(rodaGroups);
             }
           }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -22,6 +22,7 @@ import javax.crypto.SecretKey;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.authentication.AttributePrincipal;
 import org.roda.core.RodaCoreFactory;
+import org.roda.core.common.PremisV3Utils;
 import org.roda.core.common.JwtUtils;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
@@ -190,33 +191,46 @@ public class MembersController implements MembersRestService, Exportable {
       }
 
       user = RodaCoreFactory.getModelService().createUser(user, true);
+      try {
+        PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(),
+          RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+      } catch (Exception e) {
+        LOGGER.warn("Could not create PREMIS agent for CAS user '{}'", user.getName(), e);
+      }
     } else {
       // found user and authentication externally, so update user email, full name and
-      // groups from cas principal
-      // attributes if they have changed
-      if (attributes.get("email") instanceof String email && !user.getEmail().equals(attributes.get("email"))) {
-        user.setEmail(email);
-      }
-      if (attributes.get("fullname") instanceof String fullname
-        && !user.getFullName().equals(attributes.get("fullname"))) {
-        user.setFullName(fullname);
-      }
-      if (RodaCoreFactory.getRodaConfiguration().getBoolean(RodaConstants.CORE_EXTERNAL_AUTH_GROUP_MAPPING_ENABLED,
-        false)) {
-        if (attributes.get(groupsAttribute) instanceof Collection<?> memberOf) {
-          Set<String> casGroups = new HashSet<>();
-          for (Object group : memberOf) {
-            if (group instanceof String groupString) {
-              casGroups.add(groupString);
+      // groups from cas principal attributes if they have changed
+      if (attributes != null) {
+        if (attributes.get("email") instanceof String email && !user.getEmail().equals(attributes.get("email"))) {
+          user.setEmail(email);
+        }
+        if (attributes.get("fullname") instanceof String fullname
+          && !user.getFullName().equals(attributes.get("fullname"))) {
+          user.setFullName(fullname);
+        }
+        if (RodaCoreFactory.getRodaConfiguration().getBoolean(RodaConstants.CORE_EXTERNAL_AUTH_GROUP_MAPPING_ENABLED,
+          false)) {
+          if (attributes.get(groupsAttribute) instanceof Collection<?> memberOf) {
+            Set<String> casGroups = new HashSet<>();
+            for (Object group : memberOf) {
+              if (group instanceof String groupString) {
+                casGroups.add(groupString);
+              }
             }
-          }
-          Set<String> rodaGroups = mapCasGroupstoRODAGroups(casGroups);
-          if (!user.getGroups().equals(rodaGroups)) {
-            user.setGroups(rodaGroups);
+            Set<String> rodaGroups = mapCasGroupstoRODAGroups(casGroups);
+            if (!user.getGroups().equals(rodaGroups)) {
+              user.setGroups(rodaGroups);
+            }
           }
         }
       }
       RodaCoreFactory.getModelService().updateUser(user, null, true);
+      try {
+        PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(),
+          RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+      } catch (Exception e) {
+        LOGGER.warn("Could not update PREMIS agent for CAS user '{}'", user.getName(), e);
+      }
     }
 
     if (!user.isActive()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -23,7 +23,6 @@ import javax.crypto.SecretKey;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.authentication.AttributePrincipal;
 import org.roda.core.RodaCoreFactory;
-import org.roda.core.common.PremisV3Utils;
 import org.roda.core.common.JwtUtils;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
@@ -193,8 +192,7 @@ public class MembersController implements MembersRestService, Exportable {
 
       user = RodaCoreFactory.getModelService().createUser(user, true);
       try {
-        PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(),
-          RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+        RodaCoreFactory.getModelService().createOrUpdateUserAgentBinary(user.getName());
       } catch (Exception e) {
         LOGGER.warn("Could not create PREMIS agent for CAS user '{}'", user.getName(), e);
       }
@@ -227,8 +225,7 @@ public class MembersController implements MembersRestService, Exportable {
       }
       RodaCoreFactory.getModelService().updateUser(user, null, true);
       try {
-        PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(),
-          RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+        RodaCoreFactory.getModelService().createOrUpdateUserAgentBinary(user.getName());
       } catch (Exception e) {
         LOGGER.warn("Could not update PREMIS agent for CAS user '{}'", user.getName(), e);
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
@@ -23,7 +23,6 @@ import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.common.Messages;
-import org.roda.core.common.PremisV3Utils;
 import org.roda.core.common.notifications.EmailNotificationProcessor;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
@@ -248,7 +247,7 @@ public class MembersService {
     IndexService index = RodaCoreFactory.getIndexService();
     User addedUser = model.createUser(user, password, true);
     try {
-      PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(), model, index, true);
+      model.createOrUpdateUserAgentBinary(user.getName());
     } catch (Exception e) {
       LOGGER.warn("Could not create PREMIS agent for user '{}'", user.getName(), e);
     }
@@ -301,8 +300,7 @@ public class MembersService {
     User confirmedUser = RodaCoreFactory.getModelService().confirmUserEmail(username, email, emailConfirmationToken,
       true, true);
     try {
-      PremisV3Utils.createOrUpdatePremisUserAgentBinary(confirmedUser.getName(),
-        RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+      RodaCoreFactory.getModelService().createOrUpdateUserAgentBinary(confirmedUser.getName());
     } catch (Exception e) {
       LOGGER.warn("Could not create PREMIS agent for confirmed user '{}'", confirmedUser.getName(), e);
     }
@@ -311,12 +309,10 @@ public class MembersService {
 
   public User updateUser(UpdateUserRequest request) throws GenericException, AlreadyExistsException, NotFoundException,
     AuthorizationDeniedException, ValidationException, RequestNotValidException {
-    ModelService model = RodaCoreFactory.getModelService();
-    IndexService index = RodaCoreFactory.getIndexService();
     request.getUser().setExtra(request.getValues());
     User modifiedUser = RodaCoreFactory.getModelService().updateUser(request.getUser(), request.getPassword(), true);
     try {
-      PremisV3Utils.createOrUpdatePremisUserAgentBinary(request.getUser().getName(), model, index, true);
+      RodaCoreFactory.getModelService().createOrUpdateUserAgentBinary(request.getUser().getName());
     } catch (Exception e) {
       LOGGER.warn("Could not update PREMIS agent for user '{}'", request.getUser().getName(), e);
     }
@@ -340,7 +336,7 @@ public class MembersService {
 
     User finalModifiedUser = model.updateMyUser(resetUser, password, true);
     try {
-      PremisV3Utils.createOrUpdatePremisUserAgentBinary(resetUser.getName(), model, index, true);
+      model.createOrUpdateUserAgentBinary(resetUser.getName());
     } catch (Exception e) {
       LOGGER.warn("Could not update PREMIS agent for user '{}'", resetUser.getName(), e);
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
@@ -247,7 +247,11 @@ public class MembersService {
     ModelService model = RodaCoreFactory.getModelService();
     IndexService index = RodaCoreFactory.getIndexService();
     User addedUser = model.createUser(user, password, true);
-    PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(), model, index, false);
+    try {
+      PremisV3Utils.createOrUpdatePremisUserAgentBinary(user.getName(), model, index, true);
+    } catch (Exception e) {
+      LOGGER.warn("Could not create PREMIS agent for user '{}'", user.getName(), e);
+    }
     index.commit(true, RODAMember.class);
     return addedUser;
   }
@@ -294,7 +298,15 @@ public class MembersService {
 
   public User confirmUserEmail(String username, String email, String emailConfirmationToken)
     throws InvalidTokenException, NotFoundException, GenericException {
-    return RodaCoreFactory.getModelService().confirmUserEmail(username, email, emailConfirmationToken, true, true);
+    User confirmedUser = RodaCoreFactory.getModelService().confirmUserEmail(username, email, emailConfirmationToken,
+      true, true);
+    try {
+      PremisV3Utils.createOrUpdatePremisUserAgentBinary(confirmedUser.getName(),
+        RodaCoreFactory.getModelService(), RodaCoreFactory.getIndexService(), true);
+    } catch (Exception e) {
+      LOGGER.warn("Could not create PREMIS agent for confirmed user '{}'", confirmedUser.getName(), e);
+    }
+    return confirmedUser;
   }
 
   public User updateUser(UpdateUserRequest request) throws GenericException, AlreadyExistsException, NotFoundException,
@@ -303,7 +315,11 @@ public class MembersService {
     IndexService index = RodaCoreFactory.getIndexService();
     request.getUser().setExtra(request.getValues());
     User modifiedUser = RodaCoreFactory.getModelService().updateUser(request.getUser(), request.getPassword(), true);
-    PremisV3Utils.createOrUpdatePremisUserAgentBinary(request.getUser().getName(), model, index, false);
+    try {
+      PremisV3Utils.createOrUpdatePremisUserAgentBinary(request.getUser().getName(), model, index, true);
+    } catch (Exception e) {
+      LOGGER.warn("Could not update PREMIS agent for user '{}'", request.getUser().getName(), e);
+    }
     RodaCoreFactory.getIndexService().commit(true, RODAMember.class);
     return modifiedUser;
   }
@@ -323,7 +339,11 @@ public class MembersService {
     User resetUser = resetUser(modifiedUser, currentUser);
 
     User finalModifiedUser = model.updateMyUser(resetUser, password, true);
-    PremisV3Utils.createOrUpdatePremisUserAgentBinary(resetUser.getName(), model, index, false);
+    try {
+      PremisV3Utils.createOrUpdatePremisUserAgentBinary(resetUser.getName(), model, index, true);
+    } catch (Exception e) {
+      LOGGER.warn("Could not update PREMIS agent for user '{}'", resetUser.getName(), e);
+    }
     index.commit(true, RODAMember.class);
     return finalModifiedUser;
   }


### PR DESCRIPTION
## Sammanfattning

Åtgärdar #374 — bevarandehändelser visade tomt innehåll eftersom PREMIS-agenten för den utförande användaren saknades i Solr, vilket orsakade ett NotFoundException innan UI:t hann populera några fält.

Rotorsak: `createOrUpdatePremisUserAgentBinary` anropades med `notify=false` i alla skrivflöden för användare, vilket sparade agent-binären till disk men aldrig indexerade den i Solr. Vid serverstart kör `indexUsersAndGroupsFromLDAP` och re-indexerar alla agenter, men användare som skapades efter start (eller när den rutinen misslyckades tyst) fick aldrig sin agent i Solr.

- **Indexera alltid PREMIS-agent i Solr vid skapa/uppdatera användare** — `MembersService`: ändrat `notify=false` → `true` i `createUser`, `updateUser`, `updateMyUser`. Lade till PREMIS-anrop i `confirmUserEmail` för självregistrerade användare (agenten skapas när kontot aktiveras, inte vid registreringen). Stänger #415.

- **Re-indexera alltid PREMIS-agent i Solr i addAgent oavsett lagringstillstånd** — `PluginHelper.addAgent` hoppade över `createOrUpdatePremisUserAgentBinary` när binären redan fanns på disk, vilket innebar att agenter som fanns på disk men saknades i Solr aldrig återhämtades. Stänger #416.

- **Indexera PREMIS-agent i Solr vid CAS-inloggning och skydda mot null-dereference på attributes** — `casLoginHelper` kringgick `MembersService` helt, så CAS-användare fick aldrig sin agent indexerad. Lade till `createOrUpdatePremisUserAgentBinary` efter både skapa- och uppdatera-flödena, wrappat i try/catch så att ett fel inte blockerar inloggningen. Åtgärdade även en befintlig null-dereference på `attributes` i den befintliga-användare-grenen.

- **Inkludera användarnamn och undantag i PREMIS-agentens startupfellogg** — `indexUsersAndGroupsFromLDAP` loggade bara ett generellt meddelande, vilket omöjliggjorde diagnos av vilken användare eller varför det misslyckades.

## Tillfällig lösning

Tills denna fix är driftsatt, kör jobbet **"Återindexera bevarandeagentindex"** via Arkivvårdsjobb → Starta ny process.

## Testplan

- [ ] Skapa en ny användare och verifiera att bevarandehändelser kopplade till den användaren visar korrekt innehåll
- [ ] Uppdatera en befintlig användare och verifiera att agent-metadata uppdateras i Solr
- [ ] (CAS-miljöer) Logga in med CAS för första gången och verifiera att bevarandehändelser för den användaren visas korrekt
- [ ] Verifiera att workaround-jobbet fortfarande fungerar som förväntat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatisk skapande/uppdatering av bevarandeagent för användare för bättre metadatahantering.

* **Bug Fixes**
  * Robustare användarprovisionering: fel vid agenthantering loggas som varningar istället för att stoppa flödet.
  * Förbättrad felrapportering vid LDAP-indexering — mer specifik felinformation för enklare felsökning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->