### PR TITLE
fix: navigera till AIP efter borttagning av representation (#410)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationActionsToolbar.java
@@ -59,6 +59,7 @@ public class BrowseRepresentationActionsToolbar extends BrowseObjectActionsToolb
     RepresentationToolbarActions representationActions = RepresentationToolbarActions.get(object.getAipId(), state,
       actionPermissions);
     this.actions.add(new ActionableWidgetBuilder<IndexedRepresentation>(representationActions)
+      .withActionCallback(actionCallback)
       .buildGroupedListWithObjects(new ActionableObject<>(object)));
 
   }


### PR DESCRIPTION
## Sammanfattning

När en representation togs bort och användaren valde "Nej" i dialogen som frågar om man vill följa jobbet, stannade vyn kvar på representationssidan. Användaren var tvungen att navigera bort manuellt.

Felet berodde på en saknad koppling i actions-toolbaren för representationer — borttagningssignalen nådde aldrig den del av vyn som ansvarar för navigering. En enradsfix kopplar ihop signalen korrekt.

## Testplan

- [ ] Navigera till en representation
- [ ] Ta bort representationen via actions-toolbaren
- [ ] Bekräfta borttagningen
- [ ] Välj **Nej** i dialogen som frågar om du vill följa jobbet
- [ ] Förväntat: vyn navigerar automatiskt till det överordnade AIP:et
- [ ] Kontrollera att AIP-borttagning fortfarande fungerar som vanligt (ska inte påverkas)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Buggfixar**
  * Förbättrad hantering av åtgärdsåterringar i representationsverktygsfältet för att säkerställa korrekt funktionalitet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/421)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->