### PR TITLE
fix: uppdatera representationsstatistik vid filoperationer (#362 #363 #364)

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -998,7 +998,21 @@ public class IndexModelObserver implements ModelObserver {
     try {
       AIP aip = model.retrieveAIP(file.getAipId());
       List<String> ancestors = SolrUtils.getAncestors(aip.getParentId(), model);
-      indexFile(aip, file, ancestors, true).addTo(ret);
+      Long size = indexFile(aip, file, ancestors, true).addTo(ret).getReturnedObject();
+
+      // ret.isEmpty() = no exceptions from indexFile; do not update stats on partial failure
+      if (ret.isEmpty() && size != null) {
+        String repUUID = IdUtils.getRepresentationId(file.getAipId(), file.getRepresentationId());
+        Map<String, Long> increments = new HashMap<>();
+        if (file.isDirectory()) {
+          increments.put(RodaConstants.REPRESENTATION_NUMBER_OF_DATA_FOLDERS, 1L);
+        } else {
+          increments.put(RodaConstants.REPRESENTATION_NUMBER_OF_DATA_FILES, 1L);
+        }
+        increments.put(RodaConstants.REPRESENTATION_SIZE_IN_BYTES, size);
+        SolrUtils.atomicIncrement(index, IndexedRepresentation.class, repUUID, increments, (ModelObserver) this)
+          .addTo(ret);
+      }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Error indexing file: {}", file, e);
       ret.add(e);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -1036,7 +1036,7 @@ public class IndexModelObserver implements ModelObserver {
 
     String uuid = IdUtils.getFileId(aipId, representationId, fileDirectoryPath, fileId);
 
-    // Läs filens metadata innan borttagning — behövs för att dekrementera representationsräknarna
+    // Read file metadata before deletion to update representation counters
     IndexedFile indexedFile = null;
     try {
       List<String> fields = Arrays.asList(RodaConstants.INDEX_UUID, RodaConstants.FILE_SIZE,
@@ -1049,10 +1049,8 @@ public class IndexModelObserver implements ModelObserver {
       ret.add(e);
     }
 
-    // Ta alltid bort fildokumentet (idempotent operation)
     deleteDocumentFromIndex(IndexedFile.class, uuid).addTo(ret);
 
-    // Dekrementera representationsräknarna om vi lyckades hämta filens metadata
     if (indexedFile != null) {
       String repUUID = IdUtils.getRepresentationId(aipId, representationId);
       Map<String, Long> decrements = new HashMap<>();

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -1035,7 +1035,36 @@ public class IndexModelObserver implements ModelObserver {
     ReturnWithExceptions<Void, ModelObserver> ret = new ReturnWithExceptions<>(this);
 
     String uuid = IdUtils.getFileId(aipId, representationId, fileDirectoryPath, fileId);
+
+    // Läs filens metadata innan borttagning — behövs för att dekrementera representationsräknarna
+    IndexedFile indexedFile = null;
+    try {
+      List<String> fields = Arrays.asList(RodaConstants.INDEX_UUID, RodaConstants.FILE_SIZE,
+        RodaConstants.FILE_ISDIRECTORY);
+      indexedFile = SolrUtils.retrieve(index, IndexedFile.class, uuid, fields);
+    } catch (NotFoundException e) {
+      LOGGER.warn("File not found in index before deletion, representation stats will not be updated: {}", uuid);
+    } catch (GenericException e) {
+      LOGGER.error("Error retrieving file from index before deletion: {}", uuid, e);
+      ret.add(e);
+    }
+
+    // Ta alltid bort fildokumentet (idempotent operation)
     deleteDocumentFromIndex(IndexedFile.class, uuid).addTo(ret);
+
+    // Dekrementera representationsräknarna om vi lyckades hämta filens metadata
+    if (indexedFile != null) {
+      String repUUID = IdUtils.getRepresentationId(aipId, representationId);
+      Map<String, Long> decrements = new HashMap<>();
+      if (indexedFile.isDirectory()) {
+        decrements.put(RodaConstants.REPRESENTATION_NUMBER_OF_DATA_FOLDERS, -1L);
+      } else {
+        decrements.put(RodaConstants.REPRESENTATION_NUMBER_OF_DATA_FILES, -1L);
+      }
+      decrements.put(RodaConstants.REPRESENTATION_SIZE_IN_BYTES, -indexedFile.getSize());
+      SolrUtils.atomicIncrement(index, IndexedRepresentation.class, repUUID, decrements, (ModelObserver) this)
+        .addTo(ret);
+    }
 
     if (deleteIncidences) {
       deleteDocumentsFromIndex(RiskIncidence.class, RodaConstants.RISK_INCIDENCE_FILE_ID, fileId).addTo(ret);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -1547,6 +1547,25 @@ public class SolrUtils {
     return ret;
   }
 
+  public static <T extends IsIndexed, S extends Object> ReturnWithExceptions<Void, S> atomicIncrement(
+    SolrClient index, Class<T> classToCreate, String uuid, Map<String, Long> increments, S source) {
+    ReturnWithExceptions<Void, S> ret = new ReturnWithExceptions<>(source);
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.addField(RodaConstants.INDEX_UUID, uuid);
+    increments.forEach((key, delta) -> {
+      Map<String, Object> modifier = new HashMap<>(1);
+      modifier.put("inc", delta);
+      doc.addField(key, modifier);
+    });
+    try {
+      create(index, SolrCollectionRegistry.getIndexName(classToCreate), doc, source).addTo(ret);
+    } catch (NotSupportedException e) {
+      LOGGER.error("Error incrementing document in index", e);
+      ret.add(e);
+    }
+    return ret;
+  }
+
   private static Map<String, Object> set(Object value) {
     Map<String, Object> fieldModifier = new HashMap<>(1);
     // 20160511 this workaround fixes solr wrong behaviour with partial update

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -1547,6 +1547,20 @@ public class SolrUtils {
     return ret;
   }
 
+  /**
+   * Atomically increments or decrements numeric fields in a Solr document using Solr's "inc" modifier.
+   * This method is thread-safe and can be used to update counters (e.g., file counts, sizes) without 
+   * race conditions.
+   *
+   * `@param` <T> the indexed class type
+   * `@param` <S> the source object type
+   * `@param` index the Solr client
+   * `@param` classToCreate the class of the document to update
+   * `@param` uuid the document ID
+   * `@param` increments a map of field names to increment deltas (positive to increment, negative to decrement)
+   * `@param` source the source object for error tracking
+   * `@return` a ReturnWithExceptions containing any NotSupportedException that occurred
+   */
   public static <T extends IsIndexed, S extends Object> ReturnWithExceptions<Void, S> atomicIncrement(
     SolrClient index, Class<T> classToCreate, String uuid, Map<String, Long> increments, S source) {
     ReturnWithExceptions<Void, S> ret = new ReturnWithExceptions<>(source);


### PR DESCRIPTION
## Sammanfattning

Representationens räknare för antal filer, mappar och total storlek uppdaterades inte när filer skapades eller togs bort manuellt, efter maskning, eller efter ett konverteringsjobb. Räknarna uppdaterades bara vid en full omindexering av hela AIP:et.

Felet berodde på att indexeringslogiken som hanterar enskilda filhändelser aldrig uppdaterade representationens sammanfattningsdokument i Solr — bara fildokumentet.

Lösningen lägger till atomiska räknaruppdateringar direkt vid varje filhändelse, utan att röra den befintliga omindexeringspipelinen.

## Ändringar

- `SolrUtils.java` — ny hjälpmetod `atomicIncrement()` som använder Solrs inbyggda `inc`-modifier för trådsäkra räknaruppdateringar
- `IndexModelObserver.java` — `fileCreated()` och `fileDeleted()` ökar respektive minskar representationens räknare atomiskt vid varje filhändelse

## Testplan

- [ ] Skapa en mapp i en representation — antal mappar ökar med 1, storlek oförändrad
- [ ] Lägg till en fil — antal filer ökar med 1, storlek ökar med filens storlek
- [ ] Ta bort filen — antal filer minskar med 1, storlek återgår
- [ ] Kör ett konverteringsjobb — den nya representationen visar korrekta räknare direkt efter jobbet
- [ ] Utför maskning — representationen visar korrekt antal filer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Buggfixar
* Förbättrad spårning av indexstatistik för fil- och mappräknare vid skapande och radering av filer
* Bättre konsistens mellan filindex och representationräknare för mappstrukturer
* Mer tillförlitlig registrering av lagringsstorlek i indexet
* Förbättrad felhantering för saknade eller felaktigt indexerade dokument under filoperationer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/422)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->