### PR TITLE
feat(katalogträd): infällbar trädvy, matchande ikoner med övrig katalog

### DIFF
--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2712,4 +2712,10 @@ public interface ClientMessages extends Messages {
   String catalogTreeLoadError();
 
   String catalogTreeRetry();
+
+  String catalogTreeRootLabel();
+
+  String catalogTreeCollapse();
+
+  String catalogTreeExpand();
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -22,6 +22,7 @@ import org.roda.core.data.v2.index.sublist.Sublist;
 import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.ClientLogger;
+import org.roda.wui.common.client.tools.DescriptionLevelUtils;
 import org.roda.wui.common.client.tools.HistoryUtils;
 
 import com.google.gwt.core.client.GWT;
@@ -47,9 +48,6 @@ public class CatalogTreeNode extends Composite {
   private static final String ICON_TOGGLE_COLLAPSED = "<span class='fas fa-chevron-right'></span>";
   private static final String ICON_TOGGLE_EXPANDED = "<span class='fas fa-chevron-down'></span>";
   private static final String ICON_TOGGLE_LOADING = "<span class='fas fa-circle-notch fa-spin'></span>";
-  private static final String ICON_FOLDER_CLOSED = "<span class='fas fa-folder'></span>";
-  private static final String ICON_FOLDER_OPEN_STR = "<span class='fas fa-folder-open'></span>";
-  private static final String ICON_FILE_LEAF = "<span class='fas fa-folder'></span>";
 
   private final String aipId;
   private final String title;
@@ -58,7 +56,6 @@ public class CatalogTreeNode extends Composite {
   private final FlowPanel rowPanel;
   private final FlowPanel childrenPanel;
   private final HTML toggleHtml;
-  private final HTML iconHtml;
   private final Map<String, CatalogTreeNode> childNodes = new HashMap<>();
 
   private boolean expanded = false;
@@ -66,7 +63,7 @@ public class CatalogTreeNode extends Composite {
   private boolean isLeaf = false;
   private Command pendingOnComplete = null;
 
-  public CatalogTreeNode(String aipId, String title, int depth) {
+  public CatalogTreeNode(String aipId, String title, String level, int depth) {
     this.aipId = aipId;
     this.title = title;
     this.depth = depth;
@@ -86,7 +83,7 @@ public class CatalogTreeNode extends Composite {
     toggleHtml.setStyleName("catalogTreeToggle");
     rowPanel.add(toggleHtml);
 
-    iconHtml = new HTML(ICON_FOLDER_CLOSED);
+    HTML iconHtml = new HTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(level, false));
     iconHtml.setStyleName("catalogTreeIcon");
     rowPanel.add(iconHtml);
 
@@ -137,7 +134,6 @@ public class CatalogTreeNode extends Composite {
       childrenPanel.setVisible(true);
       expanded = true;
       toggleHtml.setHTML(ICON_TOGGLE_EXPANDED);
-      iconHtml.setHTML(ICON_FOLDER_OPEN_STR);
       if (onComplete != null) onComplete.execute();
     } else {
       loadChildren(onComplete);
@@ -174,14 +170,13 @@ public class CatalogTreeNode extends Composite {
           markAsLeaf();
         } else {
           for (IndexedAIP child : children) {
-            CatalogTreeNode childNode = new CatalogTreeNode(child.getId(), child.getTitle(), depth + 1);
+            CatalogTreeNode childNode = new CatalogTreeNode(child.getId(), child.getTitle(), child.getLevel(), depth + 1);
             childNodes.put(child.getId(), childNode);
             childrenPanel.add(childNode);
           }
           childrenPanel.setVisible(true);
           expanded = true;
           toggleHtml.setHTML(ICON_TOGGLE_EXPANDED);
-          iconHtml.setHTML(ICON_FOLDER_OPEN_STR);
         }
         if (onComplete != null) onComplete.execute();
       });
@@ -190,7 +185,6 @@ public class CatalogTreeNode extends Composite {
   private void markAsLeaf() {
     isLeaf = true;
     toggleHtml.setHTML("");
-    iconHtml.setHTML(ICON_FILE_LEAF);
   }
 
   private void showLoadError() {
@@ -215,7 +209,6 @@ public class CatalogTreeNode extends Composite {
     childrenPanel.setVisible(false);
     expanded = false;
     toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
-    iconHtml.setHTML(ICON_FOLDER_CLOSED);
   }
 
   public void select() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -144,6 +144,7 @@ public class CatalogTreePanel extends Composite {
   private void loadRootNodes() {
     treeBody.clear();
     rootNodes.clear();
+    rootsLoaded = false;
 
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -31,10 +31,10 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -60,10 +60,10 @@ public class CatalogTreePanel extends Composite {
   TextBox filterInput;
 
   @UiField
-  HTML collapseToggle;
+  Button collapseToggle;
 
   @UiField
-  HTML expandButton;
+  Button expandButton;
 
   @UiField
   Anchor headerTitle;
@@ -94,6 +94,8 @@ public class CatalogTreePanel extends Composite {
 
     collapseToggle.setHTML(ICON_COLLAPSE);
     collapseToggle.setTitle(messages.catalogTreeCollapse());
+    collapseToggle.getElement().setAttribute("aria-label", messages.catalogTreeCollapse());
+    collapseToggle.getElement().setAttribute("aria-expanded", "true");
     collapseToggle.addClickHandler(e -> {
       e.stopPropagation();
       setCollapsed(true);
@@ -101,6 +103,8 @@ public class CatalogTreePanel extends Composite {
 
     expandButton.setHTML(ICON_EXPAND);
     expandButton.setTitle(messages.catalogTreeExpand());
+    expandButton.getElement().setAttribute("aria-label", messages.catalogTreeExpand());
+    expandButton.getElement().setAttribute("aria-expanded", "false");
     expandButton.addClickHandler(e -> setCollapsed(false));
 
     headerTitle.setTitle(messages.catalogTreeTitle());
@@ -116,6 +120,8 @@ public class CatalogTreePanel extends Composite {
     } else {
       removeStyleName("collapsed");
     }
+    collapseToggle.getElement().setAttribute("aria-expanded", collapse ? "false" : "true");
+    expandButton.getElement().setAttribute("aria-expanded", collapse ? "false" : "true");
   }
 
   private void onFilterChanged(KeyUpEvent event) {
@@ -136,6 +142,9 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void loadRootNodes() {
+    treeBody.clear();
+    rootNodes.clear();
+
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new EmptyKeyFilterParameter(RodaConstants.AIP_PARENT_ID),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -33,6 +33,8 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -46,6 +48,9 @@ public class CatalogTreePanel extends Composite {
   /** Maximum number of root nodes to load in the catalog tree. */
   private static final int TREE_MAX_CHILDREN = 10_000;
 
+  private static final String ICON_COLLAPSE = "<i class='fas fa-angle-double-left'></i>";
+  private static final String ICON_EXPAND = "<i class='fas fa-angle-double-right'></i>";
+
   interface MyUiBinder extends UiBinder<Widget, CatalogTreePanel> {}
 
   @UiField
@@ -53,6 +58,15 @@ public class CatalogTreePanel extends Composite {
 
   @UiField
   TextBox filterInput;
+
+  @UiField
+  HTML collapseToggle;
+
+  @UiField
+  HTML expandButton;
+
+  @UiField
+  Anchor headerTitle;
 
   private static CatalogTreePanel instance = null;
 
@@ -77,7 +91,31 @@ public class CatalogTreePanel extends Composite {
         onFilterChanged(event);
       }
     });
+
+    collapseToggle.setHTML(ICON_COLLAPSE);
+    collapseToggle.setTitle(messages.catalogTreeCollapse());
+    collapseToggle.addClickHandler(e -> {
+      e.stopPropagation();
+      setCollapsed(true);
+    });
+
+    expandButton.setHTML(ICON_EXPAND);
+    expandButton.setTitle(messages.catalogTreeExpand());
+    expandButton.addClickHandler(e -> setCollapsed(false));
+
+    headerTitle.setTitle(messages.catalogTreeTitle());
+    headerTitle.setHref(org.roda.wui.common.client.tools.HistoryUtils.createHistoryHashLink(BrowseTop.RESOLVER));
+
     loadRootNodes();
+  }
+
+  private void setCollapsed(boolean collapse) {
+    if (collapse) {
+      addStyleName("collapsed");
+      getElement().getStyle().clearWidth();
+    } else {
+      removeStyleName("collapsed");
+    }
   }
 
   private void onFilterChanged(KeyUpEvent event) {
@@ -125,7 +163,7 @@ public class CatalogTreePanel extends Composite {
           return;
         }
         for (IndexedAIP aip : result.getResults()) {
-          CatalogTreeNode node = new CatalogTreeNode(aip.getId(), aip.getTitle(), 0);
+          CatalogTreeNode node = new CatalogTreeNode(aip.getId(), aip.getTitle(), aip.getLevel(), 0);
           rootNodes.put(aip.getId(), node);
           treeBody.add(node);
         }
@@ -182,9 +220,11 @@ public class CatalogTreePanel extends Composite {
       selectedNode.deselect();
       selectedNode = null;
     }
+    headerTitle.addStyleName("active");
   }
 
   private void selectNode(String aipId) {
+    headerTitle.removeStyleName("active");
     if (selectedNode != null) selectedNode.deselect();
     CatalogTreeNode node = findNode(aipId, rootNodes);
     if (node != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
@@ -6,10 +6,10 @@
     <ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
     <g:FlowPanel styleName="catalogTreePanel">
-        <g:HTML ui:field="expandButton" styleName="catalogTreeExpandButton" />
+        <g:Button ui:field="expandButton" styleName="catalogTreeExpandButton" />
         <g:FlowPanel styleName="catalogTreePanelHeader">
             <g:Anchor ui:field="headerTitle" styleName="catalogTreePanelHeaderTitle" text="{messages.catalogTreeTitle}" />
-            <g:HTML ui:field="collapseToggle" styleName="catalogTreeCollapseToggle" />
+            <g:Button ui:field="collapseToggle" styleName="catalogTreeCollapseToggle" />
         </g:FlowPanel>
         <g:FlowPanel styleName="catalogTreeFilter">
             <g:TextBox ui:field="filterInput" styleName="catalogTreeFilterInput" />

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.ui.xml
@@ -6,6 +6,11 @@
     <ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
     <g:FlowPanel styleName="catalogTreePanel">
+        <g:HTML ui:field="expandButton" styleName="catalogTreeExpandButton" />
+        <g:FlowPanel styleName="catalogTreePanelHeader">
+            <g:Anchor ui:field="headerTitle" styleName="catalogTreePanelHeaderTitle" text="{messages.catalogTreeTitle}" />
+            <g:HTML ui:field="collapseToggle" styleName="catalogTreeCollapseToggle" />
+        </g:FlowPanel>
         <g:FlowPanel styleName="catalogTreeFilter">
             <g:TextBox ui:field="filterInput" styleName="catalogTreeFilterInput" />
         </g:FlowPanel>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3349,12 +3349,53 @@ td.datePickerMonth, td.datePickerYear {
 .catalogTreePanel {
     width: 260px;
     min-width: 150px;
+    height: 100%;
     flex-shrink: 0;
     background: white;
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    position: relative;
 }
+
+/* Collapsed drawer: panel shrinks to a thin rail; only the expand button remains visible. */
+.catalogTreePanel.collapsed { width: 36px !important; min-width: 36px; }
+.catalogTreePanel.collapsed .catalogTreePanelHeader,
+.catalogTreePanel.collapsed .catalogTreeFilter,
+.catalogTreePanel.collapsed .catalogTreeBodyScroll { display: none; }
+.catalogTreePanel.collapsed .catalogTreeExpandButton { display: flex; }
+.catalogTreePanel.collapsed + .catalogTreeResizeHandle { visibility: hidden; }
+
+.catalogTreePanelHeader {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 12px 8px;
+    flex-shrink: 0;
+}
+
+.catalogTreePanelHeaderTitle {
+    font-size: 16px; font-weight: 700; color: #1F2937;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
+}
+.catalogTreePanelHeaderTitle:hover { color: COLOR_PRIMARY; }
+.catalogTreePanelHeaderTitle.active { color: COLOR_PRIMARY; }
+
+.catalogTreeCollapseToggle {
+    width: 22px; height: 22px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; color: #111827; font-size: 14px;
+    border-radius: 3px;
+}
+.catalogTreeCollapseToggle:hover { background: rgba(0, 0, 0, 0.06); }
+
+.catalogTreeExpandButton {
+    display: none; align-items: center; justify-content: center;
+    width: 22px; height: 22px; margin: 8px auto 0;
+    cursor: pointer; color: #111827; font-size: 14px;
+    border-radius: 3px;
+}
+.catalogTreeExpandButton:hover { background: rgba(0, 0, 0, 0.06); }
 
 .catalogTreeResizeHandle {
     width: 3px;
@@ -3389,17 +3430,6 @@ body.catalogTreeResizing * {
     background: white;
     color: #333333;
     box-sizing: border-box;
-}
-
-.catalogTreePanelHeader {
-    background: COLOR_GREY_DARK;
-    color: COLOR_GREY_LIGHT;
-    padding: 10px 14px;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    flex-shrink: 0;
 }
 
 .catalogTreeBodyScroll {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3356,6 +3356,7 @@ td.datePickerMonth, td.datePickerYear {
     flex-direction: column;
     overflow: hidden;
     position: relative;
+    transition: width 0.2s ease-in-out, min-width 0.2s ease-in-out;
 }
 
 /* Collapsed drawer: panel shrinks to a thin rail; only the expand button remains visible. */
@@ -3386,16 +3387,34 @@ td.datePickerMonth, td.datePickerYear {
     display: flex; align-items: center; justify-content: center;
     cursor: pointer; color: #111827; font-size: 14px;
     border-radius: 3px;
+    background: transparent;
+    border: none;
+    padding: 0;
 }
 .catalogTreeCollapseToggle:hover { background: rgba(0, 0, 0, 0.06); }
+.catalogTreeCollapseToggle:focus,
+.catalogTreeCollapseToggle:focus-visible {
+    background: rgba(0, 0, 0, 0.06);
+    outline: 2px solid COLOR_PRIMARY;
+    outline-offset: 2px;
+}
 
 .catalogTreeExpandButton {
     display: none; align-items: center; justify-content: center;
     width: 22px; height: 22px; margin: 8px auto 0;
     cursor: pointer; color: #111827; font-size: 14px;
     border-radius: 3px;
+    background: transparent;
+    border: none;
+    padding: 0;
 }
 .catalogTreeExpandButton:hover { background: rgba(0, 0, 0, 0.06); }
+.catalogTreeExpandButton:focus,
+.catalogTreeExpandButton:focus-visible {
+    background: rgba(0, 0, 0, 0.06);
+    outline: 2px solid COLOR_PRIMARY;
+    outline-offset: 2px;
+}
 
 .catalogTreeResizeHandle {
     width: 3px;

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1874,3 +1874,6 @@ catalogTreeFilterPlaceholder: Filter...
 catalogTreeLoadingLabel: Loading...
 catalogTreeLoadError: Could not load content
 catalogTreeRetry: Try again
+catalogTreeRootLabel: Catalogue
+catalogTreeCollapse: Collapse archive tree
+catalogTreeExpand: Expand archive tree

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1789,3 +1789,6 @@ conversionOutcomeDescription: En konvertering kan skapa en representation eller 
 outcomeTypeRepresentation: Representation
 outcomeTypeDissemination: Spridning
 catalogTreeRetry: Försök igen
+catalogTreeRootLabel: Katalog
+catalogTreeCollapse: Fäll in arkivträdet
+catalogTreeExpand: Fäll ut arkivträdet


### PR DESCRIPTION
…-ikoner

Tre additiva förändringar på katalogträdets sidopanel, ovanpå eterna-v1-alpha-baseline:

* Header-rad återinförs i panelens topp. "Katalog" (catalogTreeTitle) är klickbar — bara texten själv — och navigerar till BrowseTop. Bredvid titeln sitter en collapse-chevron (`«`) som fäller in panelen till en 36px-skena. I infällt läge visas en expand-chevron (`»`) på samma plats. Båda chevronerna är 22×22 i ink-svart med identisk hover-bakgrund.

* Drag-handtaget döljs automatiskt när panelen är kollapsad så det inte går att dra inline-width som ändå inte vinner mot CSS-regeln.

* Trädnoderna får nivå-baserade ikoner via samma anrop som huvudkatalogen använder: DescriptionLevelUtils.getElementLevelIconSafeHtml(level, false).

Klick på rubriken är wired som <g:Anchor> med
HistoryUtils.createHistoryHashLink — naturlig keyboard-/Tab- aktivering, högerklick-meny för "öppna i ny flik" m.m.

Endast styling- och layouttillägg — inga ändringar i actions, ingen event-bus, ingen live-update.

Closes #428
Closes #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nya funktioner
* Katalogträdpanelen kan nu sammanslås och expanderas med nya kontroller och en visuell header
* Panelen kan minimeras till en smal navigeringsrad för att spara skärmutrymme vid behov
* Trädelementens ikoner är nu intelligentare utformade baserat på deras roll i katalogen

## Förbättringar
* Uppdaterad styling och visuell feedback för bättre användarupplevelse

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/430)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->