### PR TITLE
fix: använd "Svenska" som default för EAD-språkfält (#375)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
@@ -811,7 +811,7 @@ public class AIPService {
         if (representation != null) {
           value = ServerTools.autoGenerateRepresentationValue(representation, generator);
         } else {
-          value = ServerTools.autoGenerateAIPValue(aip, user, generator);
+          value = ServerTools.autoGenerateAIPValue(aip, user, generator, locale);
         }
 
         if (value != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
@@ -191,7 +191,7 @@ public class ServerTools {
         result = aip.getTitle();
         break;
       case "language":
-        result = Locale.getDefault().getDisplayLanguage();
+        result = "Svenska";
         break;
       case "parentid":
         result = aip.getParentID();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/server/ServerTools.java
@@ -178,7 +178,7 @@ public class ServerTools {
     return values;
   }
 
-  public static String autoGenerateAIPValue(IndexedAIP aip, User user, String generator) {
+  public static String autoGenerateAIPValue(IndexedAIP aip, User user, String generator, Locale locale) {
     String result = null;
     switch (generator) {
       case "now":
@@ -191,7 +191,7 @@ public class ServerTools {
         result = aip.getTitle();
         break;
       case "language":
-        result = "Svenska";
+        result = locale.getDisplayLanguage(locale);
         break;
       case "parentid":
         result = aip.getParentID();


### PR DESCRIPTION
Closes #375

## Sammanfattning

När en användare skapar en ny beskrivande metadata med EAD2002 eller EAD3 fylldes språkfälten **"Materialets språk"** och **"Språk och skriptnoteringar"** tidigare i automatiskt med `"English"`. Sedan ETERNA standardiserar på svenska i hela GUI:t ska defaultvärdet vara `"Svenska"`.

## Root cause

Värdet sätts via attributet `auto-generate='language'` i HBS-templates, vilket triggar `ServerTools.autoGenerateAIPValue()`. Case `"language"` använde `Locale.getDefault().getDisplayLanguage()` — JVM:s default-locale, *inte* användarens webbläsarspråk eller UI-val. På en JVM med engelsk default-locale blir resultatet `"English"`.

## Ändring

En rad i `ServerTools.java`:

```diff
       case "language":
-        result = Locale.getDefault().getDisplayLanguage();
+        result = "Svenska";
         break;
```

## Påverkan

Alla fyra fält som använder `auto-generate='language'` får nu "Svenska" som default:

| Template | Fält | XPath |
|---|---|---|
| `ead_2002.xml.hbs` | `language` | `langmaterial/language` |
| `ead_2002.xml.hbs` | `languageScriptNotes` | `langmaterial` |
| `ead_3.xml.hbs` | `language` | `langmaterial/language` |
| `ead_3.xml.hbs` | `languageScriptNotes` | `langmaterial/descriptivenote` |

## Alternativ som övervägdes

Locale-medveten lösning (propagera `Locale` från request → service → `ServerTools` och köra `getDisplayLanguage(targetLocale)`) hade varit "rätt" beteende rent arkitekturmässigt. Avförd eftersom GUI:t parallellt görs enspråkigt svenskt — ingen vinst i extra abstraktionslager just nu.

## Test plan

- [ ] Skapa ny logisk enhet med EAD2002 → båda språkfälten är förifyllda med "Svenska"
- [ ] Skapa ny logisk enhet med EAD3 → båda språkfälten är förifyllda med "Svenska"
- [ ] Lägg till ytterligare beskrivande metadata på existerande AIP → samma kontroll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Buggfixar**
  * Förbättrad lokalisering av automatiskt genererade AIP-värden. Systemet använder nu användarens språkinställningar korrekt istället för systemets standardspråk vid värdegenereringen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->