### PR TITLE
fix: översätt labels i formulär för beskrivande metadata vid redigering

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
@@ -551,7 +551,7 @@ public class AIPService {
           descriptiveMetadataId + XML_EXT);
         String xml = IOUtils.toString(binary.getContent().createInputStream(), StandardCharsets.UTF_8);
 
-        Set<MetadataValue> result = getMetadataValuesFromDescriptiveMetadataFile(template, xml);
+        Set<MetadataValue> result = getMetadataValuesFromDescriptiveMetadataFile(template, xml, locale, messages);
 
         return new SupportedMetadataValue(result);
       } else {
@@ -585,7 +585,8 @@ public class AIPService {
     return false;
   }
 
-  private Set<MetadataValue> getMetadataValuesFromDescriptiveMetadataFile(String template, String xml) {
+  private Set<MetadataValue> getMetadataValuesFromDescriptiveMetadataFile(String template, String xml, Locale locale,
+    Messages messages) throws GenericException {
     Set<MetadataValue> values = ServerTools.transform(template);
     Set<MetadataValue> result = new TreeSet<>();
 
@@ -608,8 +609,8 @@ public class AIPService {
         }
         mv.set("value", value.trim());
       }
-      // getMetadataValueLabels(mv, locale, messages);
-      // getMetadataValueI18nPrefix(mv, locale, messages);
+      CommonServicesUtils.getMetadataValueLabels(mv, locale, messages);
+      CommonServicesUtils.getMetadataValueI18nPrefix(mv, locale, messages);
       result.add(mv);
     }
 


### PR DESCRIPTION
## Sammanfattning

När beskrivande metadata redan finns på disk gick `AIPService.retrieveSupportedMetadata` genom kodvägen `getMetadataValuesFromDescriptiveMetadataFile`, där anropen till `CommonServicesUtils.getMetadataValueLabels` och `getMetadataValueI18nPrefix` låg utkommenterade sedan commit `2ca4f5257` ("Improve exception handling", 2024-06-19). Resultatet blev att labels och dropdown-options inte berikades med svensk översättning, och klienten föll tillbaka på de inbyggda en/pt-värdena i template-filen.

Patchen utökar signaturen med `Locale` och `Messages` och aktiverar de två redan-befintliga anropen.

## Stänger

- Closes #391 — Metadataformulär för undernivå visar engelska fältnamn vid redigering
- Closes #417 — Bevarande metadata visas på engelska vid redigering trots svenska inställningar
- Closes #418 — Ytterligare bevarande metadata visas på engelska vid skapande trots svenska inställningar

## Rotorsaksanalys

Miguel Guimarães commit `2ca4f5257` refaktorerade `retrieveSupportedMetadata` att skilja på två fall:

1. **Metadata-fil finns inte** → `getDefaultDescriptiveMetadataValues()` läser template, applicerar `getMetadataValueLabels` + `getMetadataValueI18nPrefix` → labels översätts korrekt.
2. **Metadata-fil finns på disk** → ny metod `getMetadataValuesFromDescriptiveMetadataFile()` extraherar värden via xpath. Här lämnades översättningsanropen som `// TODO`-kommentarer eftersom hans nya helper-signatur saknade `Locale`/`Messages`.

Den dolda regressionen har funnits i ~11 månader och aktiveras först när användaren *redigerar* metadata efter första sparningen — exakt scenariot som de tre öppna issues rapporterar.

## Säkerhetsanalys

Funktionerna i `CommonServicesUtils` är **rent additiva**:

- `getMetadataValueLabels` berikar `label`-JSON-objektet med en `{"sv_SE": "..."}`-post utan att röra `"en"`/`"pt"`-värden eller xpath-extraherade `value`-attribut.
- `getMetadataValueI18nPrefix` gör samma sak för `optionsLabels` baserat på `optionsLabelI18nKeyPrefix`.
- Om en `labeli18n`-nyckel saknas i template → ingen åtgärd (`if (labels != null && labelI18N != null)`).
- Om en översättningsnyckel saknas för aktuellt locale → debug-log och fallback till befintliga en/pt-värden.

Samma anrop används redan från den parallella `getDefaultDescriptiveMetadataValues`-vägen utan kända biverkningar.

## Testplan

- [x] `mvn -pl roda-ui/roda-wui compile` lyckas
- [x] `javap` på den kompilerade klassen bekräftar fyra `invokestatic`-anrop till `getMetadataValueLabels`/`getMetadataValueI18nPrefix` (två i default-vägen + två nya i disk-vägen)
- [x] Manuell test med svenska valt:
  - [x] Skapa logisk enhet → labels visas på svenska (oförändrat — befintlig kodväg)
  - [x] Spara → öppna **Ändra** → labels visas nu på svenska (tidigare engelska)
- [ ] Granska att inga andra ställen i UI:t plockar upp `label`/`optionsLabels` på ett oförväntat sätt

## Diff-storlek

1 fil, +5/−4 rader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsanteckningar

* **Felrättningar**
  * Förbättrad hantering av metadatavärden med korrekt lokaliserad visning och internationalisering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->