### PR TITLE
fix(katalogträd): begränsa width-transition till collapse/expand

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -31,6 +31,7 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
@@ -114,6 +115,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void setCollapsed(boolean collapse) {
+    addStyleName("animatingCollapse");
     if (collapse) {
       addStyleName("collapsed");
       getElement().getStyle().clearWidth();
@@ -122,6 +124,12 @@ public class CatalogTreePanel extends Composite {
     }
     collapseToggle.getElement().setAttribute("aria-expanded", collapse ? "false" : "true");
     expandButton.getElement().setAttribute("aria-expanded", collapse ? "false" : "true");
+    new Timer() {
+      @Override
+      public void run() {
+        removeStyleName("animatingCollapse");
+      }
+    }.schedule(220);
   }
 
   private void onFilterChanged(KeyUpEvent event) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3356,6 +3356,9 @@ td.datePickerMonth, td.datePickerYear {
     flex-direction: column;
     overflow: hidden;
     position: relative;
+}
+
+.catalogTreePanel.animatingCollapse {
     transition: width 0.2s ease-in-out, min-width 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- Den globala `transition: width` på `.catalogTreePanel` gjorde att även drag-i-handtag för resize animerades pixel-för-pixel — handtaget kändes laggigt.
- Transitionen flyttas till en kortlivad `.animatingCollapse`-klass som `setCollapsed()` sätter vid collapse/expand och `Timer` tar bort efter 220 ms.
- Drag-resize blir direkt igen; collapse/expand animeras fortfarande mjukt.

## Test plan
- [ ] Klicka chevron `«` → panelen fäller in mjukt
- [ ] Klicka chevron `»` → panelen fälls ut mjukt
- [ ] Dra i `.catalogTreeResizeHandle` → bredden följer pekaren direkt utan eftersläp
- [ ] Verifiera i BrowseAIP, BrowseTop och BrowseRepresentation att resize-känslan är direkt

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Förbättrad animering för katalogträdpanelen – panelen får nu en smidig övergång vid kollaps och expansion.

* **Bug Fixes**
  * Åtgärdad CSS-styling för katalogträdpanelen för att garantera att animationsstilar tillämpas på rätt sätt.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/434)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->