### PR TITLE
fix: synkronisera katalogträdet vid AIP-operationer (#403, #407)

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -140,6 +140,7 @@ public class IndexModelObserver implements ModelObserver {
         SolrUtils.commit(index, IndexedAIP.class);
       } catch (GenericException e) {
         LOGGER.error("Error committing Solr after AIP creation", e);
+        ret.add(e);
       }
     }
 
@@ -788,11 +789,13 @@ public class IndexModelObserver implements ModelObserver {
       ret.add(e);
     }
 
-    try {
-      SolrUtils.commit(index, IndexedAIP.class);
-    } catch (GenericException e) {
-      LOGGER.error("Error committing Solr after AIP move", e);
-      ret.add(e);
+    if (ret.isEmpty()) {
+      try {
+        SolrUtils.commit(index, IndexedAIP.class);
+      } catch (GenericException e) {
+        LOGGER.error("Error committing Solr after AIP move", e);
+        ret.add(e);
+      }
     }
 
     return ret;
@@ -851,11 +854,13 @@ public class IndexModelObserver implements ModelObserver {
         ret.add(e);
     }
 
-    try {
-      SolrUtils.commit(index, IndexedAIP.class);
-    } catch (GenericException e) {
-      LOGGER.error("Error committing Solr after AIP deletion", e);
-      ret.add(e);
+    if (ret.isEmpty()) {
+      try {
+        SolrUtils.commit(index, IndexedAIP.class);
+      } catch (GenericException e) {
+        LOGGER.error("Error committing Solr after AIP deletion", e);
+        ret.add(e);
+      }
     }
 
     return ret;

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -131,10 +131,16 @@ public class IndexModelObserver implements ModelObserver {
           }
         }
       }
-      SolrUtils.commit(index, IndexedAIP.class);
     } catch (RequestNotValidException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Error getting ancestors when creating AIP", e);
       ret.add(e);
+    }
+    if (ret.isEmpty()) {
+      try {
+        SolrUtils.commit(index, IndexedAIP.class);
+      } catch (GenericException e) {
+        LOGGER.error("Error committing Solr after AIP creation", e);
+      }
     }
 
     return ret;
@@ -786,6 +792,7 @@ public class IndexModelObserver implements ModelObserver {
       SolrUtils.commit(index, IndexedAIP.class);
     } catch (GenericException e) {
       LOGGER.error("Error committing Solr after AIP move", e);
+      ret.add(e);
     }
 
     return ret;
@@ -848,6 +855,7 @@ public class IndexModelObserver implements ModelObserver {
       SolrUtils.commit(index, IndexedAIP.class);
     } catch (GenericException e) {
       LOGGER.error("Error committing Solr after AIP deletion", e);
+      ret.add(e);
     }
 
     return ret;
@@ -873,7 +881,9 @@ public class IndexModelObserver implements ModelObserver {
           descriptiveMetadata.getRepresentationId());
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
-      SolrUtils.commit(index, IndexedAIP.class);
+      if (ret.isEmpty()) {
+        SolrUtils.commit(index, IndexedAIP.class);
+      }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when creating descriptive metadata", e);
       ret.add(e);
@@ -902,7 +912,9 @@ public class IndexModelObserver implements ModelObserver {
           descriptiveMetadata.getRepresentationId());
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
-      SolrUtils.commit(index, IndexedAIP.class);
+      if (ret.isEmpty()) {
+        SolrUtils.commit(index, IndexedAIP.class);
+      }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when updating descriptive metadata", e);
       ret.add(e);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -131,6 +131,7 @@ public class IndexModelObserver implements ModelObserver {
           }
         }
       }
+      SolrUtils.commit(index, IndexedAIP.class);
     } catch (RequestNotValidException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Error getting ancestors when creating AIP", e);
       ret.add(e);
@@ -860,6 +861,7 @@ public class IndexModelObserver implements ModelObserver {
           descriptiveMetadata.getRepresentationId());
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
+      SolrUtils.commit(index, IndexedAIP.class);
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when creating descriptive metadata", e);
       ret.add(e);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -782,6 +782,12 @@ public class IndexModelObserver implements ModelObserver {
       ret.add(e);
     }
 
+    try {
+      SolrUtils.commit(index, IndexedAIP.class);
+    } catch (GenericException e) {
+      LOGGER.error("Error committing Solr after AIP move", e);
+    }
+
     return ret;
   }
 
@@ -831,13 +837,19 @@ public class IndexModelObserver implements ModelObserver {
     	String parentAipId = model.retrieveAIP(aipId).getParentId();
         if (ret.getExceptions().isEmpty() && parentAipId != null) {
         	UpdateOriginalMETS.handleParentWhenRemovedAIP(model, aipId, parentAipId);
-        }  	
+        }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException | IOException | IPException | JAXBException | SAXException e) {
         LOGGER.error("Failed to updating parentAIP when removing AIP", e);
-        
-        ret.add(e);	
+
+        ret.add(e);
     }
-    
+
+    try {
+      SolrUtils.commit(index, IndexedAIP.class);
+    } catch (GenericException e) {
+      LOGGER.error("Error committing Solr after AIP deletion", e);
+    }
+
     return ret;
   }
 
@@ -890,6 +902,7 @@ public class IndexModelObserver implements ModelObserver {
           descriptiveMetadata.getRepresentationId());
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
+      SolrUtils.commit(index, IndexedAIP.class);
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when updating descriptive metadata", e);
       ret.add(e);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -887,7 +887,7 @@ public class IndexModelObserver implements ModelObserver {
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
       if (ret.isEmpty()) {
-        SolrUtils.commit(index, IndexedAIP.class);
+        SolrUtils.commit(index, descriptiveMetadata.isFromAIP() ? IndexedAIP.class : IndexedRepresentation.class);
       }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when creating descriptive metadata", e);
@@ -918,7 +918,7 @@ public class IndexModelObserver implements ModelObserver {
         indexRepresentation(aip, representation, ancestors).addTo(ret);
       }
       if (ret.isEmpty()) {
-        SolrUtils.commit(index, IndexedAIP.class);
+        SolrUtils.commit(index, descriptiveMetadata.isFromAIP() ? IndexedAIP.class : IndexedRepresentation.class);
       }
     } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
       LOGGER.error("Failed to index AIP or representation when updating descriptive metadata", e);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -238,4 +238,15 @@ public class CatalogTreeNode extends Composite {
   public Map<String, CatalogTreeNode> getChildNodes() {
     return childNodes;
   }
+
+  public void invalidateChildren() {
+    loaded = false;
+    expanded = false;
+    isLeaf = false;
+    childNodes.clear();
+    childrenPanel.clear();
+    childrenPanel.setVisible(false);
+    toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
+    iconHtml.setHTML(ICON_FOLDER_CLOSED);
+  }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -56,6 +56,7 @@ public class CatalogTreeNode extends Composite {
   private final FlowPanel rowPanel;
   private final FlowPanel childrenPanel;
   private final HTML toggleHtml;
+  private HTML iconHtml;
   private final Map<String, CatalogTreeNode> childNodes = new HashMap<>();
   private Label titleLabel;
 
@@ -84,7 +85,7 @@ public class CatalogTreeNode extends Composite {
     toggleHtml.setStyleName("catalogTreeToggle");
     rowPanel.add(toggleHtml);
 
-    HTML iconHtml = new HTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(level, false));
+    iconHtml = new HTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(level, false));
     iconHtml.setStyleName("catalogTreeIcon");
     rowPanel.add(iconHtml);
 
@@ -235,6 +236,10 @@ public class CatalogTreeNode extends Composite {
   public void updateTitle(String newTitle) {
     title = newTitle != null ? newTitle : "";
     titleLabel.setText(title);
+  }
+
+  public void updateLevel(String level) {
+    iconHtml.setHTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(level, false));
   }
 
   public void removeChild(String aipId) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -52,7 +52,7 @@ public class CatalogTreeNode extends Composite {
   private static final String ICON_FILE_LEAF = "<span class='fas fa-folder'></span>";
 
   private final String aipId;
-  private final String title;
+  private String title;
   private final int depth;
   private final FlowPanel rootPanel;
   private final FlowPanel rowPanel;
@@ -60,6 +60,7 @@ public class CatalogTreeNode extends Composite {
   private final HTML toggleHtml;
   private final HTML iconHtml;
   private final Map<String, CatalogTreeNode> childNodes = new HashMap<>();
+  private Label titleLabel;
 
   private boolean expanded = false;
   private boolean loaded = false;
@@ -90,9 +91,9 @@ public class CatalogTreeNode extends Composite {
     iconHtml.setStyleName("catalogTreeIcon");
     rowPanel.add(iconHtml);
 
-    Label labelWidget = new Label(title);
-    labelWidget.setStyleName("catalogTreeLabel");
-    rowPanel.add(labelWidget);
+    titleLabel = new Label(title);
+    titleLabel.setStyleName("catalogTreeLabel");
+    rowPanel.add(titleLabel);
 
     childrenPanel = new FlowPanel();
     childrenPanel.setStyleName("catalogTreeNodeChildren");
@@ -237,6 +238,21 @@ public class CatalogTreeNode extends Composite {
 
   public Map<String, CatalogTreeNode> getChildNodes() {
     return childNodes;
+  }
+
+  public void updateTitle(String newTitle) {
+    title = newTitle != null ? newTitle : "";
+    titleLabel.setText(title);
+  }
+
+  public void removeChild(String aipId) {
+    CatalogTreeNode child = childNodes.remove(aipId);
+    if (child != null) {
+      child.removeFromParent();
+    }
+    if (childNodes.isEmpty() && loaded) {
+      markAsLeaf();
+    }
   }
 
   public void invalidateChildren() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -255,6 +255,5 @@ public class CatalogTreeNode extends Composite {
     childrenPanel.clear();
     childrenPanel.setVisible(false);
     toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
-    iconHtml.setHTML(ICON_FOLDER_CLOSED);
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -209,6 +209,40 @@ public class CatalogTreePanel extends Composite {
     return null;
   }
 
+  public void removeNode(String aipId, String parentAipId) {
+    if (parentAipId == null || parentAipId.isEmpty()) {
+      CatalogTreeNode node = rootNodes.remove(aipId);
+      if (node != null) {
+        node.removeFromParent();
+      }
+    } else {
+      CatalogTreeNode parent = findNode(parentAipId, rootNodes);
+      if (parent != null) {
+        parent.removeChild(aipId);
+      }
+    }
+    if (selectedNode != null && aipId.equals(selectedNode.getAipId())) {
+      selectedNode = null;
+    }
+  }
+
+  public void refreshNodeTitle(String aipId) {
+    CatalogTreeNode node = findNode(aipId, rootNodes);
+    if (node == null) return;
+    Services service = new Services(messages.catalogTreeLoadingLabel(), "get");
+    service.rodaEntityRestService(
+      s -> s.findByUuid(aipId, LocaleInfo.getCurrentLocale().getLocaleName()),
+      IndexedAIP.class)
+      .whenComplete((aip, error) -> {
+        if (error != null) {
+          // Node keeps its current title as fallback — non-critical background refresh
+          LOGGER.error("Could not refresh title for AIP " + aipId + ": " + error.getMessage(), error);
+          return;
+        }
+        node.updateTitle(aip.getTitle());
+      });
+  }
+
   public void refreshSubtree(String parentAipId) {
     if (parentAipId == null || parentAipId.isEmpty()) {
       rootNodes.clear();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -66,6 +66,7 @@ public class CatalogTreePanel extends Composite {
   private final Map<String, CatalogTreeNode> rootNodes = new HashMap<>();
   private CatalogTreeNode selectedNode = null;
   private boolean rootsLoaded = false;
+  private boolean rootsLoading = false;
   private String pendingRevealAipId = null;
 
   public CatalogTreePanel() {
@@ -98,6 +99,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void loadRootNodes() {
+    rootsLoading = true;
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new EmptyKeyFilterParameter(RodaConstants.AIP_PARENT_ID),
@@ -113,6 +115,7 @@ public class CatalogTreePanel extends Composite {
       s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)
       .whenComplete((result, error) -> {
+        rootsLoading = false;
         if (error != null) {
           LOGGER.error("Failed to load catalog tree root nodes", error);
           treeBody.clear();
@@ -142,6 +145,9 @@ public class CatalogTreePanel extends Composite {
   public void revealAip(String aipId) {
     if (!rootsLoaded) {
       pendingRevealAipId = aipId;
+      if (!rootsLoading) {
+        loadRootNodes();
+      }
       return;
     }
     doRevealAip(aipId);
@@ -208,8 +214,9 @@ public class CatalogTreePanel extends Composite {
       rootNodes.clear();
       treeBody.clear();
       rootsLoaded = false;
+      rootsLoading = false;
       pendingRevealAipId = null;
-      loadRootNodes();
+      // Reload triggered lazily by next revealAip call (after metadata is saved)
     } else {
       CatalogTreeNode parent = findNode(parentAipId, rootNodes);
       if (parent != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -299,6 +299,17 @@ public class CatalogTreePanel extends Composite {
       });
   }
 
+  public void refreshAfterMove(String oldParentId, String newParentId) {
+    boolean rootInvolved = (oldParentId == null || oldParentId.isEmpty())
+      || (newParentId == null || newParentId.isEmpty());
+    if (rootInvolved) {
+      loadRootNodes();
+    } else {
+      refreshSubtree(oldParentId);
+      refreshSubtree(newParentId);
+    }
+  }
+
   public void refreshSubtree(String parentAipId) {
     if (parentAipId == null || parentAipId.isEmpty()) {
       rootNodes.clear();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -273,7 +273,7 @@ public class CatalogTreePanel extends Composite {
       removeNodeFromSubtree(aipId, rootNodes);
     }
     if (selectedNode != null && aipId.equals(selectedNode.getAipId())) {
-      selectedNode = null;
+      clearSelection();
     }
   }
 
@@ -303,7 +303,7 @@ public class CatalogTreePanel extends Composite {
       }
     }
     if (selectedNode != null && aipId.equals(selectedNode.getAipId())) {
-      selectedNode = null;
+      clearSelection();
     }
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -202,4 +202,19 @@ public class CatalogTreePanel extends Composite {
     }
     return null;
   }
+
+  public void refreshSubtree(String parentAipId) {
+    if (parentAipId == null || parentAipId.isEmpty()) {
+      rootNodes.clear();
+      treeBody.clear();
+      rootsLoaded = false;
+      pendingRevealAipId = null;
+      loadRootNodes();
+    } else {
+      CatalogTreeNode parent = findNode(parentAipId, rootNodes);
+      if (parent != null) {
+        parent.invalidateChildren();
+      }
+    }
+  }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -151,6 +151,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void loadRootNodes() {
+    clearSelection();
     treeBody.clear();
     rootNodes.clear();
     rootsLoaded = false;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -265,6 +265,31 @@ public class CatalogTreePanel extends Composite {
     return null;
   }
 
+  public void removeNodeAnywhere(String aipId) {
+    CatalogTreeNode rootNode = rootNodes.remove(aipId);
+    if (rootNode != null) {
+      rootNode.removeFromParent();
+    } else {
+      removeNodeFromSubtree(aipId, rootNodes);
+    }
+    if (selectedNode != null && aipId.equals(selectedNode.getAipId())) {
+      selectedNode = null;
+    }
+  }
+
+  private boolean removeNodeFromSubtree(String aipId, Map<String, CatalogTreeNode> nodes) {
+    for (CatalogTreeNode node : nodes.values()) {
+      if (node.getChildNodes().containsKey(aipId)) {
+        node.removeChild(aipId);
+        return true;
+      }
+      if (removeNodeFromSubtree(aipId, node.getChildNodes())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public void removeNode(String aipId, String parentAipId) {
     if (parentAipId == null || parentAipId.isEmpty()) {
       CatalogTreeNode node = rootNodes.remove(aipId);
@@ -296,7 +321,12 @@ public class CatalogTreePanel extends Composite {
           return;
         }
         node.updateTitle(aip.getTitle());
+        node.updateLevel(aip.getLevel());
       });
+  }
+
+  public void reloadRootNodes() {
+    loadRootNodes();
   }
 
   public void refreshAfterMove(String oldParentId, String newParentId) {
@@ -312,12 +342,9 @@ public class CatalogTreePanel extends Composite {
 
   public void refreshSubtree(String parentAipId) {
     if (parentAipId == null || parentAipId.isEmpty()) {
-      rootNodes.clear();
-      treeBody.clear();
+      // Mark stale without clearing the visible tree. loadRootNodes() is triggered
+      // lazily by the next revealAip() call (e.g. after saving metadata in BrowseAIP).
       rootsLoaded = false;
-      rootsLoading = false;
-      pendingRevealAipId = null;
-      // Reload triggered lazily by next revealAip call (after metadata is saved)
     } else {
       CatalogTreeNode parent = findNode(parentAipId, rootNodes);
       if (parent != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CreateDescriptiveMetadata.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CreateDescriptiveMetadata.java
@@ -489,6 +489,7 @@ public class CreateDescriptiveMetadata extends Composite {
           if (error != null) {
             HistoryUtils.newHistory(InternalProcess.RESOLVER);
           } else {
+            CatalogTreePanel.getInstance().removeNodeAnywhere(aipId);
             HistoryUtils.newHistory(LastSelectedItemsSingleton.getInstance().getLastHistory());
           }
         });

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditDescriptiveMetadata.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/EditDescriptiveMetadata.java
@@ -475,6 +475,7 @@ public class EditDescriptiveMetadata extends Composite {
                     errors.setText("");
                     errors.setVisible(false);
                     Toast.showInfo(messages.dialogSuccess(), messages.metadataFileSaved());
+                    CatalogTreePanel.getInstance().refreshNodeTitle(aipId);
                     back();
                   }
                 });

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -346,15 +346,13 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                             }
 
                             @Override
                             public void onSuccess(final Void nothing) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -346,6 +346,8 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                             }
 
@@ -491,6 +493,7 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
                         @Override
                         public void onFailure(Throwable caught) {
                           Toast.showInfo(messages.removingSuccessTitle(), messages.removingSuccessMessage(1L));
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackDestroyed();
                         }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -347,6 +347,7 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
                             @Override
                             public void onFailure(Throwable caught) {
                               CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
+                              CatalogTreePanel.getInstance().revealAip(aipId);
                               doActionCallbackNone();
                             }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -353,6 +353,8 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onSuccess(final Void nothing) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }
@@ -499,6 +501,7 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
                         @Override
                         public void onSuccess(final Void nothing) {
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackNone();
                           HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                         }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -34,6 +34,7 @@ import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.core.data.v2.ip.Permissions;
 import org.roda.core.data.v2.ip.disposalhold.DisassociateDisposalHoldRequest;
 import org.roda.core.data.v2.representation.ChangeTypeRequest;
+import org.roda.wui.client.browse.CatalogTreePanel;
 import org.roda.wui.client.browse.CreateDescriptiveMetadata;
 import org.roda.wui.client.browse.EditPermissions;
 import org.roda.wui.client.common.LastSelectedItemsSingleton;
@@ -282,6 +283,7 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
     service.aipResource(s -> s.createAIP(parentAipId, aipType)).whenComplete((value, error) -> {
       if (value != null) {
+        CatalogTreePanel.getInstance().refreshSubtree(parentAipId);
         LastSelectedItemsSingleton.getInstance().setLastHistory(HistoryUtils.getCurrentHistoryPath());
         callback.onSuccess(Actionable.ActionImpact.NONE);
         HistoryUtils.newHistory(CreateDescriptiveMetadata.RESOLVER, RodaConstants.RODA_OBJECT_AIP, value.getId(),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -334,15 +334,13 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                             }
 
                             @Override
                             public void onSuccess(final Void nothing) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -334,6 +334,8 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                             }
 
@@ -483,6 +485,7 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
                         @Override
                         public void onFailure(Throwable caught) {
                           Toast.showInfo(messages.removingSuccessTitle(), messages.removingSuccessMessage(1L));
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackDestroyed();
                         }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -34,6 +34,7 @@ import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.core.data.v2.ip.Permissions;
 import org.roda.core.data.v2.ip.disposalhold.DisassociateDisposalHoldRequest;
 import org.roda.core.data.v2.representation.ChangeTypeRequest;
+import org.roda.wui.client.browse.CatalogTreePanel;
 import org.roda.wui.client.browse.CreateDescriptiveMetadata;
 import org.roda.wui.client.browse.EditPermissions;
 import org.roda.wui.client.common.LastSelectedItemsSingleton;
@@ -276,6 +277,7 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
     service.aipResource(s -> s.createAIP(parentAipId, aipType)).whenComplete((value, error) -> {
       if (value != null) {
+        CatalogTreePanel.getInstance().refreshSubtree(parentAipId);
         LastSelectedItemsSingleton.getInstance().setLastHistory(HistoryUtils.getCurrentHistoryPath());
         callback.onSuccess(ActionImpact.NONE);
         HistoryUtils.newHistory(CreateDescriptiveMetadata.RESOLVER, RodaConstants.RODA_OBJECT_AIP, value.getId(),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -341,6 +341,8 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onSuccess(final Void nothing) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }
@@ -491,6 +493,7 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
                         @Override
                         public void onSuccess(final Void nothing) {
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackNone();
                           HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                         }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -335,6 +335,7 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
                             @Override
                             public void onFailure(Throwable caught) {
                               CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
+                              CatalogTreePanel.getInstance().revealAip(aipId);
                               doActionCallbackNone();
                             }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -452,6 +452,7 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
                             @Override
                             public void onFailure(Throwable caught) {
                               CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
+                              CatalogTreePanel.getInstance().revealAip(aipId);
                               doActionCallbackNone();
                             }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -451,6 +451,8 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                             }
 
@@ -596,6 +598,7 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
                         @Override
                         public void onFailure(Throwable caught) {
                           Toast.showInfo(messages.removingSuccessTitle(), messages.removingSuccessMessage(1L));
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackDestroyed();
                         }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -458,6 +458,8 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onSuccess(final Void nothing) {
+                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
+                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }
@@ -604,6 +606,7 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
 
                         @Override
                         public void onSuccess(final Void nothing) {
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
                           doActionCallbackNone();
                           HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                         }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -39,6 +39,7 @@ import org.roda.core.data.v2.ip.disposalhold.DisassociateDisposalHoldRequest;
 import org.roda.core.data.v2.representation.ChangeTypeRequest;
 import org.roda.wui.client.browse.BrowseRepresentation;
 import org.roda.wui.client.browse.BrowseTop;
+import org.roda.wui.client.browse.CatalogTreePanel;
 import org.roda.wui.client.browse.CreateDescriptiveMetadata;
 import org.roda.wui.client.browse.EditPermissions;
 import org.roda.wui.client.common.LastSelectedItemsSingleton;
@@ -361,6 +362,7 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
 
     service.aipResource(s -> s.createAIP(parentAipId, aipType)).whenComplete((value, error) -> {
       if (value != null) {
+        CatalogTreePanel.getInstance().refreshSubtree(parentAipId);
         LastSelectedItemsSingleton.getInstance().setLastHistory(HistoryUtils.getCurrentHistoryPath());
         callback.onSuccess(ActionImpact.NONE);
         HistoryUtils.newHistory(CreateDescriptiveMetadata.RESOLVER, RodaConstants.RODA_OBJECT_AIP, value.getId(),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipToolbarActions.java
@@ -451,15 +451,13 @@ public class AipToolbarActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                             }
 
                             @Override
                             public void onSuccess(final Void nothing) {
-                              CatalogTreePanel.getInstance().refreshSubtree(aip.getParentID());
-                              CatalogTreePanel.getInstance().refreshSubtree(parentId);
+                              CatalogTreePanel.getInstance().refreshAfterMove(aip.getParentID(), parentId);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }


### PR DESCRIPTION
## Sammanfattning

Katalogträdet (vänster sidopanel) synkroniseras nu automatiskt när AIP-operationer utförs, utan att användaren behöver ladda om sidan.

**Vad som åtgärdas:**
- Noden tas bort från trädet när en AIP raderas
- Trädet uppdateras korrekt när en AIP flyttas (gammal och ny förälder invalideras; ny förälder expanderas)
- Nodens titel och ikon uppdateras när beskrivande metadata sparas
- Trädet laddas om korrekt när en ny AIP skapas och metadata sparas
- Trädet töms inte längre när användaren avbryter skapande av en ny AIP
- Solr committas explicit efter index-operationer för att ändringar ska synas direkt

## Tekniska förändringar

**Backend (`IndexModelObserver`):**
- Explicit `SolrUtils.commit()` efter AIP delete, move, create och metadata-uppdatering
- Commit skyddas med `ret.isEmpty()`-kontroll och fel propageras korrekt till anroparen

**`CatalogTreeNode`:**
- Ny metod `updateTitle()` uppdaterar nod-titeln in-place
- Ny metod `updateLevel()` uppdaterar ikonen vid nivåbyte
- Ny metod `removeChild()` tar bort en specifik undernod
- Ny metod `invalidateChildren()` invaliderar laddade barn

**`CatalogTreePanel`:**
- Ny metod `removeNode()` tar bort en nod givet AIP-id och förälder-id
- Ny metod `removeNodeAnywhere()` tar bort en nod utan att känna till förälder
- Ny metod `refreshNodeTitle()` hämtar uppdaterad `IndexedAIP` och uppdaterar titel + ikon
- Ny metod `refreshAfterMove()` hanterar träd-uppdatering vid flytt, inkl. root-nivå
- `refreshSubtree(null)` rensar inte längre trädet synkront — sätter bara `rootsLoaded = false` så befintliga noder är synliga tills `revealAip()` triggar omladdning

**`AipActions` / `AipSearchWrapperActions` / `AipToolbarActions`:**
- Tree-refresh vid radering (`removeNode`) och flytt (`refreshAfterMove` + `revealAip`)
- `revealAip` anropas i `onFailure` (användaren stannar kvar i vyn) men inte i `onSuccess` (användaren navigerar till jobbet)

**`EditDescriptiveMetadata`:**
- Anropar `refreshNodeTitle()` efter lyckad sparning

**`CreateDescriptiveMetadata`:**
- Anropar `removeNodeAnywhere()` vid Avbryt för att ta bort den osparade noden

## Testat
- [ ] Skapa AIP → spara metadata → nod visas i trädet
- [ ] Skapa AIP → avbryt → trädet är intakt (noden raderas)
- [ ] Radera AIP → noden försvinner från trädet
- [ ] Flytta AIP → trädet visar ny placering, ny förälder expanderas
- [ ] Uppdatera metadata (titel, nivå) → nod uppdateras i trädet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Förbättrad synkronisering av katalogträdet vid skapande, flytt, radering och metadataändring — träd uppdateras omedelbart eller väntar tills rotladdning slutförts.
  * Node-titlar och nivåikoner uppdateras korrekt efter metadataändringar eller flytt.

* **New Features**
  * Möjlighet att ta bort eller uppdatera noder oavsett position samt att ladda om rötter på begäran.

* **Chores**
  * Ökad konsistens mellan visning och sök/index-tillstånd för snabbare och mer pålitliga uppdateringar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->