### PR TITLE
fix: visa svensk text vid felmeddelande om dubblett-användare

### DIFF
--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -79,22 +79,18 @@ services:
       - "8025:8025" # web ui
 
   openldap:
-    image: docker.io/bitnami/openldap:2.6
+    image: osixia/openldap:1.5.0
     container_name: openldap
     restart: unless-stopped
-    user: 1001:root
     ports:
-      - "1389:1389"
-      - "1636:1636"
+      - "1389:389"
+      - "1636:636"
     environment:
-      - BITNAMI_DEBUG=true
-      - LDAP_ROOT=dc=roda,dc=org
-      - LDAP_SKIP_DEFAULT_TREE=yes
-      - LDAP_ADMIN_USERNAME=admin
+      - LDAP_ORGANISATION=RODA
+      - LDAP_DOMAIN=roda.org
       - LDAP_ADMIN_PASSWORD=eterna
-      - LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,pbkdf2
-    volumes:
-      - ./ldap/ldif/pbkdf2.ldif:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
+      - LDAP_TLS=false
+    command: --copy-service
 
   postgres:
     image: postgres:17

--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -71,7 +71,7 @@ services:
       - VALIDATOR_URL=none
 
   mailpit:
-    image: axllent/mailpit:v1.24
+    image: axllent/mailpit:v1.29.2
     container_name: mailpit
     restart: unless-stopped
     ports:

--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -79,18 +79,22 @@ services:
       - "8025:8025" # web ui
 
   openldap:
-    image: osixia/openldap:1.5.0
+    image: vegardit/openldap:latest
     container_name: openldap
     restart: unless-stopped
     ports:
       - "1389:389"
       - "1636:636"
     environment:
-      - LDAP_ORGANISATION=RODA
-      - LDAP_DOMAIN=roda.org
-      - LDAP_ADMIN_PASSWORD=eterna
-      - LDAP_TLS=false
-    command: --copy-service
+      - LDAP_INIT_ORG_DN=DC=roda,DC=org
+      - LDAP_INIT_ORG_NAME=RODA
+      - LDAP_INIT_ROOT_USER_DN=cn=admin,dc=roda,dc=org
+      - LDAP_INIT_ROOT_USER_PW=eterna
+      - LDAP_TLS_ENABLED=false
+    volumes:
+      - ./ldap/ldifs/init_org_tree.ldif:/opt/ldifs/init_org_tree.ldif:ro
+      - ./ldap/ldifs/init_org_entries.ldif:/opt/ldifs/init_org_entries.ldif:ro
+      - ./ldap/ldifs/init_org_ppolicy.ldif:/opt/ldifs/init_org_ppolicy.ldif:ro
 
   postgres:
     image: postgres:17

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - VALIDATOR_URL=none
 
   mailpit:
-    image: axllent/mailpit:v1.24
+    image: axllent/mailpit:v1.29.2
     restart: unless-stopped
     ports:
       - "1025:1025" # smtp server

--- a/deploys/standalone/ldap/ldifs/init_org_entries.ldif
+++ b/deploys/standalone/ldap/ldifs/init_org_entries.ldif
@@ -1,0 +1,436 @@
+version: 1
+
+dn: uid=admin,ou=users,dc=roda,dc=org
+objectClass: extensibleObject
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: shadowAccount
+cn: Administrator
+sn: Administrator
+email: demo-admin@whitered.se
+givenName: ETERNA Administrator
+shadowInactive: 0
+uid: admin
+userPassword: {SSHA}HwzRvkvS8ME8UH5QR7oWxBOaulNMeE4t
+
+dn: uid=guest,ou=users,dc=roda,dc=org
+objectClass: extensibleObject
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: shadowAccount
+cn: Guest
+sn: Guest
+email: demo-guest@whitered.se
+givenName: ETERNA Guest
+shadowInactive: 0
+uid: guest
+userPassword: {SSHA}8V34acvaiyj0He2IBBJ8mrnOyrJ3rACx
+
+dn: cn=administrators,ou=groups,dc=roda,dc=org
+objectClass: extensibleObject
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: administrators
+uniqueMember: uid=admin,ou=users,dc=roda,dc=org
+ou: Administrators
+shadowInactive: 0
+
+dn: cn=users,ou=groups,dc=roda,dc=org
+objectClass: extensibleObject
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: users
+uniqueMember: uid=admin,ou=users,dc=roda,dc=org
+ou: Users
+shadowInactive: 0
+
+dn: cn=guests,ou=groups,dc=roda,dc=org
+objectClass: extensibleObject
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: guests
+uniqueMember: uid=guest,ou=users,dc=roda,dc=org
+ou: Guests
+shadowInactive: 0
+
+dn: cn=access_key.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: access_key.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=access_key.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: access_key.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.appraisal,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.appraisal
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.create.below,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.create.below
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.create.top,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.create.top
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.update,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.update
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=aip.view,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.view
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=descriptive_metadata.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: descriptive_metadata.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=descriptive_metadata.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: descriptive_metadata.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=descriptive_metadata.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: descriptive_metadata.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=descriptive_metadata.update,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: descriptive_metadata.update
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_confirmation.delete_bin,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_confirmation.delete_bin
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_confirmation.destroy,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_confirmation.destroy
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_confirmation.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_confirmation.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_confirmation.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_confirmation.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_confirmation.restore,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_confirmation.restore
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_hold.apply,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_hold.apply
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_hold.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_hold.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_hold.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_hold.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_rule.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_rule.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_rule.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_rule.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_schedule.associate,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_schedule.associate
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_schedule.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_schedule.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=disposal_schedule.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: disposal_schedule.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=distributed_instances.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: distributed_instances.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=distributed_instances.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: distributed_instances.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=incidence.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: incidence.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=incidence.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: incidence.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=job.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: job.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=job.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: job.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=localInstanceConfiguration.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: localInstanceConfiguration.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=local_instance_configuration.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: local_instance_configuration.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=local_instance_configuration.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: local_instance_configuration.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=log_entry.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: log_entry.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=log_entry.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: log_entry.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=log_entry.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: log_entry.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=log_entry.view,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: log_entry.view
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=member.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: member.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=member.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: member.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=metadata.transform.xslt,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: metadata.transform.xslt
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=notification.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: notification.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=notification.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: notification.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=permission.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: permission.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=preservation_metadata.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: preservation_metadata.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=preservation_metadata.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: preservation_metadata.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=preservation_metadata.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: preservation_metadata.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.apply_xslt,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.apply_xslt
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.update,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.update
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=representation.view,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: representation.view
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=ri.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: ri.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=ri.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: ri.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=risk.manage,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: risk.manage
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=risk.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: risk.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=risk.view,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: risk.view
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=transfer.create,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: transfer.create
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=transfer.delete,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: transfer.delete
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+
+dn: cn=transfer.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: transfer.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org

--- a/deploys/standalone/ldap/ldifs/init_org_ppolicy.ldif
+++ b/deploys/standalone/ldap/ldifs/init_org_ppolicy.ldif
@@ -1,0 +1,1 @@
+version: 1

--- a/deploys/standalone/ldap/ldifs/init_org_tree.ldif
+++ b/deploys/standalone/ldap/ldifs/init_org_tree.ldif
@@ -1,0 +1,22 @@
+version: 1
+
+dn: ${LDAP_INIT_ORG_DN}
+description: ${LDAP_INIT_ORG_NAME}
+objectClass: top
+objectClass: organization
+${LDAP_INIT_ORG_COMPUTED_ATTRS}
+
+dn: ou=users,${LDAP_INIT_ORG_DN}
+ou: users
+objectClass: top
+objectClass: organizationalUnit
+
+dn: ou=groups,${LDAP_INIT_ORG_DN}
+ou: groups
+objectClass: top
+objectClass: organizationalUnit
+
+dn: ou=roles,${LDAP_INIT_ORG_DN}
+ou: roles
+objectClass: top
+objectClass: organizationalUnit

--- a/deploys/standalone/openldap.md
+++ b/deploys/standalone/openldap.md
@@ -1,0 +1,169 @@
+# OpenLDAP Configuration for ETERNA (Dev)
+
+## Overview
+
+ETERNA uses OpenLDAP for user authentication and role-based access control. The dev environment uses [vegardit/openldap](https://github.com/vegardit/docker-openldap) (OpenLDAP 2.6.x on Debian), replacing the deprecated osixia/openldap image.
+
+## Architecture
+
+```
+ETERNA (Spring Boot) --LDAP--> OpenLDAP container (port 1389)
+```
+
+LDAP directory structure:
+```
+dc=roda,dc=org                          (root)
+  ou=users                              (user accounts)
+    uid=admin                           (admin user, password: eterna)
+    uid=guest                           (guest user, password: roda)
+  ou=groups                             (user groups)
+    cn=administrators                   (admin group, member: uid=admin)
+    cn=users                            (regular users group, member: uid=admin)
+    cn=guests                           (guest group, member: uid=guest)
+  ou=roles                              (RBAC roles, ~63 roles)
+    cn=aip.read                         (example role)
+    cn=aip.create                       (example role)
+    cn=representation.apply_xslt        (XSLT viewer role)
+    ...                                 (all roles from roda-roles.properties)
+```
+
+## How It Works
+
+### RODA Bootstrap Behavior (Critical)
+
+RODA's `LdapUtility.bootstrap()` checks if the root DN (`dc=roda,dc=org`) exists:
+- **If root DN does NOT exist**: RODA creates everything (root, OUs, users, groups, roles)
+- **If root DN EXISTS**: RODA **skips ALL initialization** — no users, groups, or roles are created
+
+Since vegardit creates the root DN during container startup, RODA's bootstrap is skipped entirely. This means **all users, groups, and roles must be pre-seeded via init LDIFs**.
+
+### Password Hashing
+
+OpenLDAP uses **SSHA** (Salted SHA-1) for password hashing. PBKDF2-SHA512 is NOT supported by default OpenLDAP. Generate SSHA hashes with:
+
+```bash
+docker exec openldap slappasswd -s <password>
+```
+
+### Role Assignment
+
+Roles use `organizationalRole` objects with `roleOccupant` pointing to a group:
+```ldif
+dn: cn=aip.read,ou=roles,dc=roda,dc=org
+objectClass: organizationalRole
+objectClass: top
+cn: aip.read
+roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+```
+
+This gives all members of the `administrators` group the `aip.read` role.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose-dev.yaml` | vegardit/openldap service definition |
+| `ldap/ldifs/init_org_tree.ldif` | Creates root DN + OUs (uses vegardit template variables) |
+| `ldap/ldifs/init_org_entries.ldif` | Seeds users, groups, and all 63 RODA roles |
+| `ldap/ldifs/init_org_ppolicy.ldif` | Empty — prevents vegardit from creating default password policy |
+
+## Environment Variables
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `LDAP_INIT_ORG_DN` | `DC=roda,DC=org` | Base DN for the LDAP directory |
+| `LDAP_INIT_ORG_NAME` | `RODA` | Organization name |
+| `LDAP_INIT_ROOT_USER_DN` | `cn=admin,dc=roda,dc=org` | LDAP admin bind DN |
+| `LDAP_INIT_ROOT_USER_PW` | `eterna` | LDAP admin password |
+| `LDAP_TLS_ENABLED` | `false` | TLS disabled for dev |
+
+ETERNA env vars (set when starting the jar):
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `LDAP_SERVER_URL` | `ldap://localhost` | LDAP server URL |
+| `LDAP_SERVER_PORT` | `1389` | Host port (mapped from container 389) |
+
+## Common Operations
+
+### Reset LDAP (fresh start)
+
+```bash
+cd deploys/standalone
+docker compose -f docker-compose-dev.yaml down openldap
+docker volume rm standalone_roda-openldap-data standalone_roda-openldap-config
+docker compose -f docker-compose-dev.yaml up -d openldap
+```
+
+### Verify LDAP contents
+
+```bash
+# List all entries
+docker exec openldap ldapsearch -x -H ldap://localhost:389 \
+  -D 'cn=admin,dc=roda,dc=org' -w eterna \
+  -b 'dc=roda,dc=org' '(objectClass=*)' dn
+
+# Test user login
+docker exec openldap ldapwhoami -x -H ldap://localhost:389 \
+  -D 'uid=admin,ou=users,dc=roda,dc=org' -w eterna
+```
+
+### Change a user password
+
+```bash
+docker exec openldap ldappasswd -x -H ldap://localhost:389 \
+  -D 'cn=admin,dc=roda,dc=org' -w eterna \
+  -s <new-password> 'uid=admin,ou=users,dc=roda,dc=org'
+```
+
+Then update the SSHA hash in `init_org_entries.ldif` for persistence across restarts:
+```bash
+docker exec openldap slappasswd -s <new-password>
+# Copy the output hash into the LDIF
+```
+
+### Add a new role
+
+1. Add the role to `roda-roles.properties` (maps Java method to role name)
+2. Add an LDIF entry to `init_org_entries.ldif`:
+   ```ldif
+   dn: cn=new.role.name,ou=roles,dc=roda,dc=org
+   objectClass: organizationalRole
+   objectClass: top
+   cn: new.role.name
+   roleOccupant: cn=administrators,ou=groups,dc=roda,dc=org
+   ```
+3. Reset LDAP (see above)
+
+### Regenerate all roles from roda-roles.properties
+
+If `roda-roles.properties` changes significantly, regenerate the entries LDIF:
+
+```bash
+python3 -c "
+roles = set()
+with open('roda-core/roda-core/src/main/resources/config/roda-roles.properties') as f:
+    for line in f:
+        line = line.strip()
+        if line.startswith('core.roles.') and '=' in line:
+            val = line.split('=', 1)[1].strip()
+            if val and not val.startswith('core.') and not val.endswith('='):
+                roles.add(val)
+for r in sorted(roles):
+    print(r)
+"
+```
+
+## Migration from osixia/openldap
+
+The previous setup used `osixia/openldap:1.5.0` which:
+- Had 1023 CVEs (Debian Buster base, EOL)
+- Used `LDAP_ORGANISATION`, `LDAP_DOMAIN`, `LDAP_ADMIN_PASSWORD` env vars
+- Mapped port 389:389 directly
+
+vegardit/openldap:
+- ~90 CVEs, 0 critical (Debian Trixie base)
+- Uses `LDAP_INIT_ORG_DN`, `LDAP_INIT_ROOT_USER_DN`, etc.
+- Maps port 1389:389 in dev compose
+- Requires explicit init LDIFs for full RODA compatibility
+
+**Note:** Production (`docker-compose.yaml`) still uses osixia/openldap. This migration only applies to the dev compose.

--- a/docs/XSLT-Modul-Dokumentation.md
+++ b/docs/XSLT-Modul-Dokumentation.md
@@ -1,0 +1,477 @@
+# XSLT-modul för ETERNA
+
+## Innehållsförteckning
+
+1. [Översikt](#översikt)
+2. [Arkitektur](#arkitektur)
+3. [Hur XSLT-stilmallar hittas](#hur-xslt-stilmallar-hittas)
+4. [Paketera XSLT i E-ARK SIP](#paketera-xslt-i-e-ark-sip)
+5. [Globala stilmallar](#globala-stilmallar)
+6. [Ladda upp egen XSLT](#ladda-upp-egen-xslt)
+7. [Skriv ut dokument](#skriv-ut-dokument)
+8. [Behörigheter](#behörigheter)
+9. [REST API](#rest-api)
+10. [Konfiguration](#konfiguration)
+11. [Tekniska detaljer](#tekniska-detaljer)
+12. [Kända begränsningar](#kända-begränsningar)
+
+---
+
+## Översikt
+
+XSLT-modulen gör det möjligt att visa XML-filer i ETERNA som formaterade, läsbara HTML-dokument genom att applicera XSLT-stilmallar. Modulen stödjer tre nivåer av stilmallar:
+
+1. **AIP-bundna stilmallar** — XSLT-filer som paketeras tillsammans med XML-filerna i AIP:ets dokumentationsmapp. Varje XML-fil kan ha sin egen matchande stilmall.
+2. **Globala stilmallar** — Fördefinierade stilmallar som konfigureras i ETERNA och matchas via XML-namnrymd.
+3. **Användaruppladdade stilmallar** — Användare med rätt behörighet kan ladda upp en egen XSLT-fil direkt i gränssnittet för att tillfälligt transformera ett dokument.
+
+### Sökordning
+
+När en XML-fil visas söker systemet efter stilmallar i följande ordning:
+
+```
+1. AIP-dokumentation (representationsnivå)
+   └── Filnamnsträff (t.ex. Jrnl4.xml → Jrnl4.xslt)
+   └── Första XSLT som fallback
+2. AIP-dokumentation (paketnivå)
+   └── Filnamnsträff
+   └── Första XSLT som fallback
+3. Global stilmall (via namnrymdsdetektering)
+4. Ingen stilmall → 404 Not Found
+```
+
+---
+
+## Arkitektur
+
+### Komponentöversikt
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Webbläsare (GWT-klient)                                │
+│  BitstreamPreview.java                                   │
+│  ┌─────────┐ ┌──────────────┐ ┌───────────────────────┐ │
+│  │ Skriv ut│ │ Välj XSLT    │ │ Applicera XSLT        │ │
+│  └────┬────┘ └──────┬───────┘ └───────────┬───────────┘ │
+│       │              │                     │             │
+│  ┌────▼──────────────▼─────────────────────▼───────────┐ │
+│  │              <iframe srcdoc="...">                   │ │
+│  │              Renderad HTML                           │ │
+│  └─────────────────────────────────────────────────────┘ │
+└────────────────────┬───────────────────────┬─────────────┘
+                     │ GET                   │ POST
+                     ▼                       ▼
+┌────────────────────────────────────────────────────────────┐
+│  REST API (FilesController.java)                           │
+│  GET  /api/v2/files/{uuid}/preview/html                    │
+│  POST /api/v2/files/{uuid}/preview/html/transform          │
+└────────────────────┬───────────────────────┬───────────────┘
+                     │                       │
+                     ▼                       ▼
+┌────────────────────────────────────────────────────────────┐
+│  Tjänstelager (FilesService.java)                          │
+│  - Namnrymdsdetektering (XMLStreamReader)                  │
+│  - XSLT-sökning i AIP-dokumentation                        │
+│  - Fallback till global stilmall                           │
+└────────────────────┬───────────────────────┬───────────────┘
+                     │                       │
+                     ▼                       ▼
+┌────────────────────────────────────────────────────────────┐
+│  Transformering (RodaUtils.java + HTMLUtils.java)          │
+│  - Saxon HE (XSLT 2.0-processor)                          │
+│  - Cache för kompilerade stilmallar (1 min TTL)            │
+│  - i18n-parametrar till stilmallar                         │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Berörda filer
+
+| Fil | Ansvar |
+|-----|--------|
+| `FilesController.java` | REST-endpoints för förhandsvisning och transformation |
+| `FilesService.java` | Affärslogik: XSLT-sökning, namnrymdsdetektering, orchestrering |
+| `HTMLUtils.java` | Delegering till Saxon, i18n-hantering |
+| `RodaUtils.java` | Saxon XSLT 2.0-kompilering och transformation |
+| `BitstreamPreview.java` | GWT-klient: iframe, verktygsfält, utskrift |
+| `roda-roles.properties` | Rollmappning för behörighet |
+| `roda-wui.properties` | UI-registrering av roller |
+| `crosswalks/dissemination/html/` | Globala stilmallar |
+
+---
+
+## Hur XSLT-stilmallar hittas
+
+### Steg 1: AIP-dokumentation (representationsnivå)
+
+Systemet söker i AIP:ets representationsdokumentation (`representations/rep1/documentation/`) efter `.xslt`-filer.
+
+**Filnamnsträff:** Om XML-filen heter `Jrnl4.xml` letar systemet efter `Jrnl4.xslt`. Om en exakt matchning hittas används den direkt.
+
+**Fallback:** Om ingen filnamnsträff finns, används den första `.xslt`-filen som hittas i dokumentationsmappen.
+
+### Steg 2: AIP-dokumentation (paketnivå)
+
+Om ingen XSLT hittas på representationsnivå söker systemet i paketets dokumentationsmapp (`documentation/`).
+
+> **OBS:** På grund av en begränsning i commons-ip2-biblioteket (v2.10.1) hamnar representationsdokumentation ofta på paketnivå efter inmatning, även om den var korrekt placerad på representationsnivå i SIP-paketet. Därför är fallback till paketnivå viktig.
+
+### Steg 3: Global stilmall via namnrymd
+
+Om ingen AIP-bundlad XSLT hittas detekterar systemet XML-filens namnrymd (namespace) och slår upp en global stilmall via konfigurationen.
+
+Namnrymdsdetekteringen:
+1. Läser de första 4 KB av XML-filen
+2. Använder `XMLStreamReader` för att hitta rotelementets namnrymd
+3. Matchar mot konfigurerade regler i `ui.viewer.xslt.representation.rules`
+
+Exempel: En XML-fil med namnrymden `http://www.cgm.com/sv/pmo/v1` matchas mot stilmallen `cgm_pmo_journal.xslt`.
+
+### Steg 4: Ingen stilmall
+
+Om ingen stilmall hittas returneras HTTP 404. Klienten visar då XML-filen som ren text istället.
+
+---
+
+## Paketera XSLT i E-ARK SIP
+
+### Bakgrund
+
+Enligt E-ARK CSIP 2.0 (CSIPSTR16) kan dokumentation placeras antingen på paketnivå (`documentation/`) eller på representationsnivå (`representations/rep1/documentation/`). XSLT-stilmallar bör placeras på representationsnivå för att tydligt kopplas till den representation de tillhör.
+
+### SIP-paketstruktur
+
+```
+SIP-200801010141-xxxxxxxx/
+├── METS.xml                                    (rot-METS)
+├── metadata/
+│   └── descriptive/
+│       ├── 200801010141.xml                    (CGM PMO-metadata)
+│       └── dc.xml                              (Dublin Core-metadata)
+├── schemas/
+│   └── ...
+└── representations/
+    └── rep1/
+        ├── METS.xml                            (representations-METS)
+        ├── data/
+        │   ├── 200801010141_Jrnl1.xml
+        │   ├── 200801010141_Jrnl2.xml
+        │   └── ...
+        └── documentation/
+            ├── 200801010141_Jrnl1.xslt         (stilmall för Jrnl1)
+            ├── 200801010141_Jrnl2.xslt         (stilmall för Jrnl2)
+            └── ...
+```
+
+### Krav på representations-METS
+
+För att stilmallarna ska upptäckas vid inmatning måste representations-METS (`representations/rep1/METS.xml`) innehålla:
+
+**1. Filgrupp i `<mets:fileSec>`:**
+
+```xml
+<mets:fileGrp ID="fileGrp-rep1-documentation" USE="Documentation">
+  <mets:file ID="file-0100" MIMETYPE="application/xslt+xml"
+             SIZE="1234" CHECKSUM="abc123..." CHECKSUMTYPE="SHA-256">
+    <mets:FLocat LOCTYPE="URL" xlink:type="simple"
+                 xlink:href="documentation/200801010141_Jrnl1.xslt"/>
+  </mets:file>
+  <!-- fler filer... -->
+</mets:fileGrp>
+```
+
+**2. Filpekare i `<mets:structMap>`:**
+
+```xml
+<mets:div ID="div-rep1-documentation" LABEL="Documentation">
+  <mets:fptr FILEID="fileGrp-rep1-documentation"/>
+</mets:div>
+```
+
+> **Viktigt:** `<mets:fptr>`-elementet är obligatoriskt. Utan det ignorerar commons-ip2-biblioteket dokumentationsfilerna vid inmatning.
+
+### Bygga SIP-paket
+
+Skriptet `build_sip.py` (finns i `C:\claude\utb\`) automatiserar skapandet av SIP-paket med XSLT-stilmallar:
+
+```bash
+# Generera XSLT-stilmallar (en per XML-fil)
+python3 generate_xslt.py
+
+# Bygg SIP-paketet
+python3 build_sip.py
+```
+
+Skriptet:
+1. Samlar alla `.xslt`-filer från `/tmp/eterna-xslt/`
+2. Kopierar representationsfiler från ett befintligt SIP
+3. Injicerar dokumentationsreferenser i representations-METS
+4. Placerar stilmallarna i `representations/rep1/documentation/`
+5. Skapar ett komplett E-ARK SIP som ZIP-fil
+
+---
+
+## Globala stilmallar
+
+Globala stilmallar finns i:
+
+```
+config/crosswalks/dissemination/html/              (för beskrivande metadata)
+config/crosswalks/dissemination/html/representation/  (för representationsfiler)
+```
+
+### Tillgängliga stilmallar
+
+| Stilmall | Beskrivning |
+|----------|-------------|
+| `cgm_pmo_v1.xslt` | CGM PMO v1 — patientjournaler (beskrivande metadata) |
+| `dc.xslt` | Dublin Core |
+| `ead_2002.xslt` | Encoded Archival Description 2002 |
+| `ead_3.xslt` | Encoded Archival Description 3 |
+| `plain.xslt` | Ren textdump av XML |
+| `key-value.xslt` | Generiska nyckel-värdepar |
+| `event.xslt` | PREMIS-bevarandehändelser |
+
+### Skapa en ny global stilmall
+
+1. Skapa en `.xslt`-fil i `config/crosswalks/dissemination/html/representation/`
+2. Konfigurera namnrymdsmatchning i `roda-wui.properties`:
+
+```properties
+ui.viewer.xslt.representation.rules = rule1
+ui.viewer.xslt.representation.rules.rule1.namespace = http://www.example.com/ns
+ui.viewer.xslt.representation.rules.rule1.xslt = min_stilmall
+```
+
+3. Stilmallen behöver inte kompileras — ETERNA läser den vid körning
+
+### Stilmallsformat
+
+ETERNA använder Saxon HE som stödjer XSLT 2.0. Stilmallar får tillgång till i18n-parametrar via XSLT-parametern `$i18n`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:pmo="http://www.cgm.com/sv/pmo/v1">
+
+  <xsl:output method="xml" indent="yes" omit-xml-declaration="yes"/>
+  <xsl:param name="i18n" as="map(xs:string, xs:string)?" xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+
+  <xsl:template match="/">
+    <div class="descriptiveMetadata">
+      <h1><xsl:value-of select="//pmo:CaseBookName"/></h1>
+      <!-- mer transformation... -->
+    </div>
+  </xsl:template>
+</xsl:stylesheet>
+```
+
+---
+
+## Ladda upp egen XSLT
+
+Användare med behörigheten **"Applicera egen XSLT-stilmall"** kan ladda upp en egen XSLT-fil direkt i gränssnittet för att tillfälligt transformera ett XML-dokument.
+
+### Så här gör du
+
+1. Navigera till en XML-fil i ett AIP
+2. Klicka på fliken **VISA**
+3. Ovanför den renderade vyn finns ett verktygsfält med en filväljare
+4. Klicka **Välj fil** och välj en `.xslt`- eller `.xsl`-fil
+5. Klicka **Applicera XSLT**
+6. Dokumentet omtransformeras med den uppladdade stilmallen
+
+> **OBS:** Den uppladdade stilmallen sparas inte — den appliceras bara tillfälligt för den aktuella visningen. Ladda om sidan för att återgå till standardstilmallen.
+
+### Behörighet
+
+Verktygsfältet visas bara om användaren har rollen `representation.apply_xslt`. Se avsnittet [Behörigheter](#behörigheter) för hur rollen tilldelas.
+
+---
+
+## Skriv ut dokument
+
+Knappen **"Skriv ut"** finns ovanför den renderade XML-vyn och är tillgänglig för alla användare.
+
+### Så här gör du
+
+1. Navigera till en XML-fil med XSLT-renderad vy
+2. Klicka **Skriv ut**
+3. Ett nytt fönster öppnas med dokumentinnehållet
+4. Webbläsarens utskriftsdialog visas automatiskt
+5. Välj skrivare eller "Spara som PDF"
+
+### Tips för renare utskrifter
+
+I utskriftsdialogen (Edge/Chrome):
+1. Expandera **"Fler inställningar"**
+2. Stäng av **"Sidhuvuden och sidfötter"** — detta tar bort URL och sidnummer
+3. Justera marginaler vid behov
+
+---
+
+## Behörigheter
+
+### Roller
+
+| Roll | Beskrivning | Krävs för |
+|------|-------------|-----------|
+| `representation.read` | Läsa representationer och filer | Visa XSLT-renderad förhandsvisning |
+| `representation.apply_xslt` | Applicera egen XSLT-stilmall | Ladda upp och applicera egen XSLT |
+
+### Tilldela rollen i gränssnittet
+
+1. Gå till **Administration → Användare**
+2. Redigera användaren
+3. Under **Behörigheter → Representationer och filer**, markera **"Applicera egen XSLT-stilmall"**
+4. Spara
+
+> **OBS:** Gruppen "administrators" är skyddad och kan inte redigeras via gränssnittet. Tilldela rollen direkt på användarobjektet istället.
+
+### Tekniskt
+
+Rollen definieras i `roda-roles.properties`:
+
+```properties
+core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = representation.apply_xslt
+```
+
+Rollen registreras i gränssnittet via `roda-wui.properties`:
+
+```properties
+ui.role: representation.apply_xslt
+```
+
+Rollen skapas automatiskt i LDAP vid ETERNA:s första start (bootstrap) baserat på `roda-roles.properties`.
+
+---
+
+## REST API
+
+### Förhandsvisning av XML som HTML
+
+```
+GET /api/v2/files/{uuid}/preview/html?lang={locale}
+```
+
+| Parameter | Typ | Beskrivning |
+|-----------|-----|-------------|
+| `uuid` | Sökväg | Filens UUID |
+| `lang` | Query (valfri, standard: `sv`) | Språk/locale |
+
+**Svar:**
+- `200 OK` — HTML-renderat dokument
+- `401 Unauthorized` — Saknar behörighet
+- `404 Not Found` — Ingen stilmall hittades
+
+**Behörighet:** `representation.read`
+
+### Transformation med egen XSLT
+
+```
+POST /api/v2/files/{uuid}/preview/html/transform?lang={locale}
+Content-Type: multipart/form-data
+```
+
+| Parameter | Typ | Beskrivning |
+|-----------|-----|-------------|
+| `uuid` | Sökväg | Filens UUID |
+| `lang` | Query (valfri, standard: `sv`) | Språk/locale |
+| `xslt` | Fil (multipart) | XSLT-stilmall att applicera |
+
+**Svar:**
+- `200 OK` — HTML-renderat dokument med den uppladdade stilmallen
+- `401 Unauthorized` — Saknar behörighet
+- `404 Not Found` — Filen hittades inte
+
+**Behörighet:** `representation.apply_xslt`
+
+### Exempel med curl
+
+```bash
+# Förhandsvisning med standard-XSLT
+curl -u admin:eterna \
+  'http://localhost:8080/api/v2/files/{uuid}/preview/html?lang=sv'
+
+# Transformation med egen XSLT
+curl -u admin:eterna \
+  -X POST \
+  -F 'xslt=@min_stilmall.xslt' \
+  'http://localhost:8080/api/v2/files/{uuid}/preview/html/transform?lang=sv'
+```
+
+---
+
+## Konfiguration
+
+### Namnrymdsregler
+
+I `roda-wui.properties` kan man konfigurera vilken global stilmall som ska användas för en viss XML-namnrymd:
+
+```properties
+ui.viewer.xslt.representation.rules = cgm_pmo
+ui.viewer.xslt.representation.rules.cgm_pmo.namespace = http://www.cgm.com/sv/pmo/v1
+ui.viewer.xslt.representation.rules.cgm_pmo.xslt = cgm_pmo_journal
+```
+
+### Stilmallsplacering
+
+Globala stilmallar placeras i:
+
+```
+~/.roda/config/crosswalks/dissemination/html/representation/   (representationsfiler)
+~/.roda/config/crosswalks/dissemination/html/                  (beskrivande metadata)
+```
+
+Filer i `~/.roda/config/` har företräde framför standardkonfigurationen i JAR-filen.
+
+### Saxon-cache
+
+Kompilerade XSLT-stilmallar cachas i 1 minut. Ändringar i stilmallar på disk slår igenom efter att cachen löper ut — ingen omstart behövs.
+
+---
+
+## Tekniska detaljer
+
+### XSLT-motor
+
+- **Bibliotek:** Saxon HE (Home Edition)
+- **XSLT-version:** 2.0
+- **Cache:** LoadingCache med 1 minuts TTL för kompilerade stilmallar
+- **Säkerhet:** Externa entiteter och DTD-bearbetning är avaktiverade
+
+### Namnrymdsdetektering
+
+Systemet läser de första 4 KB av XML-filen och använder `XMLStreamReader` för att extrahera rotelementets namnrymd. Detta görs utan att ladda hela filen i minnet.
+
+### Klient (GWT)
+
+- XML-förhandsvisningen renderas i en `<iframe>` med `srcdoc`-attribut
+- HTML hämtas via `RequestBuilder` (GET) och injiceras direkt
+- Uppladdning av egen XSLT använder `FormData` och `XMLHttpRequest` (nativ JavaScript via JSNI)
+- Utskrift öppnar ett nytt fönster med dokumentinnehållet och anropar `window.print()`
+
+### Behörighetskontroll
+
+Behörighetskontrollen sker på två nivåer:
+
+1. **Serversidan:** `FilesController` kontrollerar rollen via `controllerAssistant.checkRoles()`
+2. **Klientsidan:** `BitstreamPreview` kontrollerar rollen asynkront via `UserLogin.getInstance().checkRole()` för att visa/dölja verktygsfältet
+
+### commons-ip2-begränsning
+
+Vid inmatning av SIP-paket via commons-ip2 (v2.10.1) placeras representationsdokumentation alltid på paketnivå i AIP:et, även om den var korrekt placerad på representationsnivå i SIP:et. ETERNA:s sökkod hanterar detta genom att söka på båda nivåerna.
+
+---
+
+## Kända begränsningar
+
+1. **commons-ip2 dokumentationsplacering** — Representationsdokumentation hamnar på paketnivå efter inmatning. Hanteras av fallback-sökning i koden.
+
+2. **Stilmallscache** — Ändringar i globala stilmallar kan ta upp till 1 minut att slå igenom på grund av Saxon-cachen.
+
+3. **Utskrift** — Webbläsarens sidhuvud/sidfot (URL, sidnummer) måste stängas av manuellt i utskriftsdialogen under "Fler inställningar".
+
+4. **Uppladdad XSLT sparas inte** — Användaruppladdade stilmallar appliceras bara tillfälligt. De sparas inte i AIP:et eller på servern.
+
+5. **Skyddade grupper** — Gruppen "administrators" är skyddad och kan inte ändras via gränssnittet. Roller måste tilldelas direkt på användarnivå.

--- a/pom.xml
+++ b/pom.xml
@@ -986,6 +986,11 @@
                 <artifactId>gson</artifactId>
                 <version>2.11.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                <artifactId>owasp-java-html-sanitizer</artifactId>
+                <version>20240325.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <reporting>

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -112,6 +112,7 @@ public final class RodaConstants {
   public static final String CROSSWALKS_DISSEMINATION_HTML_PATH = "crosswalks/dissemination/html/";
   public static final String CROSSWALKS_DISSEMINATION_HTML_EVENT_PATH = "crosswalks/dissemination/html/event.xslt";
   public static final String CROSSWALKS_DISSEMINATION_OTHER_PATH = "crosswalks/other/";
+  public static final String CROSSWALKS_DISSEMINATION_HTML_REPRESENTATION_PATH = "crosswalks/dissemination/html/representation/";
   public static final String UI_BROWSER_METADATA_DESCRIPTIVE_TYPES = "ui.browser.metadata.descriptive.types";
   public static final String I18N_UI_BROWSE_METADATA_DESCRIPTIVE_TYPE_PREFIX = "ui.browse.metadata.descriptive.type.";
   public static final String I18N_UI_BROWSE_METADATA_TECHNICAL_TYPE_PREFIX = "ui.browse.metadata.technical.type.";

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1209,6 +1209,10 @@ public final class RodaConstants {
   public static final String REPOSITORY_PERMISSIONS_LOCAL_INSTANCES_MANAGE = "local_instance_configuration.manage";
   public static final String REPOSITORY_PERMISSIONS_LOCAL_INSTANCES_READ = "local_instance_configuration.read";
 
+  public static final String REPOSITORY_PERMISSIONS_METADATA_TRANSFORM_XSLT = "metadata.transform.xslt";
+
+  public static final String PERMISSION_METHOD_TRANSFORM_DESCRIPTIVE_METADATA_WITH_XSLT = "org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt";
+
   public static final String LOG_ACTION_COMPONENT = "actionComponent";
   public static final String LOG_ACTION_METHOD = "actionMethod";
   public static final String LOG_ADDRESS = "address";

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
@@ -244,6 +244,46 @@ public class RodaUtils {
     }
   }
 
+  public static Reader applyCustomStylesheet(Binary binary, InputStream xsltInputStream,
+    Map<String, String> parameters) throws GenericException {
+    try (
+      Reader descMetadataReader = new InputStreamReader(new BOMInputStream(binary.getContent().createInputStream()))) {
+
+      XMLReader xmlReader = XMLReaderFactory.createXMLReader();
+      xmlReader.setEntityResolver(new RodaEntityResolver());
+      InputSource source = new InputSource(descMetadataReader);
+      Source text = new SAXSource(xmlReader, source);
+
+      XsltCompiler compiler = PROCESSOR.newXsltCompiler();
+      compiler.setURIResolver(new RodaURIFileResolver());
+      XsltExecutable xsltExecutable = compiler.compile(new StreamSource(xsltInputStream));
+
+      XsltTransformer transformer = xsltExecutable.load();
+      CharArrayWriter transformerResult = new CharArrayWriter();
+
+      transformer.setSource(text);
+      transformer.setDestination(PROCESSOR.newSerializer(transformerResult));
+
+      for (Entry<String, String> parameter : parameters.entrySet()) {
+        QName qName = new QName(parameter.getKey());
+        XdmValue xdmValue = new XdmAtomicValue(parameter.getValue());
+        transformer.setParameter(qName, xdmValue);
+      }
+
+      QName qNameMap = new QName("i18n");
+      XdmMap xdmMap = XdmMap.makeMap(parameters);
+      transformer.setParameter(qNameMap, xdmMap);
+
+      transformer.transform();
+
+      return new CharArrayReader(transformerResult.toCharArray());
+
+    } catch (IOException | SAXException | SaxonApiException e) {
+      throw new GenericException("Could not apply custom XSLT stylesheet to binary " + binary.getStoragePath(), e);
+    }
+  }
+
+
   public static Reader applyEventStylesheet(Binary binary, boolean onlyDetails, Map<String, String> translations,
     String path) throws GenericException {
     try (

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
@@ -26,7 +26,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -60,6 +64,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
+import net.sf.saxon.Configuration;
+import net.sf.saxon.lib.Feature;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
@@ -73,7 +79,16 @@ import net.sf.saxon.s9api.XsltTransformer;
 public class RodaUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(RodaUtils.class);
 
-  private static final Processor PROCESSOR = new Processor(false);
+  private static final long XSLT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_OUTPUT_SIZE = 10 * 1024 * 1024; // 10 MB
+
+  private static final Processor PROCESSOR = createSecuredProcessor();
+
+  private static Processor createSecuredProcessor() {
+    Configuration config = new Configuration();
+    config.setBooleanProperty(Feature.ALLOW_EXTERNAL_FUNCTIONS, false);
+    return new Processor(config);
+  }
 
   private static final LoadingCache<Triple<String, String, String>, XsltExecutable> CACHE = CacheBuilder.newBuilder()
     .expireAfterWrite(1, TimeUnit.MINUTES).build(new CacheLoader<Triple<String, String, String>, XsltExecutable>() {
@@ -95,6 +110,71 @@ public class RodaUtils {
         return createEventTransformer(path);
       }
     });
+
+  /**
+   * CharArrayWriter with a size limit to prevent output-based resource exhaustion.
+   */
+  private static class LimitedCharArrayWriter extends CharArrayWriter {
+    private final int limit;
+
+    LimitedCharArrayWriter(int limit) {
+      this.limit = limit;
+    }
+
+    @Override
+    public void write(int c) {
+      checkLimit(1);
+      super.write(c);
+    }
+
+    @Override
+    public void write(char[] c, int off, int len) {
+      checkLimit(len);
+      super.write(c, off, len);
+    }
+
+    @Override
+    public void write(String str, int off, int len) {
+      checkLimit(len);
+      super.write(str, off, len);
+    }
+
+    private void checkLimit(int additional) {
+      if (size() + additional > limit) {
+        throw new RuntimeException("XSLT output exceeded maximum size of " + limit + " bytes");
+      }
+    }
+  }
+
+  /**
+   * Executes an XSLT transformation with a timeout to prevent infinite loops.
+   */
+  private static void transformWithTimeout(XsltTransformer transformer) throws GenericException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> future = executor.submit(() -> {
+        try {
+          transformer.transform();
+        } catch (SaxonApiException e) {
+          throw new RuntimeException(e);
+        }
+      });
+      future.get(XSLT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      throw new GenericException("XSLT transformation timed out after " + XSLT_TIMEOUT_SECONDS + " seconds");
+    } catch (java.util.concurrent.ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException && cause.getCause() instanceof SaxonApiException) {
+        throw new GenericException("XSLT transformation failed", cause.getCause());
+      }
+      throw new GenericException("XSLT transformation failed", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new GenericException("XSLT transformation interrupted", e);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
 
   /** Private empty constructor */
   private RodaUtils() {
@@ -219,7 +299,7 @@ public class RodaUtils {
       XsltExecutable xsltExecutable = CACHE.get(Triple.of(basePath, metadataType, metadataVersion));
 
       XsltTransformer transformer = xsltExecutable.load();
-      CharArrayWriter transformerResult = new CharArrayWriter();
+      LimitedCharArrayWriter transformerResult = new LimitedCharArrayWriter(MAX_OUTPUT_SIZE);
 
       transformer.setSource(text);
       transformer.setDestination(PROCESSOR.newSerializer(transformerResult));
@@ -234,11 +314,11 @@ public class RodaUtils {
       XdmMap xdmMap = XdmMap.makeMap(parameters);
       transformer.setParameter(qNameMap, xdmMap);
 
-      transformer.transform();
+      transformWithTimeout(transformer);
 
       return new CharArrayReader(transformerResult.toCharArray());
 
-    } catch (IOException | SAXException | ExecutionException | SaxonApiException e) {
+    } catch (IOException | SAXException | ExecutionException e) {
       throw new GenericException("Could not process descriptive metadata binary " + binary.getStoragePath()
         + " metadata type " + metadataType + " and version " + metadataVersion, e);
     }
@@ -259,7 +339,7 @@ public class RodaUtils {
       XsltExecutable xsltExecutable = compiler.compile(new StreamSource(xsltInputStream));
 
       XsltTransformer transformer = xsltExecutable.load();
-      CharArrayWriter transformerResult = new CharArrayWriter();
+      LimitedCharArrayWriter transformerResult = new LimitedCharArrayWriter(MAX_OUTPUT_SIZE);
 
       transformer.setSource(text);
       transformer.setDestination(PROCESSOR.newSerializer(transformerResult));
@@ -274,7 +354,7 @@ public class RodaUtils {
       XdmMap xdmMap = XdmMap.makeMap(parameters);
       transformer.setParameter(qNameMap, xdmMap);
 
-      transformer.transform();
+      transformWithTimeout(transformer);
 
       return new CharArrayReader(transformerResult.toCharArray());
 
@@ -297,7 +377,7 @@ public class RodaUtils {
       XsltExecutable xsltExecutable = EVENT_CACHE.get(path);
 
       XsltTransformer transformer = xsltExecutable.load();
-      CharArrayWriter transformerResult = new CharArrayWriter();
+      LimitedCharArrayWriter transformerResult = new LimitedCharArrayWriter(MAX_OUTPUT_SIZE);
 
       transformer.setSource(text);
       transformer.setDestination(PROCESSOR.newSerializer(transformerResult));
@@ -311,9 +391,9 @@ public class RodaUtils {
         transformer.setParameter(qName, xdmValue);
       }
 
-      transformer.transform();
+      transformWithTimeout(transformer);
       return new CharArrayReader(transformerResult.toCharArray());
-    } catch (IOException | SAXException | ExecutionException | SaxonApiException e) {
+    } catch (IOException | SAXException | ExecutionException e) {
       LOGGER.error(e.getMessage(), e);
       throw new GenericException("Could not process event binary " + binary.getStoragePath(), e);
     }

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/RodaUtils.java
@@ -149,18 +149,22 @@ public class RodaUtils {
   /**
    * Executes an XSLT transformation with a timeout to prevent infinite loops.
    */
+  private static final ExecutorService XSLT_EXECUTOR = Executors.newFixedThreadPool(
+    Math.max(2, Runtime.getRuntime().availableProcessors()),
+    r -> { Thread t = new Thread(r, "xslt-transform"); t.setDaemon(true); return t; });
+
   private static void transformWithTimeout(XsltTransformer transformer) throws GenericException {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<?> future = XSLT_EXECUTOR.submit(() -> {
+      try {
+        transformer.transform();
+      } catch (SaxonApiException e) {
+        throw new RuntimeException(e);
+      }
+    });
     try {
-      Future<?> future = executor.submit(() -> {
-        try {
-          transformer.transform();
-        } catch (SaxonApiException e) {
-          throw new RuntimeException(e);
-        }
-      });
       future.get(XSLT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (TimeoutException e) {
+      future.cancel(true);
       throw new GenericException("XSLT transformation timed out after " + XSLT_TIMEOUT_SECONDS + " seconds");
     } catch (java.util.concurrent.ExecutionException e) {
       Throwable cause = e.getCause();
@@ -171,8 +175,6 @@ public class RodaUtils {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new GenericException("XSLT transformation interrupted", e);
-    } finally {
-      executor.shutdownNow();
     }
   }
 

--- a/roda-core/roda-core/src/main/resources/config/crosswalks/ingest/cgm_pmo_v1.xslt
+++ b/roda-core/roda-core/src/main/resources/config/crosswalks/ingest/cgm_pmo_v1.xslt
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:pmo="http://www.cgm.com/sv/pmo/v1"
+    exclude-result-prefixes="pmo">
+    <xsl:output method="xml" indent="yes" encoding="UTF-8" omit-xml-declaration="yes" />
+
+    <xsl:template match="/">
+        <doc>
+            <xsl:apply-templates select="pmo:JournalExport" />
+        </doc>
+    </xsl:template>
+
+    <xsl:template match="pmo:JournalExport">
+        <xsl:variable name="name" select="pmo:PatientData/pmo:Patient/pmo:Name" />
+        <xsl:variable name="code" select="pmo:PatientData/pmo:Patient/pmo:CodeNumber" />
+
+        <!-- Title: Name + Personnummer -->
+        <field name="title">
+            <xsl:value-of select="$name" />
+            <xsl:text> (</xsl:text>
+            <xsl:value-of select="$code" />
+            <xsl:text>)</xsl:text>
+        </field>
+        <field name="title_txt">
+            <xsl:value-of select="$name" />
+        </field>
+
+        <!-- Description -->
+        <field name="description">
+            <xsl:text>Elevhälsojournal - </xsl:text>
+            <xsl:value-of select="$name" />
+            <xsl:text>, </xsl:text>
+            <xsl:value-of select="$code" />
+            <xsl:text>. Exporterad från </xsl:text>
+            <xsl:value-of select="pmo:DataOrigin/pmo:System" />
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="pmo:DataOrigin/pmo:SystemVersion" />
+        </field>
+
+        <!-- Date -->
+        <xsl:variable name="created" select="substring(pmo:DataOrigin/pmo:Created, 1, 10)" />
+        <xsl:if test="string-length($created) = 10">
+            <field name="dateInitial"><xsl:value-of select="$created" />T00:00:00Z</field>
+            <field name="dateFinal"><xsl:value-of select="$created" />T00:00:00Z</field>
+        </xsl:if>
+
+        <!-- Creator / Organization -->
+        <field name="creator_txt">
+            <xsl:value-of select="pmo:DataOrigin/pmo:OrganizationName" />
+        </field>
+
+        <!-- Level -->
+        <field name="level">item</field>
+
+        <!-- Searchable text fields -->
+        <field name="identifier_txt"><xsl:value-of select="$code" /></field>
+
+        <xsl:if test="normalize-space(pmo:PatientData/pmo:Patient/pmo:BirthDate) != ''">
+            <field name="date_txt"><xsl:value-of select="pmo:PatientData/pmo:Patient/pmo:BirthDate" /></field>
+        </xsl:if>
+
+        <xsl:if test="normalize-space(pmo:CaseBookName) != ''">
+            <field name="subject_txt"><xsl:value-of select="pmo:CaseBookName" /></field>
+        </xsl:if>
+
+        <field name="type_txt">Elevhälsojournal</field>
+        <field name="language_txt">sv</field>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
@@ -224,3 +224,4 @@ core.permissions.org.roda.wui.api.controllers.Browser.listOtherMetadata = READ
 core.permissions.org.roda.wui.api.controllers.Browser.retrieveOtherMetadata = READ
 core.permissions.org.roda.wui.api.controllers.Browser.createOrUpdateOtherMetadata = UPDATE
 core.permissions.org.roda.wui.api.controllers.Browser.deleteOtherMetadata = DELETE
+	core.permissions.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = READ

--- a/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
@@ -224,7 +224,7 @@ core.permissions.org.roda.wui.api.controllers.Browser.listOtherMetadata = READ
 core.permissions.org.roda.wui.api.controllers.Browser.retrieveOtherMetadata = READ
 core.permissions.org.roda.wui.api.controllers.Browser.createOrUpdateOtherMetadata = UPDATE
 core.permissions.org.roda.wui.api.controllers.Browser.deleteOtherMetadata = DELETE
-	core.permissions.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = READ
+core.permissions.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = READ
 
 core.permissions.org.roda.wui.api.v2.controller.FilesController.previewFileAsHTML = READ
 core.permissions.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = READ

--- a/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-permissions.properties
@@ -225,3 +225,6 @@ core.permissions.org.roda.wui.api.controllers.Browser.retrieveOtherMetadata = RE
 core.permissions.org.roda.wui.api.controllers.Browser.createOrUpdateOtherMetadata = UPDATE
 core.permissions.org.roda.wui.api.controllers.Browser.deleteOtherMetadata = DELETE
 	core.permissions.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = READ
+
+core.permissions.org.roda.wui.api.v2.controller.FilesController.previewFileAsHTML = READ
+core.permissions.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = READ

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -622,3 +622,5 @@ core.roles.org.roda.wui.api.controllers.ApplicationAuth.revokeAccessKey = access
 core.roles.org.roda.wui.api.controllers.RODAInstance.synchronizeIfUpdated = local_instance_configuration.manage
 core.roles.org.roda.wui.api.controllers.DiskController.getDiskStats = aip.read
 
+
+	core.roles.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = metadata.transform.xslt

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -623,7 +623,7 @@ core.roles.org.roda.wui.api.controllers.RODAInstance.synchronizeIfUpdated = loca
 core.roles.org.roda.wui.api.controllers.DiskController.getDiskStats = aip.read
 
 
-	core.roles.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = metadata.transform.xslt
+core.roles.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = metadata.transform.xslt
 
 core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileAsHTML = representation.read
 core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = representation.apply_xslt

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -624,3 +624,6 @@ core.roles.org.roda.wui.api.controllers.DiskController.getDiskStats = aip.read
 
 
 	core.roles.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = metadata.transform.xslt
+
+core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileAsHTML = representation.read
+core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = representation.read

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -626,4 +626,4 @@ core.roles.org.roda.wui.api.controllers.DiskController.getDiskStats = aip.read
 	core.roles.org.roda.wui.api.v2.controller.AIPController.transformDescriptiveMetadataWithXslt = metadata.transform.xslt
 
 core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileAsHTML = representation.read
-core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = representation.read
+core.roles.org.roda.wui.api.v2.controller.FilesController.previewFileWithCustomXSLT = representation.apply_xslt

--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -729,6 +729,10 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2649,4 +2649,10 @@ public interface ClientMessages extends Messages {
   String reasonCantActOnUser();
 
   String reasonCantActOnGroup();
+
+  /*** XSLT Transform ***/
+  String applyXsltButton();
+
+  String xsltTransformError();
+
 }

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2655,4 +2655,18 @@ public interface ClientMessages extends Messages {
 
   String xsltTransformError();
 
+  String xsltLoading();
+
+  String xsltPrintButton();
+
+  String xsltFileTooLarge();
+
+  String xsltTransformFailed();
+
+  String xsltUploadError();
+
+  String xsltTransformTimeout();
+
+  String xsltPrintError();
+
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
@@ -18,6 +18,7 @@ import org.roda.core.RodaCoreFactory;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.LockingException;
 import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.v2.StreamResponse;
 import org.roda.core.data.v2.aip.AssessmentRequest;
@@ -390,8 +391,26 @@ public class AIPController implements AIPRestService, Exportable {
             RodaConstants.CONTROLLER_METADATA_ID_PARAM, descriptiveMetadataId);
 
           IndexedAIP indexedAIP = requestContext.getIndexService().retrieve(IndexedAIP.class, aipId,
-            RodaConstants.REPRESENTATION_FIELDS_TO_RETURN);
+            RodaConstants.AIP_PERMISSIONS_FIELDS_TO_RETURN);
           controllerAssistant.checkObjectPermissions(requestContext.getUser(), indexedAIP);
+
+          // Validate XSLT file size (max 1 MB)
+          long maxXsltSize = 1024 * 1024;
+          if (xsltFile.getSize() > maxXsltSize) {
+            throw new RequestNotValidException("XSLT file exceeds maximum size of 1 MB");
+          }
+
+          // Validate XSLT is well-formed XML
+          try (java.io.InputStream validationStream = xsltFile.getInputStream()) {
+            javax.xml.stream.XMLInputFactory xmlFactory = javax.xml.stream.XMLInputFactory.newInstance();
+            xmlFactory.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            xmlFactory.setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, false);
+            javax.xml.stream.XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(validationStream);
+            while (xmlReader.hasNext()) { xmlReader.next(); }
+            xmlReader.close();
+          } catch (Exception e) {
+            throw new RequestNotValidException("Uploaded file is not valid XML: " + e.getMessage());
+          }
 
           StreamResponse streamResponse = aipService.transformDescriptiveMetadataWithCustomXslt(requestContext,
             aipId, descriptiveMetadataId, xsltFile.getInputStream(), localeString);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.LockingException;
+import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.v2.StreamResponse;
 import org.roda.core.data.v2.aip.AssessmentRequest;
@@ -78,11 +79,14 @@ import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
@@ -362,6 +366,44 @@ public class AIPController implements AIPRestService, Exportable {
     });
 
   }
+
+  @PostMapping(path = "/{id}/metadata/descriptive/{descriptive-metadata-id}/transform", produces = MediaType.TEXT_HTML_VALUE)
+  @Operation(summary = "Transform descriptive metadata with custom XSLT",
+    description = "Apply a user-provided XSLT stylesheet to transform descriptive metadata XML into HTML.",
+    responses = {
+      @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.TEXT_HTML_VALUE)),
+      @ApiResponse(responseCode = "404", description = "Not found"),
+      @ApiResponse(responseCode = "403", description = "Forbidden")})
+  ResponseEntity<StreamingResponseBody> transformDescriptiveMetadataWithXslt(
+    @PathVariable(name = "id") String aipId,
+    @PathVariable(name = "descriptive-metadata-id") String descriptiveMetadataId,
+    @RequestPart(value = "xslt") MultipartFile xsltFile,
+    @RequestParam(name = "lang", defaultValue = "en", required = false) String localeString)
+    throws RODAException, RESTException {
+
+    return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
+      @Override
+      public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
+        try {
+          controllerAssistant.setParameters(RodaConstants.CONTROLLER_AIP_ID_PARAM, aipId,
+            RodaConstants.CONTROLLER_METADATA_ID_PARAM, descriptiveMetadataId);
+
+          IndexedAIP indexedAIP = requestContext.getIndexService().retrieve(IndexedAIP.class, aipId,
+            RodaConstants.REPRESENTATION_FIELDS_TO_RETURN);
+          controllerAssistant.checkObjectPermissions(requestContext.getUser(), indexedAIP);
+
+          StreamResponse streamResponse = aipService.transformDescriptiveMetadataWithCustomXslt(requestContext,
+            aipId, descriptiveMetadataId, xsltFile.getInputStream(), localeString);
+          return ApiUtils.okResponse(streamResponse);
+        } catch (java.io.IOException e) {
+          throw new GenericException("Could not read XSLT file", e);
+        }
+      }
+    });
+  }
+
+
 
   @GetMapping(path = "{id}/download/documentation", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
   @Operation(summary = "Downloads documentation", description = "Download AIP documentation", responses = {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
@@ -494,7 +494,7 @@ public class FilesController implements FileRestService, Exportable {
     @ApiResponse(responseCode = "404", description = "No stylesheet found for this file type", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   ResponseEntity<StreamingResponseBody> previewFileAsHTML(
     @Parameter(description = "The file UUID", required = true) @PathVariable(name = "uuid") String fileUUID,
-    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "sv", required = false) String localeString) {
+    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "en", required = false) String localeString) {
     return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
       @Override
       public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
@@ -518,7 +518,7 @@ public class FilesController implements FileRestService, Exportable {
     @ApiResponse(responseCode = "404", description = "File not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   ResponseEntity<StreamingResponseBody> previewFileWithCustomXSLT(
     @Parameter(description = "The file UUID", required = true) @PathVariable(name = "uuid") String fileUUID,
-    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "sv", required = false) String localeString,
+    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "en", required = false) String localeString,
     @Parameter(content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class)), description = "XSLT stylesheet file") @RequestPart(value = "xslt") MultipartFile xsltFile) {
     return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
       @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
@@ -11,11 +11,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.io.InputStream;
 import java.util.ArrayList;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
 import java.util.List;
 
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.v2.StreamResponse;
 import org.roda.core.data.v2.file.CreateFolderRequest;
@@ -526,6 +530,25 @@ public class FilesController implements FileRestService, Exportable {
         fileFields.add(RodaConstants.FILE_ISDIRECTORY);
         IndexedFile file = indexService.retrieve(IndexedFile.class, fileUUID, fileFields);
         controllerAssistant.checkObjectPermissions(requestContext.getUser(), file);
+
+        // Validate XSLT file size (max 1 MB)
+        long maxXsltSize = 1024 * 1024;
+        if (xsltFile.getSize() > maxXsltSize) {
+          throw new RequestNotValidException("XSLT file exceeds maximum size of 1 MB");
+        }
+
+        // Validate XSLT is well-formed XML
+        try (InputStream validationStream = xsltFile.getInputStream()) {
+          XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+          xmlFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+          xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+          XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(validationStream);
+          while (xmlReader.hasNext()) { xmlReader.next(); }
+          xmlReader.close();
+        } catch (Exception e) {
+          throw new RequestNotValidException("Uploaded file is not valid XML: " + e.getMessage());
+        }
+
         try {
           StreamResponse streamResponse = filesService.retrieveFileContentHTMLWithCustomXslt(
             requestContext, file, xsltFile.getInputStream(), localeString);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
@@ -483,4 +483,58 @@ public class FilesController implements FileRestService, Exportable {
       }
     });
   }
+  @GetMapping(path = "/{uuid}/preview/html", produces = MediaType.TEXT_HTML_VALUE)
+  @Operation(summary = "Renders file content as HTML", description = "Applies XSLT stylesheet to XML file content and returns rendered HTML. Returns 404 if no matching stylesheet is configured for the XML namespace.", responses = {
+    @ApiResponse(responseCode = "200", description = "Returns rendered HTML", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+    @ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
+    @ApiResponse(responseCode = "404", description = "No stylesheet found for this file type", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
+  ResponseEntity<StreamingResponseBody> previewFileAsHTML(
+    @Parameter(description = "The file UUID", required = true) @PathVariable(name = "uuid") String fileUUID,
+    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "sv", required = false) String localeString) {
+    return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
+      @Override
+      public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
+        controllerAssistant.setRelatedObjectId(fileUUID);
+        controllerAssistant.setParameters(RodaConstants.CONTROLLER_FILE_UUID_PARAM, fileUUID);
+        List<String> fileFields = new ArrayList<>(RodaConstants.FILE_FIELDS_TO_RETURN);
+        fileFields.add(RodaConstants.FILE_ISDIRECTORY);
+        IndexedFile file = indexService.retrieve(IndexedFile.class, fileUUID, fileFields);
+        controllerAssistant.checkObjectPermissions(requestContext.getUser(), file);
+        StreamResponse streamResponse = filesService.retrieveFileContentHTML(requestContext, file, localeString);
+        return ApiUtils.okResponse(streamResponse);
+      }
+    });
+  }
+
+  @PostMapping(path = "/{uuid}/preview/html/transform", produces = MediaType.TEXT_HTML_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @Operation(summary = "Renders file with custom XSLT", description = "Applies a user-provided XSLT stylesheet to the file content and returns rendered HTML.", responses = {
+    @ApiResponse(responseCode = "200", description = "Returns rendered HTML", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+    @ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
+    @ApiResponse(responseCode = "404", description = "File not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
+  ResponseEntity<StreamingResponseBody> previewFileWithCustomXSLT(
+    @Parameter(description = "The file UUID", required = true) @PathVariable(name = "uuid") String fileUUID,
+    @Parameter(description = "The language for internationalization") @RequestParam(name = "lang", defaultValue = "sv", required = false) String localeString,
+    @Parameter(content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class)), description = "XSLT stylesheet file") @RequestPart(value = "xslt") MultipartFile xsltFile) {
+    return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
+      @Override
+      public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
+        controllerAssistant.setRelatedObjectId(fileUUID);
+        controllerAssistant.setParameters(RodaConstants.CONTROLLER_FILE_UUID_PARAM, fileUUID);
+        List<String> fileFields = new ArrayList<>(RodaConstants.FILE_FIELDS_TO_RETURN);
+        fileFields.add(RodaConstants.FILE_ISDIRECTORY);
+        IndexedFile file = indexService.retrieve(IndexedFile.class, fileUUID, fileFields);
+        controllerAssistant.checkObjectPermissions(requestContext.getUser(), file);
+        try {
+          StreamResponse streamResponse = filesService.retrieveFileContentHTMLWithCustomXslt(
+            requestContext, file, xsltFile.getInputStream(), localeString);
+          return ApiUtils.okResponse(streamResponse);
+        } catch (java.io.IOException e) {
+          throw new RESTException(e);
+        }
+      }
+    });
+  }
+
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/AIPService.java
@@ -166,6 +166,31 @@ public class AIPService {
     return new StreamResponse(stream);
   }
 
+  public StreamResponse transformDescriptiveMetadataWithCustomXslt(RequestContext requestContext, String aipId,
+    String metadataId, InputStream xsltInputStream, String localeString)
+    throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
+
+    ModelService model = requestContext.getModelService();
+    Binary descriptiveMetadataBinary = model.retrieveDescriptiveMetadataBinary(aipId, metadataId);
+    DescriptiveMetadata descriptiveMetadata = model.retrieveDescriptiveMetadata(aipId, metadataId);
+    String filename = descriptiveMetadataBinary.getStoragePath().getName() + HTML_EXT;
+
+    String htmlResult = HTMLUtils.descriptiveMetadataToHtmlWithCustomXslt(descriptiveMetadataBinary,
+      xsltInputStream, descriptiveMetadata.getType(), descriptiveMetadata.getVersion(),
+      ServerTools.parseLocale(localeString));
+
+    ConsumesOutputStream stream = new DefaultConsumesOutputStream(filename, RodaConstants.MEDIA_TYPE_TEXT_HTML,
+      out -> {
+        PrintStream printStream = new PrintStream(out);
+        printStream.print(htmlResult);
+        printStream.close();
+      });
+
+    return new StreamResponse(stream);
+  }
+
+
+
   public StreamResponse downloadRepresentationDescriptiveMetadata(ModelService modelService, String aipId,
     String representationId, String metadataId, String versionId)
     throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -476,8 +476,9 @@ public class FilesService {
       Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId(), indexedFile.getRepresentationId(), indexedFile.getId());
       if (xsltBinary != null) {
         LOGGER.info("Using AIP-bundled XSLT from documentation for AIP {}", indexedFile.getAipId());
-        html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary,
-          xsltBinary.getContent().createInputStream(), locale);
+        try (InputStream xsltStream = xsltBinary.getContent().createInputStream()) {
+          html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary, xsltStream, locale);
+        }
       }
     } catch (Exception e) {
       LOGGER.debug("No bundled XSLT found in AIP documentation, falling back to config", e);
@@ -589,7 +590,7 @@ public class FilesService {
     for (String rule : rules) {
       String ruleNamespace = RodaCoreFactory.getRodaConfigurationAsString("ui", "viewer", "xslt", "representation",
         "rule", rule, "namespace");
-      if (namespace.equals(ruleNamespace)) {
+      if (ruleNamespace != null && namespace.equals(ruleNamespace)) {
         return RodaCoreFactory.getRodaConfigurationAsString("ui", "viewer", "xslt", "representation", "rule", rule,
           "xslt");
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -473,7 +473,7 @@ public class FilesService {
 
     // Strategy 1: Check AIP documentation for bundled XSLT stylesheet
     try {
-      Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId(), indexedFile.getId());
+      Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId(), indexedFile.getRepresentationId(), indexedFile.getId());
       if (xsltBinary != null) {
         LOGGER.info("Using AIP-bundled XSLT from documentation for AIP {}", indexedFile.getAipId());
         html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary,
@@ -532,24 +532,35 @@ public class FilesService {
 
 
 
-  private Binary findXsltInAipDocumentation(ModelService model, String aipId, String xmlFileName) {
+  private Binary findXsltInAipDocumentation(ModelService model, String aipId, String representationId, String xmlFileName) {
+    // Try representation-level documentation first, then package-level as fallback
+    Binary result = searchXsltInDocumentation(model, aipId, representationId, xmlFileName);
+    if (result == null && representationId != null) {
+      result = searchXsltInDocumentation(model, aipId, null, xmlFileName);
+    }
+    return result;
+  }
+
+  private Binary searchXsltInDocumentation(ModelService model, String aipId, String representationId,
+    String xmlFileName) {
     try {
-      StoragePath docPath = ModelUtils.getDocumentationStoragePath(aipId);
+      StoragePath docPath = representationId != null
+        ? ModelUtils.getDocumentationStoragePath(aipId, representationId)
+        : ModelUtils.getDocumentationStoragePath(aipId);
       CloseableIterable<Resource> resources = model.getStorage().listResourcesUnderDirectory(docPath, true);
       try {
-        // Derive expected XSLT name from XML filename (e.g. "Jrnl1.xml" -> "Jrnl1.xslt")
         String expectedXsltName = null;
         if (xmlFileName != null && xmlFileName.endsWith(".xml")) {
           expectedXsltName = xmlFileName.substring(0, xmlFileName.length() - 4) + ".xslt";
         }
 
-        // First pass: look for filename-matched XSLT
         Binary fallback = null;
         for (Resource resource : resources) {
           String name = resource.getStoragePath().getName();
           if (name != null && name.endsWith(".xslt")) {
             if (expectedXsltName != null && name.equals(expectedXsltName)) {
-              LOGGER.info("Found filename-matched XSLT '{}' for XML '{}'", name, xmlFileName);
+              String level = representationId != null ? "representation" : "package";
+              LOGGER.info("Found filename-matched XSLT '{}' for XML '{}' at {} level", name, xmlFileName, level);
               return model.getStorage().getBinary(resource.getStoragePath());
             }
             if (fallback == null) {
@@ -558,16 +569,16 @@ public class FilesService {
           }
         }
 
-        // Fallback: return first XSLT found (if any)
         if (fallback != null) {
-          LOGGER.info("No filename-matched XSLT for '{}', using fallback XSLT in AIP documentation", xmlFileName);
+          String level = representationId != null ? "representation" : "package";
+          LOGGER.info("No filename-matched XSLT for '{}', using fallback XSLT at {} level", xmlFileName, level);
         }
         return fallback;
       } finally {
         resources.close();
       }
     } catch (Exception e) {
-      LOGGER.debug("Could not list AIP documentation for {}: {}", aipId, e.getMessage());
+      LOGGER.debug("Could not list documentation for aip={}, rep={}: {}", aipId, representationId, e.getMessage());
     }
     return null;
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -75,6 +75,15 @@ import org.roda.wui.common.server.ServerTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import org.roda.core.data.v2.ip.StoragePath;
+import org.roda.core.storage.Resource;
+import org.roda.core.model.utils.ModelUtils;
+import org.roda.core.common.iterables.CloseableIterable;
 
 @Service
 public class FilesService {
@@ -247,7 +256,7 @@ public class FilesService {
   public StreamResponse retrieveAIPRepresentationFile(RequestContext requestContext, IndexedFile indexedFile)
     throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
     ModelService model = requestContext.getModelService();
-    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(File.class, indexedFile.getId());
+    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(indexedFile);
     if (liteFile.isEmpty()) {
       throw new RequestNotValidException("Couldn't retrieve file with id: " + indexedFile.getId());
     }
@@ -439,6 +448,147 @@ public class FilesService {
     ret = new StreamResponse(stream);
 
     return ret;
+  }
+
+  public StreamResponse retrieveFileContentHTML(RequestContext requestContext, IndexedFile indexedFile,
+    String localeString) throws GenericException, RequestNotValidException, NotFoundException,
+    AuthorizationDeniedException {
+
+    ModelService model = requestContext.getModelService();
+    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(indexedFile);
+    if (liteFile.isEmpty()) {
+      throw new RequestNotValidException("Couldn't retrieve file with id: " + indexedFile.getId());
+    }
+
+    Binary binary = model.getBinary(liteFile.get());
+
+    // Detect XML namespace from the file content
+    String namespace = detectXmlNamespace(binary);
+    if (namespace == null) {
+      throw new RequestNotValidException("File is not XML or has no namespace: " + indexedFile.getId());
+    }
+
+    Locale locale = ServerTools.parseLocale(localeString);
+    String html = null;
+
+    // Strategy 1: Check AIP documentation for bundled XSLT stylesheet
+    try {
+      Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId());
+      if (xsltBinary != null) {
+        LOGGER.info("Using AIP-bundled XSLT from documentation for AIP {}", indexedFile.getAipId());
+        html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary,
+          xsltBinary.getContent().createInputStream(), locale);
+      }
+    } catch (Exception e) {
+      LOGGER.debug("No bundled XSLT found in AIP documentation, falling back to config", e);
+    }
+
+    // Strategy 2: Fall back to namespace-based config lookup
+    if (html == null) {
+      String xsltName = resolveXsltForNamespace(namespace);
+      if (xsltName == null) {
+        throw new NotFoundException("No XSLT stylesheet configured for namespace: " + namespace);
+      }
+      html = HTMLUtils.representationFileToHtml(binary, xsltName, locale);
+    }
+
+    String filename = indexedFile.getId() + HTML_EXT;
+    final String finalHtml = html;
+    ConsumesOutputStream stream = new DefaultConsumesOutputStream(filename, RodaConstants.MEDIA_TYPE_TEXT_HTML,
+      out -> {
+        PrintStream printStream = new PrintStream(out);
+        printStream.print(finalHtml);
+        printStream.close();
+      });
+
+    return new StreamResponse(stream);
+  }
+
+
+  public StreamResponse retrieveFileContentHTMLWithCustomXslt(RequestContext requestContext,
+    IndexedFile indexedFile, InputStream xsltInputStream, String localeString)
+    throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
+
+    ModelService model = requestContext.getModelService();
+    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(indexedFile);
+    if (liteFile.isEmpty()) {
+      throw new RequestNotValidException("Couldn't retrieve file with id: " + indexedFile.getId());
+    }
+
+    Binary binary = model.getBinary(liteFile.get());
+    Locale locale = ServerTools.parseLocale(localeString);
+    String html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary, xsltInputStream, locale);
+
+    String filename = indexedFile.getId() + HTML_EXT;
+    ConsumesOutputStream stream = new DefaultConsumesOutputStream(filename, RodaConstants.MEDIA_TYPE_TEXT_HTML,
+      out -> {
+        PrintStream printStream = new PrintStream(out);
+        printStream.print(html);
+        printStream.close();
+      });
+
+    return new StreamResponse(stream);
+  }
+
+
+
+  private Binary findXsltInAipDocumentation(ModelService model, String aipId) {
+    try {
+      StoragePath docPath = ModelUtils.getDocumentationStoragePath(aipId);
+      CloseableIterable<Resource> resources = model.getStorage().listResourcesUnderDirectory(docPath, true);
+      try {
+        for (Resource resource : resources) {
+          String name = resource.getStoragePath().getName();
+          if (name != null && name.endsWith(".xslt")) {
+            return model.getStorage().getBinary(resource.getStoragePath());
+          }
+        }
+      } finally {
+        resources.close();
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Could not list AIP documentation for {}: {}", aipId, e.getMessage());
+    }
+    return null;
+  }
+
+  private String resolveXsltForNamespace(String namespace) {
+    List<String> rules = RodaCoreFactory.getRodaConfigurationAsList("ui", "viewer", "xslt", "representation",
+      "rules");
+    for (String rule : rules) {
+      String ruleNamespace = RodaCoreFactory.getRodaConfigurationAsString("ui", "viewer", "xslt", "representation",
+        "rule", rule, "namespace");
+      if (namespace.equals(ruleNamespace)) {
+        return RodaCoreFactory.getRodaConfigurationAsString("ui", "viewer", "xslt", "representation", "rule", rule,
+          "xslt");
+      }
+    }
+    return null;
+  }
+
+  private String detectXmlNamespace(Binary binary) {
+    try (InputStream is = binary.getContent().createInputStream()) {
+      byte[] header = new byte[4096];
+      int read = is.read(header);
+      if (read <= 0) return null;
+
+      XMLInputFactory factory = XMLInputFactory.newInstance();
+      factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+      factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      XMLStreamReader reader = factory.createXMLStreamReader(new ByteArrayInputStream(header, 0, read));
+      while (reader.hasNext()) {
+        int event = reader.next();
+        if (event == XMLStreamReader.START_ELEMENT) {
+          String ns = reader.getNamespaceURI();
+          reader.close();
+          return ns;
+        }
+      }
+      reader.close();
+    } catch (Exception e) {
+      LOGGER.debug("Could not detect XML namespace", e);
+    }
+    return null;
   }
 
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -473,7 +473,7 @@ public class FilesService {
 
     // Strategy 1: Check AIP documentation for bundled XSLT stylesheet
     try {
-      Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId());
+      Binary xsltBinary = findXsltInAipDocumentation(model, indexedFile.getAipId(), indexedFile.getId());
       if (xsltBinary != null) {
         LOGGER.info("Using AIP-bundled XSLT from documentation for AIP {}", indexedFile.getAipId());
         html = HTMLUtils.representationFileToHtmlWithCustomXslt(binary,
@@ -532,17 +532,37 @@ public class FilesService {
 
 
 
-  private Binary findXsltInAipDocumentation(ModelService model, String aipId) {
+  private Binary findXsltInAipDocumentation(ModelService model, String aipId, String xmlFileName) {
     try {
       StoragePath docPath = ModelUtils.getDocumentationStoragePath(aipId);
       CloseableIterable<Resource> resources = model.getStorage().listResourcesUnderDirectory(docPath, true);
       try {
+        // Derive expected XSLT name from XML filename (e.g. "Jrnl1.xml" -> "Jrnl1.xslt")
+        String expectedXsltName = null;
+        if (xmlFileName != null && xmlFileName.endsWith(".xml")) {
+          expectedXsltName = xmlFileName.substring(0, xmlFileName.length() - 4) + ".xslt";
+        }
+
+        // First pass: look for filename-matched XSLT
+        Binary fallback = null;
         for (Resource resource : resources) {
           String name = resource.getStoragePath().getName();
           if (name != null && name.endsWith(".xslt")) {
-            return model.getStorage().getBinary(resource.getStoragePath());
+            if (expectedXsltName != null && name.equals(expectedXsltName)) {
+              LOGGER.info("Found filename-matched XSLT '{}' for XML '{}'", name, xmlFileName);
+              return model.getStorage().getBinary(resource.getStoragePath());
+            }
+            if (fallback == null) {
+              fallback = model.getStorage().getBinary(resource.getStoragePath());
+            }
           }
         }
+
+        // Fallback: return first XSLT found (if any)
+        if (fallback != null) {
+          LOGGER.info("No filename-matched XSLT for '{}', using fallback XSLT in AIP documentation", xmlFileName);
+        }
+        return fallback;
       } finally {
         resources.close();
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -58,6 +58,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
   private static final String VIEWER_TYPE_HTML = "html";
   private static final String VIEWER_TYPE_PDF = "pdf";
   private static final String VIEWER_TYPE_IMAGE = "image";
+  private static final String VIEWER_TYPE_XML = "xml";
 
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
 
@@ -182,7 +183,11 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       } else if (type.equals(VIEWER_TYPE_PDF)) {
         pdfPreview();
       } else if (type.equals(VIEWER_TYPE_TEXT)) {
-        textPreview();
+        if (isXmlFile()) {
+          xmlHtmlPreview();
+        } else {
+          textPreview();
+        }
       } else if (type.equals(VIEWER_TYPE_HTML)) {
         htmlPreview();
       } else if (type.equals(VIEWER_TYPE_AUDIO)) {
@@ -192,6 +197,8 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       } else {
         notSupportedPreview();
       }
+    } else if (isXmlFile()) {
+      xmlHtmlPreview();
     } else if (object instanceof IndexedDIP) {
       IndexedDIP dip = (IndexedDIP) object;
       dipUrlPreview(dip);
@@ -503,6 +510,57 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
     html.setHTML(b.toSafeHtml());
     html.setStyleName("viewRepresentationEmptyPreview");
     return html;
+  }
+
+
+  private boolean isXmlFile() {
+    if (format != null && format.getMimeType() != null) {
+      String mime = format.getMimeType().toLowerCase();
+      if (mime.equals("text/xml") || mime.equals("application/xml") || mime.endsWith("+xml")) {
+        return true;
+      }
+    }
+    if (filename != null && filename.toLowerCase().endsWith(".xml")) {
+      return true;
+    }
+    return false;
+  }
+
+  private void xmlHtmlPreview() {
+    if (object instanceof IndexedFile) {
+      IndexedFile indexedFile = (IndexedFile) object;
+      String htmlUrl = GWT.getHostPageBaseURL() + "api/v2/files/" + indexedFile.getUUID()
+        + "/preview/html?lang=" + LocaleInfo.getCurrentLocale().getLocaleName();
+
+      RequestBuilder request = new RequestBuilder(RequestBuilder.GET, htmlUrl);
+      try {
+        request.sendRequest(null, new RequestCallback() {
+          @Override
+          public void onResponseReceived(Request req, Response response) {
+            if (response.getStatusCode() == HttpStatus.SC_OK) {
+              // XSLT rendering available - show as HTML in iframe
+              Frame frame = new Frame();
+              String html = response.getText();
+              frame.getElement().setAttribute("srcdoc", html);
+              frame.setStyleName("viewRepresentationHtmlFilePreview");
+              panel.add(frame);
+            } else {
+              // No stylesheet match - fall back to text preview
+              textPreview();
+            }
+          }
+
+          @Override
+          public void onError(Request req, Throwable exception) {
+            textPreview();
+          }
+        });
+      } catch (RequestException e) {
+        textPreview();
+      }
+    } else {
+      textPreview();
+    }
   }
 
   private void downloadFile() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -17,15 +17,21 @@ import org.roda.core.data.v2.ip.Permissions;
 import org.roda.core.data.v2.ip.metadata.FileFormat;
 import org.roda.wui.client.common.utils.IndexedDIPUtils;
 import org.roda.wui.client.common.utils.JavascriptUtils;
+import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.common.client.tools.ConfigurationManager;
 import org.roda.wui.common.client.tools.StringUtils;
 
+import java.util.Arrays;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.event.logical.shared.AttachEvent.Handler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -43,6 +49,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.FileUpload;
 import com.google.gwt.user.client.ui.Frame;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -529,23 +536,65 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
   private void xmlHtmlPreview() {
     if (object instanceof IndexedFile) {
       IndexedFile indexedFile = (IndexedFile) object;
+      String locale = LocaleInfo.getCurrentLocale().getLocaleName();
       String htmlUrl = GWT.getHostPageBaseURL() + "api/v2/files/" + indexedFile.getUUID()
-        + "/preview/html?lang=" + LocaleInfo.getCurrentLocale().getLocaleName();
+        + "/preview/html?lang=" + locale;
+      String transformUrl = GWT.getHostPageBaseURL() + "api/v2/files/" + indexedFile.getUUID()
+        + "/preview/html/transform?lang=" + locale;
 
+      // Toolbar with XSLT upload - only visible if user has representation.read role
+      FlowPanel toolbar = new FlowPanel();
+      toolbar.setStyleName("xmlPreviewToolbar");
+      toolbar.setVisible(false);
+
+      FileUpload xsltUpload = new FileUpload();
+      xsltUpload.setName("xslt");
+      xsltUpload.getElement().setAttribute("accept", ".xslt,.xsl");
+      xsltUpload.setStyleName("xmlPreviewFileInput");
+
+      Button applyButton = new Button("Applicera XSLT");
+      applyButton.setStyleName("btn btn-play xmlPreviewApplyButton");
+      applyButton.setEnabled(false);
+
+      xsltUpload.addChangeHandler(event -> applyButton.setEnabled(true));
+
+      toolbar.add(xsltUpload);
+      toolbar.add(applyButton);
+      panel.add(toolbar);
+
+      UserLogin.getInstance().checkRole(Arrays.asList("representation.read"), new AsyncCallback<Boolean>() {
+        @Override
+        public void onSuccess(Boolean hasRole) {
+          toolbar.setVisible(Boolean.TRUE.equals(hasRole));
+        }
+
+        @Override
+        public void onFailure(Throwable caught) {
+          toolbar.setVisible(false);
+        }
+      });
+
+      // Iframe for rendered HTML
+      Frame frame = new Frame();
+      frame.setStyleName("viewRepresentationHtmlFilePreview");
+
+      applyButton.addClickHandler(event -> {
+        applyButton.setEnabled(false);
+        applyButton.setText("Laddar...");
+        applyCustomXslt(xsltUpload.getElement(), transformUrl, frame.getElement(), applyButton.getElement());
+      });
+
+      // Load default XSLT rendering
       RequestBuilder request = new RequestBuilder(RequestBuilder.GET, htmlUrl);
       try {
         request.sendRequest(null, new RequestCallback() {
           @Override
           public void onResponseReceived(Request req, Response response) {
             if (response.getStatusCode() == HttpStatus.SC_OK) {
-              // XSLT rendering available - show as HTML in iframe
-              Frame frame = new Frame();
-              String html = response.getText();
-              frame.getElement().setAttribute("srcdoc", html);
-              frame.setStyleName("viewRepresentationHtmlFilePreview");
+              frame.getElement().setAttribute("srcdoc", response.getText());
               panel.add(frame);
             } else {
-              // No stylesheet match - fall back to text preview
+              panel.add(frame);
               textPreview();
             }
           }
@@ -562,6 +611,36 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       textPreview();
     }
   }
+
+  private native void applyCustomXslt(
+    com.google.gwt.dom.client.Element fileInput, String url,
+    com.google.gwt.dom.client.Element iframe, com.google.gwt.dom.client.Element button) /*-{
+    var files = fileInput.files;
+    if (!files || files.length === 0) {
+      button.innerText = "Applicera XSLT";
+      button.disabled = false;
+      return;
+    }
+    var formData = new FormData();
+    formData.append("xslt", files[0]);
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", url, true);
+    xhr.onload = function() {
+      if (xhr.status === 200) {
+        iframe.setAttribute("srcdoc", xhr.responseText);
+      } else {
+        $wnd.alert("XSLT-transformering misslyckades: " + xhr.statusText);
+      }
+      button.innerText = "Applicera XSLT";
+      button.disabled = false;
+    };
+    xhr.onerror = function() {
+      $wnd.alert("Fel vid uppladdning av XSLT");
+      button.innerText = "Applicera XSLT";
+      button.disabled = false;
+    };
+    xhr.send(formData);
+  }-*/;
 
   private void downloadFile() {
     if (bitstreamDownloadUri != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -542,6 +542,15 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       String transformUrl = GWT.getHostPageBaseURL() + "api/v2/files/" + indexedFile.getUUID()
         + "/preview/html/transform?lang=" + locale;
 
+      // Print button - always visible
+      FlowPanel printToolbar = new FlowPanel();
+      printToolbar.setStyleName("xmlPreviewToolbar");
+
+      Button printButton = new Button("Skriv ut");
+      printButton.setStyleName("btn btn-play xmlPreviewPrintButton");
+      printToolbar.add(printButton);
+      panel.add(printToolbar);
+
       // Toolbar with XSLT upload - only visible if user has representation.apply_xslt role
       FlowPanel toolbar = new FlowPanel();
       toolbar.setStyleName("xmlPreviewToolbar");
@@ -584,6 +593,8 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
         applyCustomXslt(xsltUpload.getElement(), transformUrl, frame.getElement(), applyButton.getElement());
       });
 
+      printButton.addClickHandler(event -> printIframeContent(frame.getElement()));
+
       // Load default XSLT rendering
       RequestBuilder request = new RequestBuilder(RequestBuilder.GET, htmlUrl);
       try {
@@ -611,6 +622,28 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       textPreview();
     }
   }
+
+  private native void printIframeContent(com.google.gwt.dom.client.Element iframe) /*-{
+    try {
+      var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+      var html = iframeDoc.documentElement.outerHTML;
+      var printWin = $wnd.open('', '_blank');
+      printWin.document.write(html);
+      // Inject print styles to suppress headers/footers
+      var style = printWin.document.createElement('style');
+      style.textContent = '@page { margin: 15mm; size: auto; } @media print { body { margin: 0; } }';
+      printWin.document.head.appendChild(style);
+      printWin.document.close();
+      printWin.focus();
+      // Delay to let content render before printing
+      setTimeout(function() {
+        printWin.print();
+        printWin.close();
+      }, 500);
+    } catch (e) {
+      $wnd.alert("Kunde inte skriva ut: " + e.message);
+    }
+  }-*/;
 
   private native void applyCustomXslt(
     com.google.gwt.dom.client.Element fileInput, String url,

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -546,7 +546,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       FlowPanel printToolbar = new FlowPanel();
       printToolbar.setStyleName("xmlPreviewToolbar");
 
-      Button printButton = new Button("Skriv ut");
+      Button printButton = new Button(messages.xsltPrintButton());
       printButton.setStyleName("btn btn-play xmlPreviewPrintButton");
       printToolbar.add(printButton);
       panel.add(printToolbar);
@@ -561,7 +561,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       xsltUpload.getElement().setAttribute("accept", ".xslt,.xsl");
       xsltUpload.setStyleName("xmlPreviewFileInput");
 
-      Button applyButton = new Button("Applicera XSLT");
+      Button applyButton = new Button(messages.applyXsltButton());
       applyButton.setStyleName("btn btn-play xmlPreviewApplyButton");
       applyButton.setEnabled(false);
 
@@ -589,11 +589,13 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
 
       applyButton.addClickHandler(event -> {
         applyButton.setEnabled(false);
-        applyButton.setText("Laddar...");
-        applyCustomXslt(xsltUpload.getElement(), transformUrl, frame.getElement(), applyButton.getElement());
+        applyButton.setText(messages.xsltLoading());
+        applyCustomXslt(xsltUpload.getElement(), transformUrl, frame.getElement(), applyButton.getElement(),
+          messages.applyXsltButton(), messages.xsltFileTooLarge(), messages.xsltTransformFailed(),
+          messages.xsltUploadError(), messages.xsltTransformTimeout());
       });
 
-      printButton.addClickHandler(event -> printIframeContent(frame.getElement()));
+      printButton.addClickHandler(event -> printIframeContent(frame.getElement(), messages.xsltPrintError()));
 
       // Load default XSLT rendering
       RequestBuilder request = new RequestBuilder(RequestBuilder.GET, htmlUrl);
@@ -623,7 +625,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
     }
   }
 
-  private native void printIframeContent(com.google.gwt.dom.client.Element iframe) /*-{
+  private native void printIframeContent(com.google.gwt.dom.client.Element iframe, String errorMsg) /*-{
     try {
       var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
       var html = iframeDoc.documentElement.outerHTML;
@@ -641,16 +643,18 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
         printWin.close();
       }, 500);
     } catch (e) {
-      $wnd.alert("Kunde inte skriva ut: " + e.message);
+      $wnd.alert(errorMsg + e.message);
     }
   }-*/;
 
   private native void applyCustomXslt(
     com.google.gwt.dom.client.Element fileInput, String url,
-    com.google.gwt.dom.client.Element iframe, com.google.gwt.dom.client.Element button) /*-{
+    com.google.gwt.dom.client.Element iframe, com.google.gwt.dom.client.Element button,
+    String buttonLabel, String fileTooLargeMsg, String transformFailedMsg,
+    String uploadErrorMsg, String timeoutMsg) /*-{
     var files = fileInput.files;
     if (!files || files.length === 0) {
-      button.innerText = "Applicera XSLT";
+      button.innerText = buttonLabel;
       button.disabled = false;
       return;
     }
@@ -658,7 +662,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
     var maxSize = 1024 * 1024;
     if (file.size > maxSize) {
       $wnd.alert("XSLT-filen är för stor (max 1 MB)");
-      button.innerText = "Applicera XSLT";
+      button.innerText = buttonLabel;
       button.disabled = false;
       return;
     }
@@ -671,19 +675,19 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       if (xhr.status === 200) {
         iframe.setAttribute("srcdoc", xhr.responseText);
       } else {
-        $wnd.alert("XSLT-transformering misslyckades: " + xhr.statusText);
+        $wnd.alert(transformFailedMsg + xhr.statusText);
       }
-      button.innerText = "Applicera XSLT";
+      button.innerText = buttonLabel;
       button.disabled = false;
     };
     xhr.onerror = function() {
-      $wnd.alert("Fel vid uppladdning av XSLT");
-      button.innerText = "Applicera XSLT";
+      $wnd.alert(uploadErrorMsg);
+      button.innerText = buttonLabel;
       button.disabled = false;
     };
     xhr.ontimeout = function() {
       $wnd.alert("XSLT-transformeringen tog för lång tid (timeout 30s)");
-      button.innerText = "Applicera XSLT";
+      button.innerText = buttonLabel;
       button.disabled = false;
     };
     xhr.send(formData);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -586,6 +586,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       // Iframe for rendered HTML
       Frame frame = new Frame();
       frame.setStyleName("viewRepresentationHtmlFilePreview");
+      frame.getElement().setAttribute("sandbox", "allow-same-origin");
 
       applyButton.addClickHandler(event -> {
         applyButton.setEnabled(false);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -542,7 +542,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       String transformUrl = GWT.getHostPageBaseURL() + "api/v2/files/" + indexedFile.getUUID()
         + "/preview/html/transform?lang=" + locale;
 
-      // Toolbar with XSLT upload - only visible if user has representation.read role
+      // Toolbar with XSLT upload - only visible if user has representation.apply_xslt role
       FlowPanel toolbar = new FlowPanel();
       toolbar.setStyleName("xmlPreviewToolbar");
       toolbar.setVisible(false);
@@ -562,7 +562,7 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       toolbar.add(applyButton);
       panel.add(toolbar);
 
-      UserLogin.getInstance().checkRole(Arrays.asList("representation.read"), new AsyncCallback<Boolean>() {
+      UserLogin.getInstance().checkRole(Arrays.asList("representation.apply_xslt"), new AsyncCallback<Boolean>() {
         @Override
         public void onSuccess(Boolean hasRole) {
           toolbar.setVisible(Boolean.TRUE.equals(hasRole));

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -654,10 +654,19 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       button.disabled = false;
       return;
     }
+    var file = files[0];
+    var maxSize = 1024 * 1024;
+    if (file.size > maxSize) {
+      $wnd.alert("XSLT-filen är för stor (max 1 MB)");
+      button.innerText = "Applicera XSLT";
+      button.disabled = false;
+      return;
+    }
     var formData = new FormData();
-    formData.append("xslt", files[0]);
+    formData.append("xslt", file);
     var xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);
+    xhr.timeout = 30000;
     xhr.onload = function() {
       if (xhr.status === 200) {
         iframe.setAttribute("srcdoc", xhr.responseText);
@@ -669,6 +678,11 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
     };
     xhr.onerror = function() {
       $wnd.alert("Fel vid uppladdning av XSLT");
+      button.innerText = "Applicera XSLT";
+      button.disabled = false;
+    };
+    xhr.ontimeout = function() {
+      $wnd.alert("XSLT-transformeringen tog för lång tid (timeout 30s)");
       button.innerText = "Applicera XSLT";
       button.disabled = false;
     };

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
@@ -165,6 +165,9 @@ public class DescriptiveMetadataHistory extends Composite {
   Button buttonRevert;
 
   @UiField
+  Button buttonApplyXslt;
+
+  @UiField
   Button buttonRemove;
 
   @UiField
@@ -213,6 +216,8 @@ public class DescriptiveMetadataHistory extends Composite {
       RodaConstants.PERMISSION_METHOD_REVERT_DESCRIPTIVE_METADATA_VERSION);
     PermissionClientUtils.bindPermission(buttonRemove, descriptiveMetadataVersions.getPermissions(),
       RodaConstants.PERMISSION_METHOD_DELETE_DESCRIPTIVE_METADATA_VERSION);
+    PermissionClientUtils.bindPermission(buttonApplyXslt, descriptiveMetadataVersions.getPermissions(),
+      RodaConstants.REPOSITORY_PERMISSIONS_METADATA_TRANSFORM_XSLT);
 
     Element firstElement = showXml.getElement().getFirstChildElement();
     if ("input".equalsIgnoreCase(firstElement.getTagName())) {
@@ -370,6 +375,61 @@ public class DescriptiveMetadataHistory extends Composite {
   void buttonShowXmlHandler(ClickEvent e) {
     setInHTML(!isInHTML());
     updatePreview();
+  }
+
+  @UiHandler("buttonApplyXslt")
+  void buttonApplyXsltHandler(ClickEvent e) {
+    triggerXsltFileUpload();
+  }
+
+  private native void triggerXsltFileUpload() /*-{
+    var self = this;
+    var input = $doc.createElement('input');
+    input.type = 'file';
+    input.accept = '.xsl,.xslt,.xml';
+    input.onchange = function() {
+      if (input.files.length > 0) {
+        var file = input.files[0];
+        var formData = new $wnd.FormData();
+        formData.append('xslt', file);
+
+        var aipId = self.@org.roda.wui.client.browse.DescriptiveMetadataHistory::aipId;
+        var metadataId = self.@org.roda.wui.client.browse.DescriptiveMetadataHistory::descriptiveMetadataId;
+        var uri = @org.roda.wui.common.client.tools.RestUtils::createDescriptiveMetadataTransformUri(Ljava/lang/String;Ljava/lang/String;)(aipId, metadataId);
+
+        var xhr = new $wnd.XMLHttpRequest();
+        xhr.open('POST', uri, true);
+        xhr.onload = function() {
+          if (xhr.status === 200) {
+            self.@org.roda.wui.client.browse.DescriptiveMetadataHistory::showTransformResult(Ljava/lang/String;)(xhr.responseText);
+          } else {
+            var errorMsg = xhr.responseText || 'Error transforming metadata with XSLT';
+            self.@org.roda.wui.client.browse.DescriptiveMetadataHistory::showTransformError(Ljava/lang/String;)(errorMsg);
+          }
+        };
+        xhr.onerror = function() {
+          self.@org.roda.wui.client.browse.DescriptiveMetadataHistory::showTransformError(Ljava/lang/String;)('Network error');
+        };
+        xhr.send(formData);
+      }
+    };
+    input.click();
+  }-*/;
+
+  private void showTransformResult(String html) {
+    preview.setHTML(SafeHtmlUtils.fromTrustedString(html));
+    preview.removeStyleName("code-pre");
+  }
+
+  private void showTransformError(String errorMessage) {
+    SafeHtmlBuilder b = new SafeHtmlBuilder();
+    b.append(SafeHtmlUtils.fromSafeConstant("<div class='error'>"));
+    b.append(SafeHtmlUtils.fromString(messages.xsltTransformError()));
+    b.append(SafeHtmlUtils.fromSafeConstant("<pre><code>"));
+    b.append(SafeHtmlUtils.fromString(errorMessage));
+    b.append(SafeHtmlUtils.fromSafeConstant("</code></pre>"));
+    b.append(SafeHtmlUtils.fromSafeConstant("</div>"));
+    preview.setHTML(b.toSafeHtml());
   }
 
   @UiHandler("buttonRevert")

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.ui.xml
@@ -33,7 +33,10 @@
 							<g:Button addStyleNames="btn btn-block btn-play" ui:field="buttonRevert">
 								<ui:text from='{messages.revertButton}' />
 							</g:Button>
-							<g:Button addStyleNames="btn btn-block btn-danger btn-ban" ui:field="buttonRemove">
+							<g:Button addStyleNames="btn btn-block btn-play" ui:field="buttonApplyXslt">
+									<ui:text from='{messages.applyXsltButton}' />
+								</g:Button>
+								<g:Button addStyleNames="btn btn-block btn-danger btn-ban" ui:field="buttonRemove">
 								<ui:text from='{messages.removeButton}' />
 							</g:Button>
 							<g:Button addStyleNames="btn btn-block btn-times-circle" ui:field="buttonCancel">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
@@ -211,8 +211,9 @@ public class AIPDescriptiveMetadataTabs extends Tabs {
               '<div class="descriptiveMetadataHTML">' + xhr.responseText + '</div>');
           } else {
             var errorMsg = xhr.responseText || 'Error transforming metadata';
+            var escaped = errorMsg.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
             metadataHTML.@com.google.gwt.user.client.ui.HTML::setHTML(Ljava/lang/String;)(
-              '<div class="error"><pre>' + errorMsg + '</pre></div>');
+              '<div class="error"><pre>' + escaped + '</pre></div>');
           }
         };
         xhr.onerror = function() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/AIPDescriptiveMetadataTabs.java
@@ -127,6 +127,17 @@ public class AIPDescriptiveMetadataTabs extends Tabs {
                     .assign(RestUtils.createDescriptiveMetadataDownloadUri(aip.getId(), metadataID).asString());
                 }
               }, messages.downloadButton(), "btn-download");
+
+              // Apply XSLT button (permission-gated)
+              if (PermissionClientUtils.hasPermissions(aip.getPermissions(),
+                RodaConstants.PERMISSION_METHOD_TRANSFORM_DESCRIPTIVE_METADATA_WITH_XSLT)) {
+                descriptiveMetadataToolbar.addAction(new ClickHandler() {
+                  @Override
+                  public void onClick(ClickEvent event) {
+                    triggerXsltUpload(aip.getId(), metadataID, metadataHTML);
+                  }
+                }, messages.applyXsltButton(), "btn-upload");
+              }
               // HTML
               String html = response.getText();
               SafeHtmlBuilder b = new SafeHtmlBuilder();
@@ -179,4 +190,38 @@ public class AIPDescriptiveMetadataTabs extends Tabs {
       });
     }
   }
+
+  private static native void triggerXsltUpload(String aipId, String metadataId, HTML metadataHTML) /*-{
+    var input = $doc.createElement('input');
+    input.type = 'file';
+    input.accept = '.xsl,.xslt,.xml';
+    input.onchange = function() {
+      if (input.files.length > 0) {
+        var file = input.files[0];
+        var formData = new $wnd.FormData();
+        formData.append('xslt', file);
+
+        var uri = @org.roda.wui.common.client.tools.RestUtils::createDescriptiveMetadataTransformUri(Ljava/lang/String;Ljava/lang/String;)(aipId, metadataId);
+
+        var xhr = new $wnd.XMLHttpRequest();
+        xhr.open('POST', uri, true);
+        xhr.onload = function() {
+          if (xhr.status === 200) {
+            metadataHTML.@com.google.gwt.user.client.ui.HTML::setHTML(Ljava/lang/String;)(
+              '<div class="descriptiveMetadataHTML">' + xhr.responseText + '</div>');
+          } else {
+            var errorMsg = xhr.responseText || 'Error transforming metadata';
+            metadataHTML.@com.google.gwt.user.client.ui.HTML::setHTML(Ljava/lang/String;)(
+              '<div class="error"><pre>' + errorMsg + '</pre></div>');
+          }
+        };
+        xhr.onerror = function() {
+          metadataHTML.@com.google.gwt.user.client.ui.HTML::setHTML(Ljava/lang/String;)(
+            '<div class="error">Network error during XSLT transform</div>');
+        };
+        xhr.send(formData);
+      }
+    };
+    input.click();
+  }-*/;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -12,8 +12,8 @@ package org.roda.wui.client.management;
 
 import java.util.List;
 
+import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.EmailAlreadyExistsException;
-import org.roda.core.data.exceptions.UserAlreadyExistsException;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.data.v2.user.requests.CreateUserRequest;
 import org.roda.wui.client.common.UserLogin;
@@ -128,7 +128,7 @@ public class CreateUser extends Composite {
   private void errorMessage(Throwable caught) {
     if (caught instanceof EmailAlreadyExistsException) {
       Toast.showError(messages.createUserEmailAlreadyExists(user.getEmail()));
-    } else if (caught instanceof UserAlreadyExistsException) {
+    } else if (caught instanceof AlreadyExistsException) {
       Toast.showError(messages.createUserAlreadyExists(user.getId()));
     } else {
       Toast.showError(messages.createUserFailure(caught.getMessage()));

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
@@ -16,8 +16,8 @@ import java.util.Set;
 
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
+import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.EmailAlreadyExistsException;
-import org.roda.core.data.exceptions.UserAlreadyExistsException;
 import org.roda.core.data.v2.generics.MetadataValue;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.data.v2.user.requests.RegisterUserRequest;
@@ -223,7 +223,7 @@ public class Register extends Composite {
 
     if (caught instanceof EmailAlreadyExistsException) {
       Toast.showError(messages.registerEmailAlreadyExists());
-    } else if (caught instanceof UserAlreadyExistsException) {
+    } else if (caught instanceof AlreadyExistsException) {
       Toast.showError(messages.registerUserExists());
     } else if (caught instanceof RecaptchaException) {
       Toast.showError(messages.registerWrongCaptcha());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MethodCallThrowableTreatment.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MethodCallThrowableTreatment.java
@@ -10,6 +10,7 @@ package org.roda.wui.client.services;
 import org.fusesource.restygwt.client.Method;
 import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.AuthenticationDeniedException;
+import org.roda.core.data.exceptions.EmailAlreadyExistsException;
 import org.roda.core.data.exceptions.AuthorizationDeniedException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.v2.validation.ValidationException;
@@ -58,7 +59,11 @@ public class MethodCallThrowableTreatment {
     } else if (method.getResponse().getStatusCode() == Response.SC_FORBIDDEN) {
       throwable = new AuthorizationDeniedException(throwableDetails);
     } else if (method.getResponse().getStatusCode() == Response.SC_CONFLICT) {
-      throwable = new AlreadyExistsException(throwableDetails);
+      if (throwableDetails.toLowerCase().contains("email")) {
+        throwable = new EmailAlreadyExistsException(throwableDetails);
+      } else {
+        throwable = new AlreadyExistsException(throwableDetails);
+      }
     } else if (method.getResponse().getStatusCode() == Response.SC_BAD_REQUEST) {
       if (throwableMessage.equals("Validation error")) {
         ValidationReport details = VALIDATION_REPORT_MAPPER.read(parse.isObject().get("objectDetails").toString());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
@@ -138,4 +138,28 @@ public final class HTMLUtils {
       true);
   }
 
+
+  public static String representationFileToHtml(Binary binary, String xsltName, final Locale locale)
+    throws GenericException {
+    Map<String, String> translations = getTranslations(xsltName, null, locale);
+    Reader reader = RodaUtils.applyMetadataStylesheet(binary,
+      RodaConstants.CROSSWALKS_DISSEMINATION_HTML_REPRESENTATION_PATH, xsltName, null, translations);
+    try {
+      return CharStreams.toString(reader);
+    } catch (IOException e) {
+      throw new GenericException("Could not transform representation file to HTML", e);
+    }
+  }
+
+  public static String representationFileToHtmlWithCustomXslt(Binary binary, InputStream xsltInputStream,
+    final Locale locale) throws GenericException {
+    Map<String, String> translations = new HashMap<>();
+    Reader reader = RodaUtils.applyCustomStylesheet(binary, xsltInputStream, translations);
+    try {
+      return CharStreams.toString(reader);
+    } catch (IOException e) {
+      throw new GenericException("Could not transform representation file with custom XSLT", e);
+    }
+  }
+
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
@@ -8,6 +8,7 @@
 package org.roda.wui.common;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Locale;
@@ -47,6 +48,18 @@ public final class HTMLUtils {
       throw new GenericException("Could not transform PREMIS to HTML", e);
     }
   }
+
+  public static String descriptiveMetadataToHtmlWithCustomXslt(Binary binary, InputStream xsltInputStream,
+    String metadataType, String metadataVersion, final Locale locale) throws GenericException {
+    Map<String, String> translations = getTranslations(metadataType, metadataVersion, locale);
+    Reader reader = RodaUtils.applyCustomStylesheet(binary, xsltInputStream, translations);
+    try {
+      return CharStreams.toString(reader);
+    } catch (IOException e) {
+      throw new GenericException("Could not transform metadata with custom XSLT", e);
+    }
+  }
+
 
   public static String technicalMetadataToHtml(Binary binary, String metadataType, String metadataVersion,
     final Locale locale) throws GenericException {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/HTMLUtils.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.common.Messages;
 import org.roda.core.common.RodaUtils;
@@ -32,6 +34,23 @@ import com.google.common.io.CharStreams;
  */
 public final class HTMLUtils {
 
+  private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder()
+    .allowCommonBlockElements()
+    .allowCommonInlineFormattingElements()
+    .allowElements("table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption", "col", "colgroup")
+    .allowElements("dl", "dt", "dd", "pre", "code", "hr", "a", "img", "section", "header", "footer", "nav", "main")
+    .allowAttributes("class", "id", "style", "title", "lang").globally()
+    .allowAttributes("href").onElements("a")
+    .allowAttributes("src", "alt", "width", "height").onElements("img")
+    .allowAttributes("colspan", "rowspan", "scope", "align", "valign").onElements("th", "td")
+    .allowUrlProtocols("http", "https", "data")
+    .allowStyling()
+    .toFactory();
+
+  private static String sanitizeHtml(String html) {
+    return HTML_SANITIZER.sanitize(html);
+  }
+
   /** Private empty constructor */
   private HTMLUtils() {
     // do nothing
@@ -43,7 +62,7 @@ public final class HTMLUtils {
     Reader reader = RodaUtils.applyMetadataStylesheet(binary, RodaConstants.CROSSWALKS_DISSEMINATION_HTML_PATH,
       metadataType, metadataVersion, translations);
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform PREMIS to HTML", e);
     }
@@ -54,7 +73,7 @@ public final class HTMLUtils {
     Map<String, String> translations = getTranslations(metadataType, metadataVersion, locale);
     Reader reader = RodaUtils.applyCustomStylesheet(binary, xsltInputStream, translations);
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform metadata with custom XSLT", e);
     }
@@ -85,7 +104,7 @@ public final class HTMLUtils {
         metadataVersion, translations);
     }
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform PREMIS to HTML", e);
     }
@@ -100,7 +119,7 @@ public final class HTMLUtils {
       RodaConstants.CROSSWALKS_DISSEMINATION_HTML_EVENT_PATH);
 
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform PREMIS to HTML", e);
     }
@@ -145,7 +164,7 @@ public final class HTMLUtils {
     Reader reader = RodaUtils.applyMetadataStylesheet(binary,
       RodaConstants.CROSSWALKS_DISSEMINATION_HTML_REPRESENTATION_PATH, xsltName, null, translations);
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform representation file to HTML", e);
     }
@@ -156,7 +175,7 @@ public final class HTMLUtils {
     Map<String, String> translations = new HashMap<>();
     Reader reader = RodaUtils.applyCustomStylesheet(binary, xsltInputStream, translations);
     try {
-      return CharStreams.toString(reader);
+      return sanitizeHtml(CharStreams.toString(reader));
     } catch (IOException e) {
       throw new GenericException("Could not transform representation file with custom XSLT", e);
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
@@ -171,6 +171,22 @@ public class RestUtils {
     return UriUtils.fromSafeConstant(b.toString());
   }
 
+  public static String createDescriptiveMetadataTransformUri(String aipId, String metadataId) {
+    // api/v2/aips/{id}/metadata/descriptive/{metadataId}/transform?lang={lang}
+    StringBuilder b = new StringBuilder();
+    b.append(RodaConstants.API_REST_V2_AIPS).append(URL.encodeQueryString(aipId)).append(RodaConstants.API_SEP)
+      .append("metadata").append(RodaConstants.API_SEP).append("descriptive").append(RodaConstants.API_SEP)
+      .append(URL.encodeQueryString(metadataId)).append(RodaConstants.API_SEP).append("transform");
+
+    // locale
+    b.append(RodaConstants.API_QUERY_START).append(RodaConstants.API_QUERY_KEY_LANG)
+      .append(RodaConstants.API_QUERY_ASSIGN_SYMBOL).append(LocaleInfo.getCurrentLocale().getLocaleName());
+
+    return b.toString();
+  }
+
+
+
   public static SafeUri createTechnicalMetadataHTMLUri(String fileId, String typeId) {
     return createTechnicalMetadataHTMLUri(fileId, typeId, null);
   }

--- a/roda-ui/roda-wui/src/main/resources/config/crosswalks/dissemination/html/cgm_pmo_v1.xslt
+++ b/roda-ui/roda-wui/src/main/resources/config/crosswalks/dissemination/html/cgm_pmo_v1.xslt
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:pmo="http://www.cgm.com/sv/pmo/v1"
+    exclude-result-prefixes="pmo">
+    <xsl:output method="xml" indent="yes" encoding="UTF-8" omit-xml-declaration="yes" />
+
+    <xsl:param name="i18n.patient" select="'Patient'" />
+    <xsl:param name="i18n.name" select="'Namn'" />
+    <xsl:param name="i18n.codeNumber" select="'Personnummer'" />
+    <xsl:param name="i18n.birthDate" select="'Födelsedatum'" />
+    <xsl:param name="i18n.sex" select="'Kön'" />
+    <xsl:param name="i18n.language" select="'Språk'" />
+    <xsl:param name="i18n.phone" select="'Telefon'" />
+    <xsl:param name="i18n.email" select="'E-post'" />
+    <xsl:param name="i18n.address" select="'Adress'" />
+    <xsl:param name="i18n.deceased" select="'Avliden'" />
+    <xsl:param name="i18n.confidential" select="'Sekretessmarkering'" />
+    <xsl:param name="i18n.interpreterNeeded" select="'Tolkbehov'" />
+    <xsl:param name="i18n.relatives" select="'Anhöriga'" />
+    <xsl:param name="i18n.relativeName" select="'Namn'" />
+    <xsl:param name="i18n.relativeType" select="'Relation'" />
+    <xsl:param name="i18n.custodian" select="'Vårdnadshavare'" />
+    <xsl:param name="i18n.schoolAttendance" select="'Skolplacering'" />
+    <xsl:param name="i18n.school" select="'Skola'" />
+    <xsl:param name="i18n.class" select="'Klass'" />
+    <xsl:param name="i18n.schoolYear" select="'Läsår'" />
+    <xsl:param name="i18n.period" select="'Period'" />
+    <xsl:param name="i18n.dataOrigin" select="'Dataursprung'" />
+    <xsl:param name="i18n.system" select="'System'" />
+    <xsl:param name="i18n.organization" select="'Organisation'" />
+    <xsl:param name="i18n.created" select="'Skapad'" />
+    <xsl:param name="i18n.caseBookName" select="'Journaltyp'" />
+    <xsl:param name="i18n.growthInfo" select="'Tillväxtinformation'" />
+    <xsl:param name="i18n.gaWeeks" select="'Gestationsålder (veckor)'" />
+    <xsl:param name="i18n.gaDays" select="'Gestationsålder (dagar)'" />
+    <xsl:param name="i18n.yes" select="'Ja'" />
+    <xsl:param name="i18n.no" select="'Nej'" />
+
+    <xsl:template name="bool">
+        <xsl:param name="val" />
+        <xsl:choose>
+            <xsl:when test="$val = 'true'"><xsl:value-of select="$i18n.yes" /></xsl:when>
+            <xsl:otherwise><xsl:value-of select="$i18n.no" /></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="/">
+        <div class="descriptiveMetadata">
+            <xsl:apply-templates select="pmo:JournalExport" />
+        </div>
+    </xsl:template>
+
+    <xsl:template match="pmo:JournalExport">
+        <!-- Case book name -->
+        <xsl:if test="normalize-space(pmo:CaseBookName) != ''">
+            <div class="field">
+                <div class="label"><xsl:value-of select="$i18n.caseBookName" /></div>
+                <div class="value"><xsl:value-of select="pmo:CaseBookName" /></div>
+            </div>
+        </xsl:if>
+
+        <!-- Data Origin -->
+        <xsl:apply-templates select="pmo:DataOrigin" />
+
+        <!-- Patient Data -->
+        <xsl:apply-templates select="pmo:PatientData/pmo:Patient" />
+    </xsl:template>
+
+    <!-- Data Origin section -->
+    <xsl:template match="pmo:DataOrigin">
+        <div class="field">
+            <div class="label sectionHeader"><xsl:value-of select="$i18n.dataOrigin" /></div>
+            <div class="value">
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.system" /></div>
+                    <div class="value"><xsl:value-of select="pmo:System" /><xsl:text> </xsl:text><xsl:value-of select="pmo:SystemVersion" /></div>
+                </div>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.organization" /></div>
+                    <div class="value"><xsl:value-of select="pmo:OrganizationName" /></div>
+                </div>
+                <xsl:if test="normalize-space(pmo:TopOrganizationName) != ''">
+                    <div class="field">
+                        <div class="label">Huvudorganisation</div>
+                        <div class="value"><xsl:value-of select="pmo:TopOrganizationName" /></div>
+                    </div>
+                </xsl:if>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.created" /></div>
+                    <div class="value"><xsl:value-of select="substring(pmo:Created, 1, 10)" /></div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Patient section -->
+    <xsl:template match="pmo:Patient">
+        <div class="field">
+            <div class="label sectionHeader"><xsl:value-of select="$i18n.patient" /></div>
+            <div class="value">
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.name" /></div>
+                    <div class="value"><xsl:value-of select="pmo:Name" /></div>
+                </div>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.codeNumber" /></div>
+                    <div class="value"><xsl:value-of select="pmo:CodeNumber" /></div>
+                </div>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.birthDate" /></div>
+                    <div class="value"><xsl:value-of select="pmo:BirthDate" /></div>
+                </div>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.sex" /></div>
+                    <div class="value">
+                        <xsl:choose>
+                            <xsl:when test="pmo:Sex = 'F'">Kvinna</xsl:when>
+                            <xsl:when test="pmo:Sex = 'M'">Man</xsl:when>
+                            <xsl:otherwise><xsl:value-of select="pmo:Sex" /></xsl:otherwise>
+                        </xsl:choose>
+                    </div>
+                </div>
+                <xsl:if test="normalize-space(pmo:Language) != ''">
+                    <div class="field">
+                        <div class="label"><xsl:value-of select="$i18n.language" /></div>
+                        <div class="value"><xsl:value-of select="pmo:Language" /></div>
+                    </div>
+                </xsl:if>
+                <xsl:if test="normalize-space(pmo:MobilePhone) != ''">
+                    <div class="field">
+                        <div class="label"><xsl:value-of select="$i18n.phone" /></div>
+                        <div class="value"><xsl:value-of select="pmo:MobilePhone" /></div>
+                    </div>
+                </xsl:if>
+                <xsl:if test="normalize-space(pmo:Email) != ''">
+                    <div class="field">
+                        <div class="label"><xsl:value-of select="$i18n.email" /></div>
+                        <div class="value"><xsl:value-of select="pmo:Email" /></div>
+                    </div>
+                </xsl:if>
+                <div class="field">
+                    <div class="label"><xsl:value-of select="$i18n.deceased" /></div>
+                    <div class="value">
+                        <xsl:call-template name="bool"><xsl:with-param name="val" select="pmo:Deceased" /></xsl:call-template>
+                    </div>
+                </div>
+                <xsl:if test="pmo:ConfidentialData = 'true'">
+                    <div class="field">
+                        <div class="label"><xsl:value-of select="$i18n.confidential" /></div>
+                        <div class="value"><xsl:value-of select="$i18n.yes" /></div>
+                    </div>
+                </xsl:if>
+                <xsl:if test="pmo:InterpreterNeeded = 'true'">
+                    <div class="field">
+                        <div class="label"><xsl:value-of select="$i18n.interpreterNeeded" /></div>
+                        <div class="value"><xsl:value-of select="$i18n.yes" /></div>
+                    </div>
+                </xsl:if>
+
+                <!-- Address -->
+                <xsl:apply-templates select="pmo:PatientAddress" />
+
+                <!-- Relatives -->
+                <xsl:if test="pmo:Relative">
+                    <div class="field">
+                        <div class="label sectionHeader"><xsl:value-of select="$i18n.relatives" /></div>
+                        <div class="value">
+                            <xsl:for-each select="pmo:Relative">
+                                <div class="field">
+                                    <div class="label"><xsl:value-of select="pmo:RelativeType" /></div>
+                                    <div class="value">
+                                        <xsl:value-of select="pmo:Name" />
+                                        <xsl:if test="pmo:Custodian = 'true'">
+                                            <xsl:text> (</xsl:text><xsl:value-of select="$i18n.custodian" /><xsl:text>)</xsl:text>
+                                        </xsl:if>
+                                        <xsl:if test="pmo:Deceased = 'true'">
+                                            <xsl:text> — </xsl:text><xsl:value-of select="$i18n.deceased" />
+                                            <xsl:if test="normalize-space(pmo:DeceasedDate) != ''">
+                                                <xsl:text> </xsl:text><xsl:value-of select="pmo:DeceasedDate" />
+                                            </xsl:if>
+                                        </xsl:if>
+                                    </div>
+                                </div>
+                            </xsl:for-each>
+                        </div>
+                    </div>
+                </xsl:if>
+
+                <!-- Growth Info -->
+                <xsl:if test="pmo:GrowthPatInfo">
+                    <div class="field">
+                        <div class="label sectionHeader"><xsl:value-of select="$i18n.growthInfo" /></div>
+                        <div class="value">
+                            <div class="field">
+                                <div class="label"><xsl:value-of select="$i18n.gaWeeks" /></div>
+                                <div class="value"><xsl:value-of select="pmo:GrowthPatInfo/pmo:GAWeeks" /></div>
+                            </div>
+                            <div class="field">
+                                <div class="label"><xsl:value-of select="$i18n.gaDays" /></div>
+                                <div class="value"><xsl:value-of select="pmo:GrowthPatInfo/pmo:GADays" /></div>
+                            </div>
+                        </div>
+                    </div>
+                </xsl:if>
+
+                <!-- School Attendance -->
+                <xsl:if test="pmo:SchoolAttendance">
+                    <div class="field">
+                        <div class="label sectionHeader"><xsl:value-of select="$i18n.schoolAttendance" /></div>
+                        <div class="value">
+                            <xsl:for-each select="pmo:SchoolAttendance">
+                                <div class="field">
+                                    <div class="label"><xsl:value-of select="pmo:SchoolYear" /></div>
+                                    <div class="value">
+                                        <xsl:value-of select="pmo:School" />
+                                        <xsl:if test="normalize-space(pmo:Class) != ''">
+                                            <xsl:text>, </xsl:text><xsl:value-of select="$i18n.class" /><xsl:text> </xsl:text><xsl:value-of select="pmo:Class" />
+                                        </xsl:if>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="pmo:StartDate" />
+                                        <xsl:text> – </xsl:text>
+                                        <xsl:value-of select="pmo:EndDate" />
+                                        <xsl:text>)</xsl:text>
+                                    </div>
+                                </div>
+                            </xsl:for-each>
+                        </div>
+                    </div>
+                </xsl:if>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Address -->
+    <xsl:template match="pmo:PatientAddress">
+        <div class="field">
+            <div class="label"><xsl:value-of select="$i18n.address" /></div>
+            <div class="value">
+                <xsl:value-of select="pmo:Address1" />
+                <xsl:if test="normalize-space(pmo:ZipCode) != '' or normalize-space(pmo:City) != ''">
+                    <xsl:text>, </xsl:text>
+                    <xsl:value-of select="pmo:ZipCode" />
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="pmo:City" />
+                </xsl:if>
+            </div>
+        </div>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
@@ -338,6 +338,7 @@ ui.browse.metadata.descriptive.type.ead-c_dglab=Encoded Archival Description Com
 ui.browse.metadata.descriptive.type.ead_3=Encoded Archival Description 3
 ui.browse.metadata.descriptive.type.ead-c=Encoded Archival Description Component
 ui.browse.metadata.descriptive.type.key-value=Key-Value
+ui.browse.metadata.descriptive.type.cgm_pmo_v1=CGM PMO Elevhu00e4lsojournal
 
 ##########################################
 # Technical Metadata

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1194,6 +1194,7 @@ role[representation.read]:List and search representations and computer files
 role[representation.create]:Create representations and computer files
 role[representation.update]:Update representations and computer files
 role[representation.delete]:Delete representations and computer files
+role[representation.apply_xslt]:Apply custom XSLT stylesheet
 
 role[descriptive_metadata.read]:List and retrieve descriptive metadata
 role[descriptive_metadata.create]:Create descriptive metadata

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1851,3 +1851,10 @@ sipDeleted:Deleted
 # XSLT Transform feature
 applyXsltButton=Apply XSLT
 xsltTransformError=Error transforming metadata with custom XSLT
+xsltLoading=Loading...
+xsltPrintButton=Print
+xsltFileTooLarge=XSLT file is too large (max 1 MB)
+xsltTransformFailed=XSLT transformation failed: 
+xsltUploadError=Error uploading XSLT
+xsltTransformTimeout=XSLT transformation timed out (timeout 30s)
+xsltPrintError=Could not print: 

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1846,3 +1846,7 @@ detailsIngest: Ingest
 ingestIdentifier: Jobs
 sipIdentifier: Identifiers
 sipDeleted:Deleted
+
+# XSLT Transform feature
+applyXsltButton=Apply XSLT
+xsltTransformError=Error transforming metadata with custom XSLT

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1749,3 +1749,12 @@ marketStoreInstallLabel:Installera
 # Descriptive metatada lock to edit
 editDescMetadataLockedTitle: Det går inte att redigera beskrivande metadata
 editDescMetadataLockedText: Denna logiska enhet redigeras just nu av en annan användare
+applyXsltButton=Applicera XSLT
+xsltTransformError=Fel vid XSLT-transformering
+xsltLoading=Laddar...
+xsltPrintButton=Skriv ut
+xsltFileTooLarge=XSLT-filen \u00e4r f\u00f6r stor (max 1 MB)
+xsltTransformFailed=XSLT-transformering misslyckades: 
+xsltUploadError=Fel vid uppladdning av XSLT
+xsltTransformTimeout=XSLT-transformeringen tog f\u00f6r l\u00e5ng tid (timeout 30s)
+xsltPrintError=Kunde inte skriva ut: 

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1170,6 +1170,7 @@ role[representation.read]:Lista och sök i representationer och filer
 role[representation.create]:Skapa representationer och filer
 role[representation.update]:Uppdatera representationer och filer
 role[representation.delete]:Ta bort representationer och filer
+role[representation.apply_xslt]:Applicera egen XSLT-stilmall
 
 role[descriptive_metadata.read]:Lista och hämta beskrivande metadata
 role[descriptive_metadata.create]:Skapa beskrivande metadata

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -322,6 +322,7 @@ ui.browser.metadata.descriptive.types = ead_3
 ui.browser.metadata.descriptive.types = ead_2002
 ui.browser.metadata.descriptive.types = dc_SimpleDC20021212
 ui.browser.metadata.descriptive.types = key-value
+ui.browser.metadata.descriptive.types = cgm_pmo_v1
 
 ##########################################################################
 # Descriptive Metadata order

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -232,6 +232,7 @@ ui.role: representation.view
 ui.role: representation.create
 ui.role: representation.update
 ui.role: representation.delete
+ui.role: representation.apply_xslt
 
 ui.roleTitle: descriptive_metadata
 ui.role: descriptive_metadata.read

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -724,3 +724,28 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .enterprise-editions {
     color: white;
 }
+/* XML XSLT Preview Toolbar */
+.xmlPreviewToolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.xmlPreviewFileInput {
+  flex: 0 1 auto;
+}
+
+.xmlPreviewApplyButton {
+  white-space: nowrap;
+}
+
+.viewRepresentationHtmlFilePreview {
+  width: 100%;
+  min-height: 600px;
+  border: 1px solid #ddd;
+}


### PR DESCRIPTION
## Vad ändrades

Felmeddelandet som visas när man försöker skapa en användare eller registrera sig med ett redan använt användarnamn eller e-postadress visades på engelska istället för svenska.

## Grundorsak

Klientkoden kontrollerade `instanceof UserAlreadyExistsException`, men `MethodCallThrowableTreatment` (som omvandlar HTTP-svar till Java-undantag) skapade aldrig en `UserAlreadyExistsException` — bara en `AlreadyExistsException`. Matchningen misslyckades alltid och felet hamnade i den generiska `else`-grenen som visade ett otydligt engelskspråkigt meddelande.

Dessutom skiljde inte koden på duplikat-användarnamn (HTTP 409) och duplikat-e-post (HTTP 409) — båda hanterades likadant.

## Ändrade filer

- **`MethodCallThrowableTreatment.java`** — HTTP 409-hanteraren skapar nu `EmailAlreadyExistsException` om serversvaret innehåller "email" i detaljtexten, annars `AlreadyExistsException`
- **`CreateUser.java`** — kontrollerar nu `instanceof AlreadyExistsException` (istället för `UserAlreadyExistsException`)
- **`Register.java`** — samma korrigering som i `CreateUser.java`

## Testning

1. Navigera till Användare och grupper → Lägg till användare
2. Fyll i uppgifter för en befintlig användare och spara
3. Felmeddelandet ska nu visas på svenska: *"Det finns redan en användare med det namnet…"*

Closes #387