### PR TITLE
fix: visa modal-dialog när CSV-export startas (#392)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
@@ -19,7 +19,6 @@ import org.roda.core.data.v2.jobs.CreateJobRequest;
 import org.roda.wui.client.common.utils.AsyncCallbackUtils;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.tools.ConfigurationManager;
-import org.roda.wui.common.client.widgets.Toast;
 
 import com.github.nmorel.gwtjackson.client.ObjectMapper;
 import com.google.gwt.core.client.GWT;
@@ -178,8 +177,9 @@ public class ExportSearchDialog {
       if (throwable != null) {
         AsyncCallbackUtils.defaultFailureTreatment(throwable);
       } else {
-        Toast.showInfo(messages.exportListTitle(), messages.exportSearchJobStarted());
         dialogBox.hide();
+        Dialogs.showInformationDialog(messages.exportListTitle(), messages.exportSearchJobStarted(),
+          messages.dialogOk(), false);
       }
     });
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/dialogs/ExportSearchDialog.java
@@ -106,18 +106,18 @@ public class ExportSearchDialog {
 
     // Buttons panel
     FlowPanel buttonsPanel = new FlowPanel();
-    buttonsPanel.addStyleName("export-search-dialog-buttons");
+    buttonsPanel.addStyleName("wui-dialog-layout-footer");
+
+    Button cancelButton = new Button(messages.dialogCancel());
+    cancelButton.addStyleName("btn btn-default btn-times-circle");
+    cancelButton.addClickHandler(event -> dialogBox.hide());
+    buttonsPanel.add(cancelButton);
 
     startButton = new Button(messages.exportSearchDialogStartButton());
-    startButton.addStyleName("btn btn-primary");
+    startButton.addStyleName("btn btn-play");
     startButton.addClickHandler(event -> onStartExport(filter, exportFilename, exportClass));
     updateStartButtonState();
     buttonsPanel.add(startButton);
-
-    Button cancelButton = new Button(messages.dialogCancel());
-    cancelButton.addStyleName("btn btn-default");
-    cancelButton.addClickHandler(event -> dialogBox.hide());
-    buttonsPanel.add(cancelButton);
 
     content.add(buttonsPanel);
     dialogBox.setWidget(content);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -45,6 +45,7 @@ import org.roda.wui.client.common.NoAsyncCallback;
 import org.roda.wui.client.common.actions.Actionable;
 import org.roda.wui.client.common.actions.model.ActionableObject;
 import org.roda.wui.client.common.actions.widgets.ActionableWidgetBuilder;
+import org.roda.wui.client.common.dialogs.Dialogs;
 import org.roda.wui.client.common.dialogs.ExportSearchDialog;
 import org.roda.wui.client.common.lists.pagination.ListSelectionState;
 import org.roda.wui.client.common.lists.pagination.ListSelectionUtils;
@@ -59,7 +60,6 @@ import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.tools.RestUtils;
 import org.roda.wui.common.client.tools.StringUtils;
 import org.roda.wui.common.client.widgets.MyCellTableResources;
-import org.roda.wui.common.client.widgets.Toast;
 import org.roda.wui.common.client.widgets.wcag.AccessibleCellTable;
 import org.roda.wui.common.client.widgets.wcag.AccessibleFocusPanel;
 import org.roda.wui.common.client.widgets.wcag.AccessibleSimplePager;
@@ -423,10 +423,17 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
             if (throwable != null) {
               AsyncCallbackUtils.defaultFailureTreatment(throwable);
             } else {
-              Toast.showInfo(messages.exportListTitle(), messages.exportListMessage(limit.getResult().intValue()));
-              RestUtils.requestCSVExport(getClassToReturn(), getFilter(), dataProvider.getSorter(),
-                new Sublist(0, limit.getResult().intValue()), getFacets(), getJustActive(), false,
-                notNullSummary + ".csv");
+              final int exportLimit = limit.getResult().intValue();
+              Dialogs.showInformationDialog(messages.exportListTitle(),
+                messages.exportListMessage(exportLimit), messages.dialogOk(), false,
+                new NoAsyncCallback<Void>() {
+                  @Override
+                  public void onSuccess(Void result) {
+                    RestUtils.requestCSVExport(getClassToReturn(), getFilter(), dataProvider.getSorter(),
+                      new Sublist(0, exportLimit), getFacets(), getJustActive(), false,
+                      notNullSummary + ".csv");
+                  }
+                });
             }
           });
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -5191,6 +5191,37 @@ body.catalogTreeResizing * {
     margin-bottom: 10px;
 }
 
+.export-search-dialog {
+    padding: 10px;
+    min-width: 400px;
+    max-width: 700px;
+}
+
+.export-search-dialog-hitcount {
+    margin-bottom: 12px;
+    line-height: 1.5;
+}
+
+.export-search-dialog-fields-label {
+    margin-bottom: 6px;
+    font-weight: 500;
+}
+
+.export-search-dialog-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 16px;
+}
+
+.export-search-dialog .wui-dialog-layout-footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    padding-top: 8px;
+}
+
 .pull-right {
     float: right;
 }

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1437,7 +1437,7 @@ sourceObjectList:A manually selected list with {0} {1}
 runningInBackgroundTitle:The action is running on background
 runningInBackgroundDescription:The progress of the action can be monitored on the internal actions page
 exportListTitle:Exporting list
-exportListMessage:Exporting list with a maximum limit of {0} items
+exportListMessage:Exporting list with a maximum limit of {0} items. The file will be downloaded directly to your computer.
 exportSearchJobStarted:Export started — download the result from Internal Actions when the job is complete.
 exportSearchDialogStartButton:Start export
 exportSearchDialogFieldsLabel:Select fields to include:

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1415,7 +1415,7 @@ exportListMessage:Exporterar lista med en maxgräns på {0} objekt
 exportSearchJobStarted:Export startad — hämta resultatet under Interna åtgärder när jobbet är klart.
 exportSearchDialogStartButton:Starta export
 exportSearchDialogFieldsLabel:Välj fält att inkludera:
-exportSearchDialogHitCount:Din sökning returnerade {0} träffar. Alla exporteras som CSV.
+exportSearchDialogHitCount:Din sökning returnerade {0} träffar. Alla exporteras som CSV. Resultatet hämtas under Interna åtgärder när jobbet är klart.
 exportSearchDialogTitle:Exportera sökresultat
 representationInformationAssociatedWith:
 representationInformationAssociatedWith[AIP]:Associerad med logiska enheter</span> där fält <span class="code">{0}</span> är <span class="code">{1}</span>

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1411,7 +1411,7 @@ sourceObjectList:En manuellt vald lista med {0} {1}
 runningInBackgroundTitle:Åtgärden körs i bakgrunden
 runningInBackgroundDescription:Åtgärdens status kan övervakas på den interna åtgärdssidan
 exportListTitle:Exporterar lista
-exportListMessage:Exporterar lista med en maxgräns på {0} objekt
+exportListMessage:Exporterar lista med en maxgräns på {0} objekt. Filen laddas ned direkt till din dator.
 exportSearchJobStarted:Export startad — hämta resultatet under Interna åtgärder när jobbet är klart.
 exportSearchDialogStartButton:Starta export
 exportSearchDialogFieldsLabel:Välj fält att inkludera:


### PR DESCRIPTION
## Sammanfattning

Löser issue #392 — användaren fick ingen tydlig bekräftelse när en CSV-export startades.

### Ändringar

**`AsyncTableCell`** (direkt nedladdning via REST):
- Ersätter tyst toast med en modal som informerar om exportgränsen (`exportListMessage`)
- Filen laddas ned först när användaren klickar OK

**`ExportSearchDialog`** (bakgrundsjobb via `SearchExportPlugin`):
- Ersätter tyst toast med en modal (`exportSearchJobStarted`) som bekräftar att jobbet är igång
- Filen hämtas sedan i Interna åtgärder

**i18n**:
- `exportListMessage` uppdaterad på engelska och svenska för att tydliggöra att filen laddas ned direkt till datorn

## Risker och beroenden

- Inga migreringar eller manuella steg krävs
- Inga nya beroenden
- Berör enbart frontend-flödet för CSV-export