### PR TITLE
fix: byt ut "Bevara permanent" mot "Bevara" i gallringsschema

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1463,7 +1463,7 @@ disposalScheduleActionCol:Åtgärd
 disposalScheduleAction:{0}
 disposalScheduleAction[DESTROY]:Gallra
 disposalScheduleAction[REVIEW]:Granska
-disposalScheduleAction[RETAIN_PERMANENTLY]:Bevara permanent
+disposalScheduleAction[RETAIN_PERMANENTLY]:Bevara
 disposalScheduleRetentionTriggerElementId:Identifierare av element för bevarande
 disposalScheduleRetentionPeriodInterval:Gallringsintervall
 disposalScheduleRetentionPeriodIntervalValue:{0}
@@ -1602,7 +1602,7 @@ disposalConfirmationAssociationTitle:Gallringsbekräftelse
 disposalHoldsAssociationInformationTitle:Gallringsstopp
 transitiveDisposalHoldsAssociationInformationTitle:Transitivt gallringsstopp tilldelas genom annan logisk enhet
 disposalScheduleActionCode:{0}
-disposalScheduleActionCode[RETAIN_PERMANENTLY]:Behåll permanent
+disposalScheduleActionCode[RETAIN_PERMANENTLY]:Bevara
 disposalScheduleActionCode[REVIEW]:Granska
 disposalScheduleActionCode[DESTROY]:Gallra
 disposalPolicyScheduleSummary:Förfaller {0} {1}


### PR DESCRIPTION
## Vad ändrades

Formuleringen "Bevara permanent" i gallringsschemat var språkligt otydlig — "permanent" är i det här sammanhanget överflödigt eller missvisande. Texten är ersatt med enbart "Bevara".

## Ändrade rader

`ClientMessages_sv_SE.properties`:
- `disposalScheduleAction[RETAIN_PERMANENTLY]`: Bevara permanent → **Bevara**
- `disposalScheduleActionCode[RETAIN_PERMANENTLY]`: Behåll permanent → **Bevara**

<img width="334" height="215" alt="image" src="https://github.com/user-attachments/assets/173a1512-d6d5-463b-87f5-d9fc837d1b2d" />




Closes #406