### PR TITLE
fix(i18n): lägg till svensk översättning för logEntryReason

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -952,6 +952,7 @@ learnMore:Läs mer
 searchDuplicateWarningMessage:Fältet {0} är duplicerat. En 'OR'-operator kommer att användas.
 # Activity log
 logEntryIdentifier:Identifierare
+logEntryReason:Anledning
 logEntryComponent:Komponent
 logEntryMethod:Metod
 logEntryAddress:Adresss


### PR DESCRIPTION
## Summary
- Lägger till saknad i18n-nyckel `logEntryReason:Anledning` i `ClientMessages_sv_SE.properties`
- Kolumnrubriken "Reason" i granskningsloggen visas nu på svenska

Löser #411

## Test plan
- [x] Gå till Loggposter/Granskningslogg i Katalogen
- [x] Verifiera att kolumnrubriken visas som "Anledning" istället för "Reason"