### PR TITLE
fix: översätt felmeddelanden för gallringsfrist till svenska

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1120,6 +1120,8 @@ public final class RodaConstants {
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_INTERVAL = "retentionPeriodInterval";
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_DETAILS = "retentionPeriodDetails";
   public static final String AIP_DISPOSAL_RETENTION_PERIOD_CALCULATION = "retentionPeriodCalculation";
+  public static final String DISPOSAL_RETENTION_PERIOD_ERROR_MISSING_START_DATE = "MISSING_START_DATE";
+  public static final String DISPOSAL_RETENTION_PERIOD_ERROR_INVALID_START_DATE_TYPE = "INVALID_START_DATE_TYPE";
 
   // AIP types
   public static final String AIP_TYPE_MIXED = "MIXED";

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -1969,7 +1969,7 @@ public class SolrUtils {
     Object o = retrieve.getFields().get(disposalSchedule.getRetentionTriggerElementId());
 
     if (o == null) {
-      values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_DETAILS, "Retention period start date is missing");
+      values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_DETAILS, RodaConstants.DISPOSAL_RETENTION_PERIOD_ERROR_MISSING_START_DATE);
       values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_CALCULATION, RetentionPeriodCalculation.ERROR.name());
       return values;
     }
@@ -1977,7 +1977,7 @@ public class SolrUtils {
     if (o instanceof Date retentionPeriodStartDate) {
       cal.setTime(retentionPeriodStartDate);
     } else {
-      values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_DETAILS, "Retention period start must be of date type");
+      values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_DETAILS, RodaConstants.DISPOSAL_RETENTION_PERIOD_ERROR_INVALID_START_DATE_TYPE);
       values.put(RodaConstants.AIP_DISPOSAL_RETENTION_PERIOD_CALCULATION, RetentionPeriodCalculation.ERROR.name());
       return values;
     }

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2237,6 +2237,10 @@ public interface ClientMessages extends Messages {
 
   String disposalRetentionDueDateLabel();
 
+  String retentionPeriodStartDateMissing();
+
+  String retentionPeriodStartDateInvalidType();
+
   String disposalRetentionPeriodLabel();
 
   String disposalActionLabel();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/RetentionPeriodPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/association/RetentionPeriodPanel.java
@@ -98,7 +98,7 @@ public class RetentionPeriodPanel extends Composite {
       retentionOverdueDateLabel.setVisible(false);
       disposalRetentionDueDate.setVisible(false);
       disposalRetentionPeriod.setVisible(false);
-      disposalRetentionStartDate.setText(aip.getRetentionPeriodDetails());
+      disposalRetentionStartDate.setText(translateRetentionPeriodDetails(aip.getRetentionPeriodDetails()));
     }
   }
 
@@ -120,6 +120,15 @@ public class RetentionPeriodPanel extends Composite {
       }
 
     }
+  }
+
+  private String translateRetentionPeriodDetails(String details) {
+    if ("MISSING_START_DATE".equals(details)) {
+      return messages.retentionPeriodStartDateMissing();
+    } else if ("INVALID_START_DATE_TYPE".equals(details)) {
+      return messages.retentionPeriodStartDateInvalidType();
+    }
+    return details;
   }
 
   interface MyUiBinder extends UiBinder<Widget, RetentionPeriodPanel> {

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1564,6 +1564,8 @@ associateDisposalScheduleDialogMessage:Are you sure you want to associate the sc
 disposalRetentionStartDateLabel:Retention start date
 disposalRetentionDueDateLabel:Retention due date
 disposalRetentionPeriodLabel:Retention period
+retentionPeriodStartDateMissing:Due date missing — retention period start date cannot be calculated
+retentionPeriodStartDateInvalidType:Retention period start date is not of date type
 disposalActionLabel:Disposal action
 holdStatusLabel:Hold status
 disposalOnHoldStatusLabel:On hold

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1536,6 +1536,8 @@ associateDisposalScheduleDialogMessage:Är du säker på att du vill koppla sche
 disposalRetentionStartDateLabel:Startdatum för gallringsfrist
 disposalRetentionDueDateLabel:Förfallodatum för gallringsfrist
 disposalRetentionPeriodLabel:Gallringsfrist
+retentionPeriodStartDateMissing:Slutdatum saknas — gallringsfristens startdatum kan inte beräknas
+retentionPeriodStartDateInvalidType:Startdatum för gallringsfristen är inte av datumtyp
 disposalActionLabel:Gallringsåtgärd
 holdStatusLabel:Status gallringsstopp
 disposalOnHoldStatusLabel:Stoppad


### PR DESCRIPTION
## Vad ändrades

Felmeddelanden som visas under \*\*Gallringsfrist\*\* när startdatum saknas eller är fel typ var hårdkodade engelska strängar i `SolrUtils.java`. Dessa är nu ersatta med felkoder som översätts i klienten via i18n.

## Ändrade filer

- `RodaConstants.java`: Två nya konstanter — `DISPOSAL_RETENTION_PERIOD_ERROR_MISSING_START_DATE` och `DISPOSAL_RETENTION_PERIOD_ERROR_INVALID_START_DATE_TYPE`
- `SolrUtils.getRetentionPeriod()`: Skriver nu felkoder i stället för engelska strängar
- `RetentionPeriodPanel.java`: Ny metod `translateRetentionPeriodDetails()` som mappar felkoder till i18n-meddelanden
- `ClientMessages.java`: Två nya metoddeklarationer
- `ClientMessages.properties`: Engelska fallback-texter
- `ClientMessages_sv_SE.properties`: Svenska översättningar

## Meddelanden

| Felkod | Svenska |
|--------|---------|
| `MISSING_START_DATE` | Slutdatum saknas — gallringsfristens startdatum kan inte beräknas |
| `INVALID_START_DATE_TYPE` | Startdatum för gallringsfristen är inte av datumtyp |

## Känt beteende

Befintliga AIPs som redan har det gamla engelska felmeddelandet lagrat i Solr visar fortfarande den gamla texten tills gallringsschemat kopplas om på nytt (vilket triggar en ny `SolrUtils.getRetentionPeriod()`-körning som skriver den nya felkoden).

Closes #408