### PR TITLE
fix: sätt korrekta Cache-Control-headers för statiska resurser

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/RodaConfig.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/RodaConfig.java
@@ -12,6 +12,7 @@ import jakarta.servlet.ServletException;
 import org.apereo.cas.client.session.SingleSignOutHttpSessionListener;
 import org.roda.wui.filter.OnOffFilter;
 import org.roda.wui.filter.SecurityHeadersFilter;
+import org.roda.wui.filter.StaticCacheFilter;
 import org.roda.wui.servlets.ContextListener;
 import org.roda.wui.servlets.RodaWuiServlet;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -177,6 +178,15 @@ public class RodaConfig {
 
     registrationBean.addUrlPatterns("/login", "/logout");
 
+    return registrationBean;
+  }
+
+  @Bean
+  public FilterRegistrationBean<StaticCacheFilter> staticCacheFilter() {
+    FilterRegistrationBean<StaticCacheFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new StaticCacheFilter());
+    registrationBean.addUrlPatterns("/*");
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
     return registrationBean;
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/StaticCacheFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/StaticCacheFilter.java
@@ -1,0 +1,78 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/ETERNA-earkiv/ETERNA
+ */
+package org.roda.wui.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Sets appropriate Cache-Control headers for static resources.
+ *
+ * HTML entry points and GWT bootstrap files (.nocache.js) get no-store so
+ * browsers always fetch a fresh copy after a deploy. Content-hashed files
+ * (.cache.js, webjars) get immutable so they are cached indefinitely.
+ */
+public class StaticCacheFilter implements Filter {
+
+  private static final String NO_STORE = "no-store";
+  private static final String IMMUTABLE = "public, max-age=31536000, immutable";
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    String path = resolvePath(httpRequest);
+
+    if (isNeverCache(path)) {
+      httpResponse.setHeader("Cache-Control", NO_STORE);
+    } else if (isImmutable(path)) {
+      httpResponse.setHeader("Cache-Control", IMMUTABLE);
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  private String resolvePath(HttpServletRequest request) {
+    String contextPath = request.getContextPath();
+    String uri = request.getRequestURI();
+    if (uri == null) {
+      return "";
+    }
+    if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+      return uri.substring(contextPath.length());
+    }
+    return uri;
+  }
+
+  // HTML shells and GWT bootstrap must never be served from cache after a deploy
+  private boolean isNeverCache(String path) {
+    return path.endsWith(".html") || path.endsWith(".nocache.js");
+  }
+
+  // Content-hashed files are safe to cache indefinitely
+  private boolean isImmutable(String path) {
+    return path.endsWith(".cache.js") || path.startsWith("/webjars/");
+  }
+
+  @Override
+  public void destroy() {
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/StaticCacheFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/StaticCacheFilter.java
@@ -64,7 +64,7 @@ public class StaticCacheFilter implements Filter {
 
   // HTML shells and GWT bootstrap must never be served from cache after a deploy
   private boolean isNeverCache(String path) {
-    return path.endsWith(".html") || path.endsWith(".nocache.js");
+    return "/".equals(path) || path.endsWith(".html") || path.endsWith(".nocache.js");
   }
 
   // Content-hashed files are safe to cache indefinitely


### PR DESCRIPTION
HTML-skalssidor (Main.html, Portal.html) och GWT-bootstrap (*.nocache.js) cachar nu aldrig i webbläsaren (no-store), vilket eliminerar behovet av hård refresh efter en deploy.

Innehållshashade filer (*.cache.js, /webjars/) cachas som immutable i ett år eftersom deras filnamn redan är unika per bygge.

Nytt filter: StaticCacheFilter, körs med högsta prioritet (HIGHEST_PRECEDENCE).

closes #382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Prestandaförbättringar**
  * Optimerad cachehantering för statiska resurser. Dynamiska resurser cachelagras inte, medan versionerade filer cachelagras långvarigt för snabbare sidladdningar och reducerad serverbelastning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->