### PR TITLE
fix(#412): ersätt UI-laddningsetikett med beskrivande audit-reason

### DIFF
--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2718,4 +2718,12 @@ public interface ClientMessages extends Messages {
   String catalogTreeCollapse();
 
   String catalogTreeExpand();
+
+  String catalogTreeReasonListChildren();
+
+  String catalogTreeReasonListRoots();
+
+  String catalogTreeReasonGetAncestors();
+
+  String catalogTreeReasonRetrieveAIP();
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -155,7 +155,7 @@ public class CatalogTreeNode extends Composite {
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
-    Services service = new Services("List AIP children", "get");
+    Services service = new Services(messages.catalogTreeReasonListChildren(), "get");
     service.rodaEntityRestService(
       s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -155,7 +155,7 @@ public class CatalogTreeNode extends Composite {
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
-    Services service = new Services(messages.catalogTreeLoadingLabel(), "get");
+    Services service = new Services("List AIP children", "get");
     service.rodaEntityRestService(
       s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -165,7 +165,7 @@ public class CatalogTreePanel extends Composite {
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
-    Services service = new Services(messages.catalogTreeLoadingLabel(), "get");
+    Services service = new Services("List root AIPs", "get");
     service.rodaEntityRestService(
       s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)
@@ -209,7 +209,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void doRevealAip(String aipId) {
-    Services service = new Services(messages.catalogTreeLoadingLabel(), "get");
+    Services service = new Services("Get AIP ancestors", "get");
     service.aipResource(s -> s.getAncestors(aipId))
       .whenComplete((ancestors, error) -> {
         if (error != null) {
@@ -311,7 +311,7 @@ public class CatalogTreePanel extends Composite {
   public void refreshNodeTitle(String aipId) {
     CatalogTreeNode node = findNode(aipId, rootNodes);
     if (node == null) return;
-    Services service = new Services(messages.catalogTreeLoadingLabel(), "get");
+    Services service = new Services("Retrieve AIP", "get");
     service.rodaEntityRestService(
       s -> s.findByUuid(aipId, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -165,7 +165,7 @@ public class CatalogTreePanel extends Composite {
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
 
-    Services service = new Services("List root AIPs", "get");
+    Services service = new Services(messages.catalogTreeReasonListRoots(), "get");
     service.rodaEntityRestService(
       s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)
@@ -209,7 +209,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void doRevealAip(String aipId) {
-    Services service = new Services("Get AIP ancestors", "get");
+    Services service = new Services(messages.catalogTreeReasonGetAncestors(), "get");
     service.aipResource(s -> s.getAncestors(aipId))
       .whenComplete((ancestors, error) -> {
         if (error != null) {
@@ -311,7 +311,7 @@ public class CatalogTreePanel extends Composite {
   public void refreshNodeTitle(String aipId) {
     CatalogTreeNode node = findNode(aipId, rootNodes);
     if (node == null) return;
-    Services service = new Services("Retrieve AIP", "get");
+    Services service = new Services(messages.catalogTreeReasonRetrieveAIP(), "get");
     service.rodaEntityRestService(
       s -> s.findByUuid(aipId, LocaleInfo.getCurrentLocale().getLocaleName()),
       IndexedAIP.class)

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1877,3 +1877,7 @@ catalogTreeRetry: Try again
 catalogTreeRootLabel: Catalogue
 catalogTreeCollapse: Collapse archive tree
 catalogTreeExpand: Expand archive tree
+catalogTreeReasonListChildren: List AIP children
+catalogTreeReasonListRoots: List root AIPs
+catalogTreeReasonGetAncestors: Get AIP ancestors
+catalogTreeReasonRetrieveAIP: Retrieve AIP

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1792,3 +1792,7 @@ catalogTreeRetry: Försök igen
 catalogTreeRootLabel: Katalog
 catalogTreeCollapse: Fäll in arkivträdet
 catalogTreeExpand: Fäll ut arkivträdet
+catalogTreeReasonListChildren: Lista AIP-barn
+catalogTreeReasonListRoots: Lista rot-AIPs
+catalogTreeReasonGetAncestors: Hämta AIP-förfäder
+catalogTreeReasonRetrieveAIP: Hämta AIP


### PR DESCRIPTION
Fältet "reason" i Loggposter visade "Laddar..." eftersom CatalogTreeNode och CatalogTreePanel skickade UI-spinnertexten (messages.catalogTreeLoadingLabel) som operationsanledning i Services-konstruktorn, vilket sparades rakt av i audit-loggen.

Ersatt med meningsfulla engelska strängar som matchar övriga Services-anrop i kodbasen:
- CatalogTreeNode: "List AIP children"
- CatalogTreePanel (root): "List root AIPs"
- CatalogTreePanel (ancestors): "Get AIP ancestors"
- CatalogTreePanel (refresh): "Retrieve AIP"

closes #412 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Förbättringar

* **Förbättringar**
  * Förbättrad klarhet i katalogträdets användargränssnitt med mer kontextspecifika meddelandetexter för olika operationer (listning av barn, rotmarkeringar, förfäder och AIP-hämtning).
  * Uppdaterad svensk språklokal för dessa meddelandetexter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->