### PR TITLE
fix(i18n): byt ut "resurser" mot "paket" i inleverans-gränssnittet (#442)

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_sv_SE.properties
@@ -239,6 +239,29 @@ ui.facets.LogEntry.actionComponent.org.roda.wui.api.controllers.Disposals: Gallr
 ui.facets.LogEntry.actionComponent.org.roda.wui.api.controllers.UserManagement: Användarhantering
 ui.facets.LogEntry.actionComponent.org.roda.wui.api.v1.ManagementTasksResource: Administrativ uppgift
 ui.facets.LogEntry.actionComponent.org.roda.wui.filter.CasWebAuthFilter: CAS Login
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.AIPController: Logiska enheter
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.ClassificationPlanController: Klassificeringsplan
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.ConfigurationController: Konfiguration
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DIPPlanController: Spridningar
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DisposalConfirmationController: Gallringsbekräftelser
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DisposalHoldController: Gallringsstopp
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DisposalRuleController: Gallringsregler
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DisposalScheduleController: Gallringsplaner
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.DistributedInstances: Distribuerade instanser
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.FilesController: Filer
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.JobsController: Jobb
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.MembersController: Användare och grupper
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.MetricsController: Mätvärden
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.NotificationController: Notiser
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.PreservationAgentController: Bevarandeagenter
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.PreservationEventController: Bevarandehändelser
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.RepresentationController: Representationer
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.RepresentationInformationController: Representationsinformation
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.RiskController: Risker
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.RiskIncidenceController: Riskincidenter
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.controller.TransferredResourceController: Överförda paket
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.services.IndexService: Index
+ui.facets.LogEntry.actionComponent.org.roda.wui.api.v2.services.MembersService: Användare och grupper
 ui.facets.LogEntry.actionMethod: Metoder
 ui.facets.LogEntry.state: Resultat
 ui.facets.LogEntry.state.FAILURE: Misslyckande

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -26,6 +26,7 @@ catalogueItemTitle:Logisk enhet
 catalogueRepresentationTitle:Representation
 catalogueFileTitle:Fil
 catalogueDIPTitle:Spridning
+catalogueTransferredResourceTitle:Överfört paket
 preservationActionsTitle:Arkivvårdsjobb
 ingestProcessTitle:Inleveransprocess
 internalProcessTitle:Interna åtgärder
@@ -174,7 +175,7 @@ allOfAObject[org.roda.core.data.v2.ip.Representation]:Alla representationer
 allOfAObject[org.roda.core.data.v2.ip.IndexedRepresentation]:Alla representationer
 allOfAObject[org.roda.core.data.v2.ip.File]:Alla filer
 allOfAObject[org.roda.core.data.v2.ip.IndexedFile]:Alla filer
-allOfAObject[org.roda.core.data.v2.ip.TransferredResource]:Alla överförda resurser
+allOfAObject[org.roda.core.data.v2.ip.TransferredResource]:Alla överförda paket
 allOfAObject[org.roda.core.data.v2.ip.DIP]:Alla spridningar
 allOfAObject[org.roda.core.data.v2.ip.IndexedDIP]:Alla spridningar
 allOfAObject[org.roda.core.data.v2.ip.DIPFile]:Alla spridningsfiler
@@ -202,7 +203,7 @@ someOfAObject[org.roda.core.data.v2.ip.Representation]:representationer
 someOfAObject[org.roda.core.data.v2.ip.IndexedRepresentation]:representationer
 someOfAObject[org.roda.core.data.v2.ip.File]:filer
 someOfAObject[org.roda.core.data.v2.ip.IndexedFile]:filer
-someOfAObject[org.roda.core.data.v2.ip.TransferredResource]:överförda resurser
+someOfAObject[org.roda.core.data.v2.ip.TransferredResource]:överförda paket
 someOfAObject[org.roda.core.data.v2.ip.DIP]:spridningar
 someOfAObject[org.roda.core.data.v2.ip.IndexedDIP]:spridningar
 someOfAObject[org.roda.core.data.v2.ip.DIPFile]:spridningsfiler
@@ -236,7 +237,7 @@ oneOfAObject[org.roda.core.data.v2.ip.Representation]:representation
 oneOfAObject[org.roda.core.data.v2.ip.IndexedRepresentation]:representation
 oneOfAObject[org.roda.core.data.v2.ip.File]:fil
 oneOfAObject[org.roda.core.data.v2.ip.IndexedFile]:fil
-oneOfAObject[org.roda.core.data.v2.ip.TransferredResource]:överförd resurs
+oneOfAObject[org.roda.core.data.v2.ip.TransferredResource]:överfört paket
 oneOfAObject[org.roda.core.data.v2.ip.DIP]:spridning
 oneOfAObject[org.roda.core.data.v2.ip.IndexedDIP]:spridning
 oneOfAObject[org.roda.core.data.v2.ip.DIPFile]:spridningsfil
@@ -262,7 +263,7 @@ oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalConfirmation]:gallringsbe
 oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalRule]:gallringsregler
 selected[\=1]:{0,number} {1} vald
 selected:{0,number} {1} vald
-inspectTransferredResource:Inspektera överförd resurs
+inspectTransferredResource:Inspektera överfört paket
 identifierNotFound:Identifierare (hittades inte)
 originalRepresentation:original
 alternativeRepresentation:alternativ
@@ -280,8 +281,8 @@ ingestTransferItemInfo:Skapad av {0}, med {1}
 ingestTransferRemoveFolderConfirmDialogTitle:Bekräfta borttagning av mapp
 ingestTransferRemoveSelectedConfirmDialogMessage:Är du säker på att du vill ta bort de valda {0} filerna och mapparna?
 ingestTransferLastScanned:Senast kontrollerad {0,localdatetime,predef:DATE_TIME_MEDIUM}
-ingestTransferNotFoundDialogTitle:Resurs hittades inte
-ingestTransferNotFoundDialogMessage:Resursen hittades inte
+ingestTransferNotFoundDialogTitle:Paketet hittades inte
+ingestTransferNotFoundDialogMessage:Paketet hittades inte
 ingestTransferNotFoundDialogButton:Fortsätt
 ingestTransferCreateFolderTitle:Nytt mappnamn
 ingestTransferCreateFolderMessage:Välj ett namn på den nya mappen
@@ -469,7 +470,7 @@ showSIPExtended:Submission Information Package (SIP)
 showAIPExtended:Archival Information Package (AIP)
 showRepresentationExtended:Representation
 showFileExtended:Fil
-showTransferredResourceExtended:Uppladdad resurs
+showTransferredResourceExtended:Uppladdat paket
 showJobSourceObjects:Källobjekt
 showAttachments:Bilagor
 jobStopConfirmDialogTitle:Bekräfta avbrytning av åtgärd
@@ -511,7 +512,7 @@ searchDropdownLabels:{0}
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedAIP]:Logiska enheter
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedRepresentation]:Representation
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedFile]:Filer
-searchDropdownLabels[org.roda.core.data.v2.ip.TransferredResource]:Uppladdade resurser
+searchDropdownLabels[org.roda.core.data.v2.ip.TransferredResource]:Uppladdade paket
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedPreservationEvent]:Spridningar
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedDIP]:Spridningar
 searchDropdownLabels[org.roda.core.data.v2.ip.DIPFile]:Spridningsfiler
@@ -600,7 +601,7 @@ selectAipSearchResults:Sökresultat
 selectRepresentationSearchResults:Sökresultat
 selectFileSearchResults:Sökresultat
 selectTransferredResourcesSearchResults:Sökresultat
-renameTransferredResourcesDialogTitle:Byt namn på uppladdad resurs
+renameTransferredResourcesDialogTitle:Byt namn på uppladdat paket
 # Rename Item
 renameItemTitle:Byt namn på objektet
 renameSuccessful:Byte av namn lyckades!
@@ -878,7 +879,7 @@ manage:Hantera
 appraisalTitle:Ankomstkontroll
 appraisalAccept:Godkänn
 appraisalReject:Avvisa
-transferredResourcesTitle:Resurser för inleverans
+transferredResourcesTitle:Överförda paket
 newArchivalPackage:Skapa en logisk enhet
 newSublevel:Skapa undernivå
 moveArchivalPackage:Flytta
@@ -1375,7 +1376,7 @@ jobReportSource:Källa
 jobReportSource[org.roda.core.data.v2.ip.AIP]:Källa logisk enhet
 jobReportSource[org.roda.core.data.v2.ip.Representation]:Källrepresentation
 jobReportSource[org.roda.core.data.v2.ip.File]:Källfil
-jobReportSource[org.roda.core.data.v2.ip.TransferredResource]:Källa uppladdad resurs
+jobReportSource[org.roda.core.data.v2.ip.TransferredResource]:Källa uppladdat paket
 jobReportSource[org.roda.core.data.v2.ip.DIP]:Källspridning
 jobReportSource[org.roda.core.data.v2.ip.DIPFile]:Källspridningsfil
 jobReportSource[org.roda.core.data.v2.risks.Risk]:Källrisk
@@ -1393,7 +1394,7 @@ jobReportOutcome:Resultat
 jobReportOutcome[org.roda.core.data.v2.ip.AIP]:Utfall logisk enhet
 jobReportOutcome[org.roda.core.data.v2.ip.Representation]:Resultatrepresentation
 jobReportOutcome[org.roda.core.data.v2.ip.File]:Resultatfil
-jobReportOutcome[org.roda.core.data.v2.ip.TransferredResource]:Resultat uppladdad resurs
+jobReportOutcome[org.roda.core.data.v2.ip.TransferredResource]:Resultat uppladdat paket
 jobReportOutcome[org.roda.core.data.v2.ip.DIP]:Resultatspridning
 jobReportOutcome[org.roda.core.data.v2.ip.DIPFile]:Resultatspridningsfil
 jobReportOutcome[org.roda.core.data.v2.risks.Risk]:Utfallsrisk

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -26,7 +26,7 @@ catalogueItemTitle:Logisk enhet
 catalogueRepresentationTitle:Representation
 catalogueFileTitle:Fil
 catalogueDIPTitle:Spridning
-catalogueTransferredResourceTitle:Överfört paket
+catalogueTransferredResourceTitle:Överförda paket
 preservationActionsTitle:Arkivvårdsjobb
 ingestProcessTitle:Inleveransprocess
 internalProcessTitle:Interna åtgärder
@@ -512,7 +512,7 @@ searchDropdownLabels:{0}
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedAIP]:Logiska enheter
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedRepresentation]:Representation
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedFile]:Filer
-searchDropdownLabels[org.roda.core.data.v2.ip.TransferredResource]:Uppladdade paket
+searchDropdownLabels[org.roda.core.data.v2.ip.TransferredResource]:efter överförda paket
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedPreservationEvent]:Spridningar
 searchDropdownLabels[org.roda.core.data.v2.ip.IndexedDIP]:Spridningar
 searchDropdownLabels[org.roda.core.data.v2.ip.DIPFile]:Spridningsfiler


### PR DESCRIPTION
## Sammanfattning

Byter ut begreppet "resurs/resurser" mot "paket" i den svenska UI-texten för inleverans-/uppladdningsflödet, i enlighet med issue #442.

### Ändringar i `ClientMessages_sv_SE.properties` (GWT-kompilerad)
- `transferredResourcesTitle`: Resurser för inleverans → **Överförda paket**
- `catalogueTransferredResourceTitle`: (ny nyckel) → **Överförda paket**
- `searchDropdownLabels[TransferredResource]`: Uppladdade resurser → **efter överförda paket** (ger "Sök efter överförda paket")
- `allOfAObject[TransferredResource]`: Alla uppladdade resurser → **Alla överförda paket**
- `someOfAObject[TransferredResource]`: uppladdade resurser → **överförda paket**
- `oneOfAObject[TransferredResource]`: uppladdad resurs → **överfört paket**
- `inspectTransferredResource`: Inspektera uppladdad resurs → **Inspektera överfört paket**
- Flera relaterade nycklar för dialograder, job-rapporter, breadcrumbs m.m.

### Ändringar i `ServerMessages_sv_SE.properties` (server-side)
- 23 nya `ui.facets.LogEntry.actionComponent.*`-nycklar för att märka log-facetter med svenska etiketter (t.ex. "Överförda paket", "Logiska enheter", "Processer").

## Risker och manuella steg
- `ClientMessages_sv_SE.properties` är GWT-kompilerad — kräver ny GWT-kompilering (`mvn gwt:compile`) för att synas i UI.
- `ServerMessages_sv_SE.properties` kan laddas live via `~/.roda/config/i18n/` utan omstart.
- Inga migrationer, inga nya beroenden.

## Closes
Closes #442