### PR TITLE
fix(i18n): byt ut "Ankomstkontroll" mot "Leveranskontroll" (#443 #441)

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -6,7 +6,7 @@ and:och
 genericTitle:Titel
 processTitle:Process
 reportTitle:Processrapport för informationspaket
-ingestAppraisalTitle:Ankomstkontroll
+ingestAppraisalTitle:Leveranskontroll
 riskHistoryTitle:Riskhistorik
 editIncidenceTitle:Redigera riskincidens
 editIncidencesTitle:Redigera riskincidenser
@@ -118,7 +118,7 @@ sidebarActionsTitle:Åtgärder
 sidebarDisposalBinTitle:Papperskorg
 sidebarDisposalScheduleTitle:Gallringsschema
 sidebarDisposalConfirmationTitle:Gallringsbekräftelse
-sidebarAppraisalTitle:Ankomstkontroll
+sidebarAppraisalTitle:Leveranskontroll
 metadataParseError:Fel på rad {0}, kolumn {1}: {2}
 notFoundError:Hittades inte
 descriptiveMetadataTransformToHTMLError:Det gick inte att omvandla beskrivande metadata till HTML
@@ -875,7 +875,7 @@ searchWithin:Sök inom
 searchDescendants:Sök i undernivåer
 searchPackage:Sök i paket
 manage:Hantera
-appraisalTitle:Ankomstkontroll
+appraisalTitle:Leveranskontroll
 appraisalAccept:Godkänn
 appraisalReject:Avvisa
 transferredResourcesTitle:Resurser för inleverans
@@ -1052,7 +1052,7 @@ title[ingest_submit_upload]:Skicka paket
 title[ingest_submit_create]:Skapa paket
 title[ingest_list]:Process
 title[ingest_help]:Hjälp
-title[ingest_appraisal]:Ankomstkontroll
+title[ingest_appraisal]:Leveranskontroll
 title[settings]:Inställningar
 title[language]:Språk
 title[profile]:Profil
@@ -1172,7 +1172,7 @@ permissionsSelectAll:{0} \u2013 välj alla
 role:{0} (oöversatt)
 role[aip.view]:Hämta logiska enheter (AIP)
 role[aip.read]:Lista och sök efter logiska enheter (AIP)
-role[aip.appraisal]:Acceptera eller avvisa logiska enheter i ankomstkontroll
+role[aip.appraisal]:Acceptera eller avvisa logiska enheter i leveranskontroll
 role[aip.create.top]:Skapa logiska toppenheter
 role[aip.create.below]:Skapa logiska enheter
 role[aip.update]:Uppdatera logiska enheter

--- a/roda-ui/roda-wui/src/main/resources/config/theme/IngestAppraisalDescription_sv_SE.html
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/IngestAppraisalDescription_sv_SE.html
@@ -1,7 +1,7 @@
-<p>Ankomstkontroll är processen för att avgöra om arkivobjekten och annat
+<p>Leveranskontroll är processen för att avgöra om arkivobjekten och annat
 material har bevarandevärde. Bedömning kan göras på
-samlings-, skapar-, serie-, fil- eller objektsnivå. Bedömningen kan ske 
-före överföringen och före den fysiska flytten, under eller efter anslutningen. 
+samlings-, skapar-, serie-, fil- eller objektsnivå. Bedömningen kan ske
+före överföringen och före den fysiska flytten, under eller efter anslutningen.
 Grunden för bedömningsbeslut kan omfatta ett antal
 faktorer inklusive informationens härkomst, innehåll,
 autenticitet, tillförlitlighet, ordning, fullständighet,


### PR DESCRIPTION
## Sammanfattning

Byter ut begreppet "Ankomstkontroll" mot "Leveranskontroll" genomgående i den svenska UI-texten, i enlighet med #443. Uppdaterar även info-texten under info-knappen (#441).

### Ändringar i `ClientMessages_sv_SE.properties` (GWT-kompilerad)
- `ingestAppraisalTitle`: Ankomstkontroll → **Leveranskontroll**
- `sidebarAppraisalTitle`: Ankomstkontroll → **Leveranskontroll**
- `appraisalTitle`: Ankomstkontroll → **Leveranskontroll**
- `title[ingest_appraisal]`: Ankomstkontroll → **Leveranskontroll**
- `role[aip.appraisal]`: …i ankomstkontroll → **…i leveranskontroll**

### Ändringar i `IngestAppraisalDescription_sv_SE.html` (server-side)
- Inledande mening: "Ankomstkontroll är processen…" → **"Leveranskontroll är processen…"**

## Risker och manuella steg
- `ClientMessages_sv_SE.properties` är GWT-kompilerad — kräver ny GWT-kompilering (`mvn gwt:compile`) för att synas i UI.
- `IngestAppraisalDescription_sv_SE.html` laddas live och kan även läggas i `~/.roda/config/theme/` utan omstart.
- Inga migrationer, inga nya beroenden.

## Closes
Closes #443
Closes #441