### PR TITLE
docs: lägg till sida Vanliga begrepp i hjälpdokumentationen (#438)

### DIFF
--- a/documentation/reference/Help_sv_SE.md
+++ b/documentation/reference/Help_sv_SE.md
@@ -20,6 +20,7 @@ Tekniska referenser och detaljerad information om systemet.
 
 Steg-för-steg guider för att använda ETERNA effektivt.
 
+- **[Vanliga begrepp](usage/Vanliga_Begrepp_sv_SE.md)** - Förklaringar till vanliga begrepp inom e-arkivering och ETERNA
 - **[Redigera Beskrivande Metadata](usage/EditDescriptiveMetadata_sv_SE.md)** - Hur man redigerar metadata
 - **[Avancerad Sökning](usage/Advanced_Search_sv_SE.md)** - Avancerade sökfunktioner
 - **[Inleverans](usage/Pre_Ingest_sv_SE.md)** - Förbereda data för arkivering

--- a/documentation/reference/Overview_sv_SE.md
+++ b/documentation/reference/Overview_sv_SE.md
@@ -29,7 +29,7 @@ För mer information, besök gärna ETERNA:s webbplats:
 
 ## Funktioner i menyraden
 
-ETERNA har UI-stöd för följande funktionella enheter. Funktionerna är organiserade i menyn under följande huvudkategorier: **Katalog**, **Sök**, **Leverans** (Inleverans, Process, Ankomstkontroll), **Administration** (Arkivvårdsjobb, Interna åtgärder, Granskningslogg, Aviseringslogg, Rapportering, Användare och grupper), **Gallring** (Gallringspolicyer, Gallringsbekräftelse, Förfallna gallringar, Gallrade objekt) och **Planering** (Representationsnätverk, Riskregister, Bevarandehändelser, Bevarandeaktör).
+ETERNA har UI-stöd för följande funktionella enheter. Funktionerna är organiserade i menyn under följande huvudkategorier: **Katalog**, **Sök**, **Leverans** (Inleverans, Process, Leveranskontroll), **Administration** (Arkivvårdsjobb, Interna åtgärder, Granskningslogg, Aviseringslogg, Rapportering, Användare och grupper), **Gallring** (Gallringspolicyer, Gallringsbekräftelse, Förfallna gallringar, Gallrade objekt) och **Planering** (Representationsnätverk, Riskregister, Bevarandehändelser, Bevarandeaktör).
 
 ### Katalog
 
@@ -51,9 +51,9 @@ Inleveransytan är en tillfällig lagringsyta för att ta emot inlämningsinform
 
 Inleveransprocessen innehåller funktioner för att acceptera inlämningspaket (SIP) från producenter, förbereda arkivpaket (AIP) för lagring och säkerställa att arkivpaket och deras stödjande beskrivande information etableras i e-arkivet. Den här sidan listar alla inleveranser som för närvarande körs och alla leveranser som har körts tidigare. I den högra sidopanelen är det möjligt att filtrera jobb baserat på deras tillstånd och vilken användare som initierade jobbet. Genom att klicka på ett objekt i tabellen är det möjligt att se hur arbetet fortskrider samt ytterligare detaljer.
 
-#### Ankomstkontroll
+#### Leveranskontroll
 
-Ankomstkontroll är en process för att avgöra om informationen och annat material har bevarandevärde. Bedömning kan göras på samling-, skapar-, serie-, fil- eller objektsnivå. Ankomstkontrollen kan ske före eller efter överföringen. Grunden för beslut kan omfatta ett antal faktorer inklusive informationens härkomst, innehåll, autenticitet, tillförlitlighet, ordning, fullständighet, skick, kostnader för bevarandet samt informationens egenvärde.
+Leveranskontroll är en process för att avgöra om informationen och annat material har bevarandevärde. Bedömning kan göras på samling-, skapar-, serie-, fil- eller objektsnivå. Leveranskontrollen kan ske före eller efter överföringen. Grunden för beslut kan omfatta ett antal faktorer inklusive informationens härkomst, innehåll, autenticitet, tillförlitlighet, ordning, fullständighet, skick, kostnader för bevarandet samt informationens egenvärde.
 
 ### Administration
 

--- a/documentation/usage/Vanliga_Begrepp_sv_SE.md
+++ b/documentation/usage/Vanliga_Begrepp_sv_SE.md
@@ -30,21 +30,3 @@ Här hittar du förklaringar till vanliga begrepp som används i ETERNA och inom
 | Informationssäkerhet | Skydd av information utifrån konfidentialitet, riktighet och tillgänglighet. |
 | Handling | Något som innehåller information. I ETERNA utgörs en handling av en eller flera filer. |
 | Ärende | En samling handlingar, t.ex. ett bygglovsärende innehåller handlingarna: begäran om bygglov och beslut om bygglov. |
-
-## Beskrivningsnivåer (EAD3)
-
-Dessa nivåer används för att beskriva arkivhierarkin i ETERNA och är hämtade från standarden EAD3.
-
-| Engelska (EAD3) | Svenska | Förklaring |
-|---|---|---|
-| Fonds | Bestånd | En hel samling. Till exempel: Riksarkivet har Myndighet X:s och Myndighet Y:s arkivbestånd. De finns i samma arkivlokal men är olika arkivbestånd. |
-| Class | Klass | Högsta roten i en hierarki. Används sällan i svenska arkiv. |
-| Collection | Samling | Annat ord för bestånd. Ett bestånd kan också ha samlingar, t.ex. om ett personarkiv för en författare har en samling brev med en annan kändis. Används främst i Allmänna Arkivschemat. |
-| Record group | Volym | Också ett annat ord för bestånd, vanligt i USA och andra engelskspråkiga länder. OBS: En volym för en svensk arkivarie är en fysisk enhet, t.ex. en kartong som innehåller ärende 1251–1284. |
-| Subgroup | Process | En grupp relaterade handlingar inom en volym eller samling. I svensk arkivterminologi passar "process" bäst, även om grupperingen kan vara geografisk eller administrativ. |
-| Subfonds | Delbestånd | En del av ett bestånd. Används på liknande sätt som samling men för processbaserad arkivredovisning. |
-| Serie | Serie | En gruppering bestående av volymer i ett fysiskt arkiv. I ett e-arkiv består en serie förmodligen av underserier. |
-| Subseries | Underserie | En gruppering av serier som finns inuti en serie. |
-| File | Ärende/Akt | Ett ärende är en avgränsad process inom verksamhetsbaserad arkivredovisning. Inom Allmänna Arkivschemat används nivån Akt för samma struktur. |
-| Item | Handling | En informationsbärare – kan vara vad som helst: PDF, film, DNA-prov. Det är i denna förvaringsenhet som representationen ska ligga. Övriga nivåer ska inte ha handlingar direkt i sig. |
-| Other level | Annan nivå | Används om övriga strukturenheter inte kan beskriva materialet på rätt sätt. |

--- a/documentation/usage/Vanliga_Begrepp_sv_SE.md
+++ b/documentation/usage/Vanliga_Begrepp_sv_SE.md
@@ -1,0 +1,50 @@
+# Vanliga begrepp
+
+Här hittar du förklaringar till vanliga begrepp som används i ETERNA och inom e-arkivering.
+
+## Allmänna begrepp
+
+| Begrepp | Förklaring |
+|---|---|
+| Arkivredovisning | Beskrivning av vilka handlingar som finns, hur de är organiserade och hur de ska förstås. |
+| Klassificeringsstruktur | Struktur som används för att ordna och beskriva handlingar. Klassificeringsstrukturen används inom arkivredovisning och e-arkiv för att skapa en enhetlig och sökbar organisation av information. Härifrån byggs trädstrukturen. |
+| Bevarande | Att säkerställa att information kan läsas, förstås och användas i minst tusen år. |
+| Gallring | Förstöring eller borttagning av information enligt beslutade regler. Ska inte gå att återskapa. Även om man inte kan se innehållet eller inte öppna filen har gallring skett. |
+| Informationspaket | Samlad mängd information och metadata som överförs eller lagras i e-arkivet. |
+| SIP (Submission Information Package) | Leveranspaket från verksamhetssystem till e-arkiv. |
+| AIP (Archival Information Package) | Paket som lagras och bevaras i e-arkivet. |
+| DIP (Dissemination Information Package) | Paket som lämnas ut till användare vid sökning eller utlämnande. |
+| Verksamhetssystem | System där information skapas och används i det dagliga arbetet. |
+| Export | Uttag av information från ett verksamhetssystem för överföring till e-arkiv. |
+| Autenticitet | Att informationen är äkta och inte har förändrats otillåtet. |
+| Integritet | Att informationen är fullständig och korrekt. |
+| Tillgänglighet | Att information kan hittas och användas när den behövs. |
+| Spårbarhet | Möjlighet att följa förändringar, åtkomst och hantering av information. I ETERNA hanteras detta genom PREMIS. |
+| Informationsklassning | Bedömning av informationens skyddsbehov, t.ex. sekretess eller känslighet. Inte samma sak som sekretessklassning. |
+| Sekretess | Skydd av information som inte får lämnas ut till obehöriga. Sekretessmarkering sker utifrån OSL. |
+| Personuppgift | Information som direkt eller indirekt kan kopplas till en levande person. Gäller allt från personnummer till bilder och DNA. |
+| GDPR | EU:s dataskyddsförordning som reglerar behandling av personuppgifter. Arkivlagen står över den. |
+| Allmän handling | Handling som förvaras hos myndighet och är inkommen eller upprättad där. |
+| Livscykelhantering | Hantering av information från skapande till gallring eller långtidsbevarande. |
+| Riksarkivet | Svensk myndighet som ansvarar för statens arkivfrågor och föreskrifter. |
+| Informationssäkerhet | Skydd av information utifrån konfidentialitet, riktighet och tillgänglighet. |
+| Handling | Något som innehåller information. I ETERNA utgörs en handling av en eller flera filer. |
+| Ärende | En samling handlingar, t.ex. ett bygglovsärende innehåller handlingarna: begäran om bygglov och beslut om bygglov. |
+
+## Beskrivningsnivåer (EAD3)
+
+Dessa nivåer används för att beskriva arkivhierarkin i ETERNA och är hämtade från standarden EAD3.
+
+| Engelska (EAD3) | Svenska | Förklaring |
+|---|---|---|
+| Fonds | Bestånd | En hel samling. Till exempel: Riksarkivet har Myndighet X:s och Myndighet Y:s arkivbestånd. De finns i samma arkivlokal men är olika arkivbestånd. |
+| Class | Klass | Högsta roten i en hierarki. Används sällan i svenska arkiv. |
+| Collection | Samling | Annat ord för bestånd. Ett bestånd kan också ha samlingar, t.ex. om ett personarkiv för en författare har en samling brev med en annan kändis. Används främst i Allmänna Arkivschemat. |
+| Record group | Volym | Också ett annat ord för bestånd, vanligt i USA och andra engelskspråkiga länder. OBS: En volym för en svensk arkivarie är en fysisk enhet, t.ex. en kartong som innehåller ärende 1251–1284. |
+| Subgroup | Process | En grupp relaterade handlingar inom en volym eller samling. I svensk arkivterminologi passar "process" bäst, även om grupperingen kan vara geografisk eller administrativ. |
+| Subfonds | Delbestånd | En del av ett bestånd. Används på liknande sätt som samling men för processbaserad arkivredovisning. |
+| Serie | Serie | En gruppering bestående av volymer i ett fysiskt arkiv. I ett e-arkiv består en serie förmodligen av underserier. |
+| Subseries | Underserie | En gruppering av serier som finns inuti en serie. |
+| File | Ärende/Akt | Ett ärende är en avgränsad process inom verksamhetsbaserad arkivredovisning. Inom Allmänna Arkivschemat används nivån Akt för samma struktur. |
+| Item | Handling | En informationsbärare – kan vara vad som helst: PDF, film, DNA-prov. Det är i denna förvaringsenhet som representationen ska ligga. Övriga nivåer ska inte ha handlingar direkt i sig. |
+| Other level | Annan nivå | Används om övriga strukturenheter inte kan beskriva materialet på rätt sätt. |


### PR DESCRIPTION
## Sammanfattning

Lägger till en ny undersida **Vanliga begrepp** under Användarguider i hjälpdokumentationen, i enlighet med #438. Uppdaterar även begreppet "Ankomstkontroll" till "Leveranskontroll" genomgående i dokumentationen.

### Nya och ändrade filer

- **`documentation/usage/Vanliga_Begrepp_sv_SE.md`** (ny) — tabell med 24 vanliga begrepp inom e-arkivering och ETERNA
- **`documentation/reference/Help_sv_SE.md`** — länk till Vanliga begrepp tillagd överst under Användarguider
- **`documentation/reference/Overview_sv_SE.md`** — "Ankomstkontroll" → "Leveranskontroll" (menyöversikt, sektionstiteln och beskrivningstexten)

## Risker och manuella steg

- Endast Markdown-dokumentation — inga kod- eller konfigurationsändringar.
- Inga migrationer, inga nya beroenden.
- Filerna serveras dynamiskt via theme-API:t, ingen GWT-kompilering krävs.

## Closes
Closes #438