### PR TITLE
fix: ändra etikett Bevara permanent till Bevara

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1622,7 +1622,7 @@ disposalPolicyScheduleDaySummary[one]:imorgon
 disposalPolicyScheduleDaySummary:om {0,number} dagar
 disposalPolicySummaryReady:Förfallen för {0} 
 permanentlyRetained:Aldrig
-disposalPolicyRetainPermanently:Behålls permanent
+disposalPolicyRetainPermanently:Bevara
 disposalPolicyDestroyedAIPSummary:Gallrades {0}
 retentionPeriod:{0}
 retentionPeriod[\=1|DAYS]:1 dag


### PR DESCRIPTION
## Sammanfattning

- Byter ut etiketten "Behålls permanent" mot "Bevara" för `RETAIN_PERMANENTLY`-åtgärden i gallringspolicysammanfattningen

Closes #406

## Testplan

- [ ] Kontrollera att statusbadgen visar "Bevara" (inte "Behålls permanent") för AIP med gallringsregel RETAIN_PERMANENTLY