### PR TITLE
fix(#510): revert preservation event strings to English

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/antivirus/AntivirusPlugin.java
@@ -245,17 +245,17 @@ public class AntivirusPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Sökte igenom paketet efter skadliga program med ClamAV.";
+    return "Scanned package for malicious programs using ClamAV.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Paketet innehåller inga kända skadliga program.";
+    return "The package does not contain any known malicious programs.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Ett skadligt program hittades i paketet.";
+    return "A malicious program was detected inside the package.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
@@ -394,17 +394,17 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
 
   @Override
   public String getPreservationEventDescription() {
-    return "Identifierade objektets filformat och versioner med Siegfried.";
+    return "Identified the object's file formats and versions using Siegfried.";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Filformat identifierades och registrerades i PREMIS-objekt.";
+    return "File formats were identified and recorded in PREMIS objects.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Misslyckades med att identifiera filformat i paketet.";
+    return "Failed to identify file formats in the package.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
@@ -107,22 +107,22 @@ public class ApplyDisposalRulesPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Tillämpade gallringsregler på AIP:er i arkivet";
+    return "Apply the disposal rules to AIPs in the repository";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Gallringsplan kopplades till AIP:et via gallringsregel";
+    return "Disposal schedule successfully associated to AIP via disposal rule";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Det gick inte att koppla gallringsplan till AIP:et via gallringsregel";
+    return "Failed to associate disposal schedule to AIP via disposal rule";
   }
 
   @Override
   public String getPreservationEventSkippedMessage() {
-    return "Hoppade över koppling av gallringsplan till AIP:et via gallringsregel";
+    return "Skipped disposal schedule association to AIP via disposal rule";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/AutoAcceptSIPPlugin.java
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
 public class AutoAcceptSIPPlugin extends AbstractPlugin<AIP> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AutoAcceptSIPPlugin.class);
 
-  public static final String FAILURE_MESSAGE = "Det gick inte att lägga till AIP:et i arkivets inventarieförteckning.";
-  public static final String SUCCESS_MESSAGE = "AIP:et lades till i arkivets inventarieförteckning.";
-  public static final String DESCRIPTION = "Paketet lades till i inventarieförteckningen. Från och med nu övergår ansvaret för det digitala innehållets bevarande till arkivet.";
+  public static final String FAILURE_MESSAGE = "Failed to add the AIP to the repository's inventory.";
+  public static final String SUCCESS_MESSAGE = "The AIP was successfully added to the repository's inventory.";
+  public static final String DESCRIPTION = "Added package to the inventory. After this point, the responsibility for the digital content's preservation is passed on to the repository.";
 
   @Override
   public void init() throws PluginException {

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/BagitToAIPPlugin.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class BagitToAIPPlugin extends SIPToAIPPlugin {
   private static final Logger LOGGER = LoggerFactory.getLogger(BagitToAIPPlugin.class);
-  private static final String UNPACK_DESCRIPTION = "Extraherade objekt från paketet i BagIt-format.";
+  private static final String UNPACK_DESCRIPTION = "Extracted objects from package in BagIt format.";
   private static final String METADATA_FILE = "metadata.xml";
 
   private boolean createSubmission = false;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
@@ -59,7 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
-  public static final String UNPACK_DESCRIPTION = "Extraherade objekt från paket i E-ARK SIP 2-format.";
+  public static final String UNPACK_DESCRIPTION = "Extracted objects from package in E-ARK SIP 2 format.";
   private static final Logger LOGGER = LoggerFactory.getLogger(EARKSIP2ToAIPPlugin.class);
   private boolean createSubmission = false;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIPToAIPPlugin.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 public class EARKSIPToAIPPlugin extends SIPToAIPPlugin {
   private static final Logger LOGGER = LoggerFactory.getLogger(EARKSIPToAIPPlugin.class);
 
-  public static final String UNPACK_DESCRIPTION = "Extraherade objekt från paket i E-ARK SIP-format.";
+  public static final String UNPACK_DESCRIPTION = "Extracted objects from package in E-ARK SIP format.";
 
   private boolean createSubmission = false;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/SIPToAIPPlugin.java
@@ -29,14 +29,14 @@ import org.slf4j.LoggerFactory;
 public abstract class SIPToAIPPlugin extends AbstractPlugin<TransferredResource> {
   private static final Logger LOGGER = LoggerFactory.getLogger(SIPToAIPPlugin.class);
 
-  public static final String UNPACK_SUCCESS_MESSAGE = "SIP:et har packats upp.";
-  public static final String UNPACK_FAILURE_MESSAGE = "Inleveransprocessen misslyckades med att packa upp SIP:et.";
+  public static final String UNPACK_SUCCESS_MESSAGE = "The SIP has been successfully unpacked.";
+  public static final String UNPACK_FAILURE_MESSAGE = "The ingest process failed to unpack the SIP.";
   public static final String UNPACK_PARTIAL_MESSAGE = null;
   public static final PreservationEventType UNPACK_EVENT_TYPE = PreservationEventType.UNPACKING;
 
-  public static final String WELLFORMED_DESCRIPTION = "Kontrollerade att det mottagna SIP:et är välformat, komplett och att inga oväntade filer inkluderades.";
-  public static final String WELLFORMED_SUCCESS_MESSAGE = "SIP:et var välformat och komplett.";
-  public static final String WELLFORMED_FAILURE_MESSAGE = "SIP:et var inte välformat eller några filer saknades.";
+  public static final String WELLFORMED_DESCRIPTION = "Checked that the received SIP is well formed, complete and that no unexpected files were included.";
+  public static final String WELLFORMED_SUCCESS_MESSAGE = "The SIP was well formed and complete.";
+  public static final String WELLFORMED_FAILURE_MESSAGE = "The SIP was not well formed or some files were missing.";
   public static final String WELLFORMED_PARTIAL_MESSAGE = null;
   public static final PreservationEventType WELLFORMED_EVENT_TYPE = PreservationEventType.WELLFORMEDNESS_CHECK;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/TransferredResourceToAIPPlugin.java
@@ -54,7 +54,7 @@ public class TransferredResourceToAIPPlugin extends SIPToAIPPlugin {
   private static final String METADATA_TYPE = "key-value";
   private static final String METADATA_VERSION = null;
   private static final String METADATA_FILE = "metadata.xml";
-  private static final String UNPACK_DESCRIPTION = "Extraherade objekt från paketet i fil/mappformat.";
+  private static final String UNPACK_DESCRIPTION = "Extracted objects from package in file/folder format.";
 
   private boolean createSubmission = false;
   private Optional<String> computedSearchScope;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/VerifyUserAuthorizationPlugin.java
@@ -190,10 +190,11 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    String description = "Användarbehörigheter har kontrollerats för att säkerställa att användaren har tillräcklig behörighet att lagra AIP:et under den önskade noden i klassificeringssystemet.";
+    String description = "User permissions have been checked to ensure that he has sufficient authorization to store the AIP under the desired "
+      + "node of the classification scheme.";
 
     if (hasFreeAccess) {
-      description += " Läsbehörighet gavs till användargruppen enligt beskrivande metadata.";
+      description += " It was given READ permission to the users group as indicated on the descriptive metadata";
     }
 
     return description;
@@ -201,12 +202,12 @@ public class VerifyUserAuthorizationPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Användaren har tillräckliga behörigheter för att deponera AIP:et under den angivna noden i klassificeringssystemet.";
+    return "The user has enough permissions to deposit the AIP under the designated node of the classification scheme";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Användaren har inte tillräckliga behörigheter för att deponera AIP:et under den angivna noden i klassificeringssystemet.";
+    return "The user does not have enough permissions to deposit the AIP under the designated node of the classification scheme";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/AddRepresentationInformationFilterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/AddRepresentationInformationFilterPlugin.java
@@ -160,17 +160,17 @@ public class AddRepresentationInformationFilterPlugin extends AbstractPlugin<Rep
 
   @Override
   public String getPreservationEventDescription() {
-    return "Lade till filter för representationsinformation";
+    return "Add representation information filter";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Filtret för representationsinformation lades till";
+    return "Representation information filter was added successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Det gick inte att lägga till filtret för representationsinformation";
+    return "Representation information filter failed to add";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
@@ -175,12 +175,12 @@ public class ChangeRodaMemberStatusPlugin<T extends RODAMember> extends Abstract
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "The ETERNA user status were successfully updated";
+    return "The ETERNA user status was successfully updated";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "The ETERNA user status were not successfully updated";
+    return "The ETERNA user status was not successfully updated";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/ChangeRodaMemberStatusPlugin.java
@@ -175,12 +175,12 @@ public class ChangeRodaMemberStatusPlugin<T extends RODAMember> extends Abstract
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "The RODA user status were successfully updated";
+    return "The ETERNA user status were successfully updated";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "The RODA user status were not successfully updated";
+    return "The ETERNA user status were not successfully updated";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRODAObjectPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/DeleteRODAObjectPlugin.java
@@ -163,17 +163,17 @@ public class DeleteRODAObjectPlugin<T extends IsRODAObject> extends AbstractPlug
 
   @Override
   public String getPreservationEventDescription() {
-    return "Deletes RODA entities";
+    return "Deletes ETERNA entities";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "RODA entities were successfully removed";
+    return "ETERNA entities were successfully removed";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "RODA entities were not successfully removed";
+    return "ETERNA entities were not successfully removed";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAllRodaEntitiesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexAllRodaEntitiesPlugin.java
@@ -185,7 +185,7 @@ public class ReindexAllRodaEntitiesPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAIPEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAIPEventPlugin.java
@@ -181,7 +181,7 @@ public class ReindexPreservationAIPEventPlugin extends AbstractPlugin<AIP> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAgentPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationAgentPlugin.java
@@ -198,7 +198,7 @@ public class ReindexPreservationAgentPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationRepositoryEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexPreservationRepositoryEventPlugin.java
@@ -201,7 +201,7 @@ public class ReindexPreservationRepositoryEventPlugin extends AbstractPlugin<Voi
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaEntityPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexRodaEntityPlugin.java
@@ -237,7 +237,7 @@ public abstract class ReindexRodaEntityPlugin<T extends IsRODAObject> extends Ab
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexTransferredResourcePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/maintenance/reindex/ReindexTransferredResourcePlugin.java
@@ -199,7 +199,7 @@ public class ReindexTransferredResourcePlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Reindex Roda entity";
+    return "Reindex ETERNA entity";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
@@ -267,17 +267,17 @@ public class EditFileFormatPlugin extends AbstractPlugin<File> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Ändrade filernas formatmetadata";
+    return "Changed files' format metadata";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Filformat uppdaterades och registrerades i PREMIS-objekt.";
+    return "File formats were updated and recorded in PREMIS objects.";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Det gick inte att uppdatera filformaten i paketet.";
+    return "Failed to update file formats in the package.";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskAssociationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/risks/RiskAssociationPlugin.java
@@ -343,7 +343,7 @@ public class RiskAssociationPlugin<T extends IsRODAObject> extends AbstractPlugi
 
   @Override
   public String getPreservationEventDescription() {
-    return getDescription();
+    return "Associated selected objects with risks in the risk registry";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPEventPlugin.java
@@ -120,17 +120,17 @@ public class InstanceIdentifierAIPEventPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren för AIP-bevarandehändelser";
+    return "Updated the AIP preservation events instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren för AIP-bevarandehändelsen uppdaterades.";
+    return "The AIP preservation event instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren för AIP-bevarandehändelsen.";
+    return "Could not update the AIP preservation event instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierAIPPlugin.java
@@ -111,17 +111,17 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierDIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierDIPPlugin.java
@@ -112,17 +112,17 @@ public class InstanceIdentifierDIPPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierJobPlugin.java
@@ -112,17 +112,17 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierNotificationPlugin.java
@@ -112,17 +112,17 @@ public class InstanceIdentifierNotificationPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierPreservationAgentPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierPreservationAgentPlugin.java
@@ -252,17 +252,17 @@ public class InstanceIdentifierPreservationAgentPlugin extends AbstractPlugin<Vo
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepositoryEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepositoryEventPlugin.java
@@ -118,17 +118,17 @@ public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<Void
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren för arkivets bevarandehändelser";
+    return "Updated the repository preservation events instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren för arkivets bevarandehändelse uppdaterades.";
+    return "The repository preservation event instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren för arkivets bevarandehändelse.";
+    return "Could not update the repository preservation event instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepresentationInformationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRepresentationInformationPlugin.java
@@ -98,17 +98,17 @@ public class InstanceIdentifierRepresentationInformationPlugin extends AbstractP
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskIncidencePlugin.java
@@ -112,17 +112,17 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<Void> 
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/InstanceIdentifierRiskPlugin.java
@@ -112,17 +112,17 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
@@ -185,17 +185,17 @@ public class LocalInstanceRegisterPlugin extends NoObjectsMultipleStepPlugin {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/LocalInstanceRegisterPlugin.java
@@ -166,7 +166,7 @@ public class LocalInstanceRegisterPlugin extends NoObjectsMultipleStepPlugin {
 
   @Override
   public String getName() {
-    return "RODA-objektets instansidentifierare";
+    return "ETERNA-objektets instansidentifierare";
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/RegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/synchronization/instance/RegisterPlugin.java
@@ -70,17 +70,17 @@ public class RegisterPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getPreservationEventDescription() {
-    return "Uppdaterade instansidentifieraren";
+    return "Updated the instance identifier";
   }
 
   @Override
   public String getPreservationEventSuccessMessage() {
-    return "Instansidentifieraren uppdaterades.";
+    return "The instance identifier was updated successfully";
   }
 
   @Override
   public String getPreservationEventFailureMessage() {
-    return "Kunde inte uppdatera instansidentifieraren.";
+    return "Could not update the instance identifier";
   }
 
   @Override


### PR DESCRIPTION
Closes #510

## Summary

- Återställer alla , ,  och  till engelska
- Gäller 18 plugin-filer som fick svenska strängar via issue #285 (PR #311)

## Ändrade filer

-  — format identification strings
-  — malware scan strings
-  — disposal rule strings (inkl. skipped)
-  — format metadata strings
-  — authorization check strings
-  — representation info strings
-  /  — instance identifier strings
- 10×  — instance identifier strings

## Test plan

- [x] Verifiera att preservation events i PREMIS-objekt visas på engelska efter körning av t.ex. Siegfried-plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Ändringar**
  * Uppdaterade användarvänliga meddelanden för bevarandehändelser från svenska till engelska i flera plugins (beskrivningar, framgångs‑ och felmeddelanden och vissa publika konstanter).
  * Uppdaterade förekomster av "RODA" till "ETERNA" i synliga meddelanden.
  * Ingen funktionslogik eller publika API‑signaturer har ändrats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->