### PR TITLE
feat: ghost-noder i katalogträdet för användare med begränsad behörighet (#480, #481)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-katalogträd-ghost-noder.md
+++ b/docs/superpowers/plans/2026-05-20-katalogträd-ghost-noder.md
@@ -1,0 +1,733 @@
+# Katalogträd Ghost-noder — Implementationsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Visa accessible AIPs i katalogträdet även när användaren saknar behörighet till rotnoderna, med otillgängliga förfäder renderade som "ghost-noder" (grå, ej klickbara, alltid utfällda).
+
+**Architecture:** `loadRootNodes()` i `CatalogTreePanel` kör ett fallback-flöde om root-sökningen returnerar 0 resultat: hämta alla AIPs användaren har tillgång till (max 200), bygg ancestor-kedjor via `getAncestors()`, och konstruera ett ghost-träd. `CatalogTreeNode` utökas med en ghost-konstruktor och `addPrebuiltChild()`. Noderna kopplas uppifrån och ned; deduplicering sker för reella rotnoder (depth 0) men ej för ghost-noder.
+
+**Tech Stack:** GWT (Java → JS), Spring Boot REST, Solr-index, GWT i18n (ClientMessages), GSS (CSS-in-GWT)
+
+---
+
+## Berörda filer
+
+| Fil | Förändring |
+|---|---|
+| `roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java` | Ny metod `catalogTreeGhostNodeLabel()` |
+| `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties` | Ny nyckel `catalogTreeGhostNodeLabel` |
+| `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties` | Ny nyckel `catalogTreeGhostNodeLabel` |
+| `roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss` | Ny CSS-klass `.catalogTreeNode.ghost` |
+| `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java` | Ghost-konstruktor, `addPrebuiltChild()`, `isGhostNode()`, skydda `toggle()`/`collapse()` |
+| `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java` | Fallback i `loadRootNodes()`, `loadFallbackGhostTree()`, `insertFallbackChain()`, `finalizeFallbackTree()`, uppdaterad `applyFilter()` |
+
+---
+
+## Task 0: Skapa feature branch
+
+**Files:** (inga ändringar, bara git)
+
+- [ ] **Steg 1: Skapa och checka ut feature branch**
+
+Kör i WSL från worktree-katalogen:
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git checkout -b feat/480-katalogträd-ghost-noder"
+```
+
+Förväntat output: `Switched to a new branch 'feat/480-katalogträd-ghost-noder'`
+
+---
+
+## Task 1: i18n — Ghost-nyckel
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java:2728`
+- Modify: `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties:1883`
+- Modify: `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties:1800`
+
+- [ ] **Steg 1: Lägg till metod i ClientMessages.java efter rad 2728**
+
+Befintlig kod (rad 2728–2729):
+```java
+  String catalogTreeReasonRetrieveAIP();
+}
+```
+
+Ersätt med:
+```java
+  String catalogTreeReasonRetrieveAIP();
+
+  String catalogTreeGhostNodeLabel();
+}
+```
+
+- [ ] **Steg 2: Lägg till engelsk nyckel i ClientMessages.properties efter rad 1883**
+
+Befintlig rad 1883:
+```
+catalogTreeReasonRetrieveAIP: Retrieve AIP
+```
+
+Lägg till efter raden:
+```
+catalogTreeGhostNodeLabel: Access denied
+```
+
+- [ ] **Steg 3: Lägg till svensk nyckel i ClientMessages_sv_SE.properties efter rad 1800**
+
+Befintlig rad 1800:
+```
+catalogTreeReasonRetrieveAIP: Hämta AIP
+```
+
+Lägg till efter raden:
+```
+catalogTreeGhostNodeLabel: Åtkomst saknas
+```
+
+- [ ] **Steg 4: Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties && git commit -m 'feat: i18n-nyckel för ghost-nod i katalogträdet'"
+```
+
+---
+
+## Task 2: CSS — Ghost-nodstil
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss:3570`
+
+- [ ] **Steg 1: Lägg till ghost-CSS efter `.catalogTreeNodeError`-blocket (rad 3570)**
+
+Befintlig kod (rad 3563–3571):
+```css
+.catalogTreeNodeError {
+    padding: 4px 8px 4px 40px;
+    font-size: 11px;
+    color: COLOR_PRIMARY;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+```
+
+Ersätt med:
+```css
+.catalogTreeNodeError {
+    padding: 4px 8px 4px 40px;
+    font-size: 11px;
+    color: COLOR_PRIMARY;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.catalogTreeNode.ghost {
+    cursor: default;
+    color: #aaaaaa;
+    font-style: italic;
+}
+
+.catalogTreeNode.ghost:hover {
+    background: transparent;
+}
+
+.catalogTreeNode.ghost .catalogTreeIcon {
+    color: #cccccc;
+}
+
+```
+
+- [ ] **Steg 2: Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss && git commit -m 'feat: CSS-stil för ghost-noder i katalogträdet'"
+```
+
+---
+
+## Task 3: CatalogTreeNode — Ghost-stöd
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java`
+
+- [ ] **Steg 1: Lägg till `ghost`-fält och `ghostCounter` efter befintliga fält (rad 65)**
+
+Befintlig kod (rad 63–66):
+```java
+  private boolean expanded = false;
+  private boolean loaded = false;
+  private boolean isLeaf = false;
+  private Command pendingOnComplete = null;
+```
+
+Ersätt med:
+```java
+  private boolean expanded = false;
+  private boolean loaded = false;
+  private boolean isLeaf = false;
+  private Command pendingOnComplete = null;
+  private final boolean ghost;
+  private static int ghostCounter = 0;
+```
+
+- [ ] **Steg 2: Lägg till `this.ghost = false;` i befintlig konstruktor (rad 68)**
+
+Befintlig konstruktor (rad 68–71):
+```java
+  public CatalogTreeNode(String aipId, String title, String level, int depth) {
+    this.aipId = aipId;
+    this.title = title;
+    this.depth = depth;
+```
+
+Ersätt med:
+```java
+  public CatalogTreeNode(String aipId, String title, String level, int depth) {
+    this.ghost = false;
+    this.aipId = aipId;
+    this.title = title;
+    this.depth = depth;
+```
+
+- [ ] **Steg 3: Lägg till ghost-fabriksmetod och privat ghost-konstruktor efter befintlig konstruktor (efter rad 119)**
+
+Befintlig kod (rad 117–119):
+```java
+    rootPanel.add(rowPanel);
+    rootPanel.add(childrenPanel);
+
+    initWidget(rootPanel);
+  }
+```
+
+Ersätt med:
+```java
+    rootPanel.add(rowPanel);
+    rootPanel.add(childrenPanel);
+
+    initWidget(rootPanel);
+  }
+
+  /** Skapar en ghost-nod som representerar ett AIP utan behörighet. */
+  public static CatalogTreeNode createGhostNode(int depth) {
+    return new CatalogTreeNode(depth);
+  }
+
+  private CatalogTreeNode(int depth) {
+    this.ghost = true;
+    this.aipId = "__ghost__" + (ghostCounter++);
+    this.title = messages.catalogTreeGhostNodeLabel();
+    this.depth = depth;
+
+    rootPanel = new FlowPanel();
+
+    rowPanel = new FlowPanel();
+    rowPanel.setStyleName("catalogTreeNode ghost");
+
+    for (int i = 0; i < depth; i++) {
+      FlowPanel indent = new FlowPanel();
+      indent.setStyleName("catalogTreeIndent");
+      rowPanel.add(indent);
+    }
+
+    toggleHtml = new HTML("");
+    toggleHtml.setStyleName("catalogTreeToggle");
+    rowPanel.add(toggleHtml);
+
+    iconHtml = new HTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(RodaConstants.AIP_GHOST, false));
+    iconHtml.setStyleName("catalogTreeIcon");
+    rowPanel.add(iconHtml);
+
+    titleLabel = new Label(this.title);
+    titleLabel.setStyleName("catalogTreeLabel");
+    rowPanel.add(titleLabel);
+
+    childrenPanel = new FlowPanel();
+    childrenPanel.setStyleName("catalogTreeNodeChildren");
+    childrenPanel.setVisible(true);
+
+    rootPanel.add(rowPanel);
+    rootPanel.add(childrenPanel);
+
+    loaded = true;
+    expanded = true;
+
+    initWidget(rootPanel);
+  }
+```
+
+- [ ] **Steg 4: Skydda `toggle()` och `collapse()` mot ghost-noder**
+
+Befintlig `toggle()` (rad 121–128):
+```java
+  public void toggle() {
+    if (isLeaf) return;
+    if (expanded) {
+      collapse();
+    } else {
+      expand(null);
+    }
+  }
+```
+
+Ersätt med:
+```java
+  public void toggle() {
+    if (ghost || isLeaf) return;
+    if (expanded) {
+      collapse();
+    } else {
+      expand(null);
+    }
+  }
+```
+
+Befintlig `collapse()` (rad 210–214):
+```java
+  public void collapse() {
+    childrenPanel.setVisible(false);
+    expanded = false;
+    toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
+  }
+```
+
+Ersätt med:
+```java
+  public void collapse() {
+    if (ghost) return;
+    childrenPanel.setVisible(false);
+    expanded = false;
+    toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
+  }
+```
+
+- [ ] **Steg 5: Lägg till `addPrebuiltChild()` och `isGhostNode()` efter `collapse()` (rad 214)**
+
+Befintlig kod (rad 215–218):
+```java
+  public void select() {
+    rowPanel.addStyleName("selected");
+  }
+```
+
+Ersätt med:
+```java
+  /**
+   * Lägger till ett förkonstruerat barn (används vid fallback ghost-träd).
+   * Sätter noden som laddad och utfälld.
+   */
+  public void addPrebuiltChild(CatalogTreeNode child) {
+    if (childNodes.containsKey(child.getAipId())) {
+      return;
+    }
+    childNodes.put(child.getAipId(), child);
+    childrenPanel.add(child);
+    if (!ghost) {
+      loaded = true;
+      expanded = true;
+      childrenPanel.setVisible(true);
+      toggleHtml.setHTML(ICON_TOGGLE_EXPANDED);
+    }
+  }
+
+  public boolean isGhostNode() {
+    return ghost;
+  }
+
+  public void select() {
+    rowPanel.addStyleName("selected");
+  }
+```
+
+- [ ] **Steg 6: Verifiera att koden kompilerar**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests -q 2>&1 | tail -20"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Steg 7: Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java && git commit -m 'feat: ghost-konstruktor och addPrebuiltChild i CatalogTreeNode (#480)'"
+```
+
+---
+
+## Task 4: CatalogTreePanel — Fallback ghost-träd
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java`
+
+- [ ] **Steg 1: Lägg till saknade imports**
+
+Befintlig import-sektion (rad 10–13):
+```java
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+```
+
+Ersätt med:
+```java
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+```
+
+- [ ] **Steg 2: Aktivera fallback i `loadRootNodes()` om sökningen returnerar 0 resultat**
+
+Befintlig kod i `loadRootNodes()` (rad 186–197):
+```java
+        for (IndexedAIP aip : result.getResults()) {
+          CatalogTreeNode node = new CatalogTreeNode(aip.getId(), aip.getTitle(), aip.getLevel(), 0);
+          rootNodes.put(aip.getId(), node);
+          treeBody.add(node);
+        }
+        rootsLoaded = true;
+        if (pendingRevealAipId != null) {
+          String id = pendingRevealAipId;
+          pendingRevealAipId = null;
+          doRevealAip(id);
+        }
+```
+
+Ersätt med:
+```java
+        if (result.getResults().isEmpty()) {
+          loadFallbackGhostTree();
+          return;
+        }
+        for (IndexedAIP aip : result.getResults()) {
+          CatalogTreeNode node = new CatalogTreeNode(aip.getId(), aip.getTitle(), aip.getLevel(), 0);
+          rootNodes.put(aip.getId(), node);
+          treeBody.add(node);
+        }
+        rootsLoaded = true;
+        if (pendingRevealAipId != null) {
+          String id = pendingRevealAipId;
+          pendingRevealAipId = null;
+          doRevealAip(id);
+        }
+```
+
+- [ ] **Steg 3: Lägg till `loadFallbackGhostTree()` efter `loadRootNodes()` (efter rad 198)**
+
+Befintlig kod (rad 199–209):
+```java
+  public void revealAip(String aipId) {
+    if (!rootsLoaded) {
+      pendingRevealAipId = aipId;
+      if (!rootsLoading) {
+        loadRootNodes();
+      }
+      return;
+    }
+    doRevealAip(aipId);
+  }
+```
+
+Ersätt med:
+```java
+  private void loadFallbackGhostTree() {
+    FindRequest findRequest = new FindRequest.FindRequestBuilder(
+      new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+      false)
+      .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
+      .withSublist(new Sublist(0, 200))
+      .build();
+
+    Services service = new Services(messages.catalogTreeReasonListRoots(), "get");
+    service.rodaEntityRestService(
+      s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
+      IndexedAIP.class)
+      .whenComplete((result, error) -> {
+        if (error != null) {
+          LOGGER.error("Fallback ghost tree query failed", error);
+          rootsLoaded = true;
+          return;
+        }
+        List<IndexedAIP> aips = result.getResults();
+        if (aips.isEmpty()) {
+          rootsLoaded = true;
+          return;
+        }
+
+        Map<String, CatalogTreeNode> nodeMap = new LinkedHashMap<>();
+        List<CatalogTreeNode> roots = new ArrayList<>();
+        int[] remaining = {aips.size()};
+
+        for (IndexedAIP aip : aips) {
+          Services s2 = new Services(messages.catalogTreeReasonGetAncestors(), "get");
+          s2.aipResource(srv -> srv.getAncestors(aip.getId()))
+            .whenComplete((ancestors, err) -> {
+              if (err != null) {
+                LOGGER.warn("Could not get ancestors for fallback AIP " + aip.getId() + ", skipping");
+              } else {
+                Collections.reverse(ancestors);
+                insertFallbackChain(ancestors, aip, nodeMap, roots);
+              }
+              remaining[0]--;
+              if (remaining[0] == 0) {
+                finalizeFallbackTree(roots);
+              }
+            });
+        }
+      });
+  }
+
+  private void insertFallbackChain(List<IndexedAIP> ancestors, IndexedAIP targetAip,
+      Map<String, CatalogTreeNode> nodeMap, List<CatalogTreeNode> roots) {
+    CatalogTreeNode parent = null;
+
+    for (int i = 0; i < ancestors.size(); i++) {
+      IndexedAIP anc = ancestors.get(i);
+      CatalogTreeNode node;
+
+      if (anc == null) {
+        node = CatalogTreeNode.createGhostNode(i);
+      } else if (i == 0 && nodeMap.containsKey(anc.getId())) {
+        parent = nodeMap.get(anc.getId());
+        continue;
+      } else {
+        node = new CatalogTreeNode(anc.getId(), anc.getTitle(), anc.getLevel(), i);
+        if (i == 0) {
+          nodeMap.put(anc.getId(), node);
+        }
+      }
+
+      if (parent == null) {
+        roots.add(node);
+      } else {
+        parent.addPrebuiltChild(node);
+      }
+      parent = node;
+    }
+
+    if (nodeMap.containsKey(targetAip.getId())) {
+      return;
+    }
+    CatalogTreeNode targetNode = new CatalogTreeNode(
+      targetAip.getId(), targetAip.getTitle(), targetAip.getLevel(), ancestors.size());
+    nodeMap.put(targetAip.getId(), targetNode);
+    if (parent == null) {
+      roots.add(targetNode);
+    } else {
+      parent.addPrebuiltChild(targetNode);
+    }
+  }
+
+  private void finalizeFallbackTree(List<CatalogTreeNode> roots) {
+    for (CatalogTreeNode root : roots) {
+      rootNodes.put(root.getAipId(), root);
+      treeBody.add(root);
+    }
+    rootsLoaded = true;
+    if (pendingRevealAipId != null) {
+      String id = pendingRevealAipId;
+      pendingRevealAipId = null;
+      doRevealAip(id);
+    }
+  }
+
+  public void revealAip(String aipId) {
+    if (!rootsLoaded) {
+      pendingRevealAipId = aipId;
+      if (!rootsLoading) {
+        loadRootNodes();
+      }
+      return;
+    }
+    doRevealAip(aipId);
+  }
+```
+
+- [ ] **Steg 4: Null-säkra `expandChain()` för ghost-förfäder**
+
+`getAncestors()` kan returnera `null`-värden för otillgängliga förfäder. Befintlig `expandChain()` anropar `.getId()` utan null-kontroll — NPE i fallback-scenariot.
+
+Befintlig `expandChain()` (rad 224–240):
+```java
+  private void expandChain(List<IndexedAIP> ancestors, int index, String targetId) {
+    if (index >= ancestors.size()) {
+      selectNode(targetId);
+      return;
+    }
+    CatalogTreeNode node = findNode(ancestors.get(index).getId(), rootNodes);
+    if (node == null) {
+      selectNode(targetId);
+      return;
+    }
+    node.expand(new com.google.gwt.user.client.Command() {
+      @Override
+      public void execute() {
+        expandChain(ancestors, index + 1, targetId);
+      }
+    });
+  }
+```
+
+Ersätt med:
+```java
+  private void expandChain(List<IndexedAIP> ancestors, int index, String targetId) {
+    if (index >= ancestors.size()) {
+      selectNode(targetId);
+      return;
+    }
+    IndexedAIP ancestor = ancestors.get(index);
+    if (ancestor == null) {
+      // Ghost-förfader: redan utfälld, fortsätt till nästa
+      expandChain(ancestors, index + 1, targetId);
+      return;
+    }
+    CatalogTreeNode node = findNode(ancestor.getId(), rootNodes);
+    if (node == null) {
+      selectNode(targetId);
+      return;
+    }
+    node.expand(new com.google.gwt.user.client.Command() {
+      @Override
+      public void execute() {
+        expandChain(ancestors, index + 1, targetId);
+      }
+    });
+  }
+```
+
+- [ ] **Steg 6: Uppdatera `applyFilter()` för ghost-noder**
+
+Befintlig `applyFilter()` (rad 143–151):
+```java
+  private boolean applyFilter(CatalogTreeNode node, String query) {
+    boolean selfMatches = query.isEmpty() || (node.getTitle() != null && node.getTitle().toLowerCase().contains(query));
+    boolean childMatches = false;
+    for (CatalogTreeNode child : node.getChildNodes().values()) {
+      if (applyFilter(child, query)) childMatches = true;
+    }
+    node.setVisible(selfMatches || childMatches);
+    return selfMatches || childMatches;
+  }
+```
+
+Ersätt med:
+```java
+  private boolean applyFilter(CatalogTreeNode node, String query) {
+    boolean childMatches = false;
+    for (CatalogTreeNode child : node.getChildNodes().values()) {
+      if (applyFilter(child, query)) childMatches = true;
+    }
+    if (node.isGhostNode()) {
+      node.setVisible(query.isEmpty() || childMatches);
+      return query.isEmpty() || childMatches;
+    }
+    boolean selfMatches = query.isEmpty() || (node.getTitle() != null && node.getTitle().toLowerCase().contains(query));
+    node.setVisible(selfMatches || childMatches);
+    return selfMatches || childMatches;
+  }
+```
+
+- [ ] **Steg 7: Verifiera att koden kompilerar**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests -q 2>&1 | tail -20"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Steg 8: Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java && git commit -m 'feat: fallback ghost-träd i katalogträdet för användare utan rot-behörighet (#480, #481)'"
+```
+
+---
+
+## Task 5: GWT-kompilering och manuell testning
+
+**Files:** (inga ändringar)
+
+- [ ] **Steg 1: GWT-kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn -pl roda-ui/roda-wui -am gwt:compile -Pdebug-main -Dscope.gwt-dev=compile -q 2>&1 | tail -20"
+```
+
+Förväntat: `BUILD SUCCESS` (tar 20–30 min)
+
+- [ ] **Steg 2: Kopiera GWT RPC-filer**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && ./roda-ui/roda-wui/copy_gwt_rpc.sh"
+```
+
+- [ ] **Steg 3: Starta om Spring Boot**
+
+```bash
+wsl -d Ubuntu -- bash -c "fuser -k 8080/tcp 5005/tcp 2>/dev/null; sleep 1; cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && tmux new-session -d -s eterna-test-ghost 'PATH=\"$HOME/.local/bin:$PATH\" SIEGFRIED_MODE=server SIEGFRIED_SERVER_URL=http://localhost:5138 mvn -pl roda-ui/roda-wui -am spring-boot:run -Pdebug-main 2>&1 | tee /tmp/eterna-ghost-test.log'"
+```
+
+- [ ] **Steg 4: Vänta tills Spring Boot är uppe**
+
+Kontrollera loggen:
+```bash
+wsl -d Ubuntu -- bash -c "tail -5 /tmp/eterna-ghost-test.log"
+```
+
+Förväntat: raden `Started RODA in X seconds` syns.
+
+- [ ] **Steg 5: Manuell testning — Testscenario 1 (admin)**
+
+1. Logga in som admin-användare på http://localhost:8080
+2. Navigera till Katalog
+3. Verifiera: Katalogträdet visar root-noder som vanligt (normalflödet är oförändrat)
+
+- [ ] **Steg 6: Manuell testning — Testscenario 2 (begränsad användare)**
+
+1. Logga in som en användare som bara har behörighet till ett AIP längre ner i strukturen (INTE till rotnoden)
+2. Navigera till Katalog
+3. Verifiera:
+   - Trädet är INTE tomt
+   - Förfäder utan behörighet visas som grå kursiva noder med texten "Åtkomst saknas"
+   - Ghost-noder är utfällda och kan inte fällas in
+   - Noden som användaren har behörighet till visas som normal klickbar nod
+   - Klick på ghost-nod händer ingenting (ingen navigering)
+
+- [ ] **Steg 7: Manuell testning — Testscenario 3 (sökfilter)**
+
+1. Logga in som den begränsade användaren
+2. Skriv in en söksträng i trädets filterruta
+3. Verifiera:
+   - Ghost-noder döljs om inga av deras barn matchar filtret
+   - Ghost-noder visas om ett eller flera barn matchar filtret
+   - Ghost-noder visas inte om filtret matchar deras text ("åtkomst") — de ska inte vara sökbara på sin labeltext
+
+---
+
+## Task 6: Slutcommit och städning
+
+**Files:** (inga ändringar)
+
+- [ ] **Steg 1: Kontrollera git-status**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git log --oneline feat/480-katalogträd-ghost-noder ^eterna-v1-alpha-2026-05-20 2>/dev/null | head -10"
+```
+
+Förväntat: 4 commits syns (i18n, CSS, CatalogTreeNode, CatalogTreePanel)
+
+- [ ] **Steg 2: Kontrollera att inga oavsiktliga filer är ändrade**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git status --short"
+```
+
+Förväntat: tom output (inga ostageade ändringar)

--- a/docs/superpowers/plans/2026-05-21-findbyuuid-granskningslogg.md
+++ b/docs/superpowers/plans/2026-05-21-findbyuuid-granskningslogg.md
@@ -1,0 +1,604 @@
+# findByUuid Granskningslogg — Implementationsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrappa `findByUuid()` i alla 17 REST-controllers med `requestHandler.processRequest()` så att varje AIP-åtkomst (och motsvarande för övriga entitetstyper) skapar en post i granskningsloggen.
+
+**Architecture:** `requestHandler.processRequest()` är det etablerade mönstret i kodbasen — det sätter `requestContext`, anropar `registerAction()` i ett finally-block och sätter `state` baserat på eventuella undantag. Innehållsentiteter (AIP, Representation, File, DIP, DIPFile, PreservationEvent) får dessutom `checkObjectPermissions`. Systementiteter (Job, Risk, AuditLog m.fl.) får bara rollkontrollen från `processRequest`.
+
+**Tech Stack:** Java 17, Spring Boot 3.4, GWT (klientsida för i18n), Maven
+
+---
+
+### Task 1: i18n-nyckel + BrowseAIP
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java`
+- Modify: `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties`
+- Modify: `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java`
+
+- [ ] **Lägg till i18n-metod i ClientMessages.java**
+
+Lägg till efter de befintliga `catalogTree*`-metoderna (kring rad 2730):
+
+```java
+String browseAIPReasonViewAIP();
+```
+
+- [ ] **Lägg till engelsk nyckel i ClientMessages.properties**
+
+Lägg till efter `catalogTreeGhostNodeLabel`:
+
+```
+browseAIPReasonViewAIP: View AIP
+```
+
+- [ ] **Lägg till svensk nyckel i ClientMessages_sv_SE.properties**
+
+Lägg till efter `catalogTreeGhostNodeLabel`:
+
+```
+browseAIPReasonViewAIP: Visa AIP
+```
+
+- [ ] **Ersätt hårdkodad sträng i BrowseAIP.java**
+
+I `BrowseAIP.refresh()` — byt ut:
+
+```java
+Services service = new Services("Retrieve AIP", "get");
+```
+
+mot:
+
+```java
+Services service = new Services(messages.browseAIPReasonViewAIP(), "get");
+```
+
+Klassen använder redan `messages` — kontrollera att `private static final ClientMessages messages = GWT.create(ClientMessages.class);` finns i klasshuvudet.
+
+- [ ] **Kompilera och verifiera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java && git commit -m 'feat: i18n-nyckel browseAIPReasonViewAIP och loggningsorsak i BrowseAIP'"
+```
+
+---
+
+### Task 2: AIPController.findByUuid
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java:119-135`
+
+- [ ] **Ersätt findByUuid i AIPController.java**
+
+Nuvarande kod:
+```java
+@Override
+public IndexedAIP findByUuid(String uuid, String localeString) {
+  IndexedAIP retrieve = indexService.retrieve(IndexedAIP.class, uuid, new ArrayList<>());
+
+  RodaConstants.DistributedModeType distributedModeType = RodaCoreFactory.getDistributedModeType();
+
+  if (RODAInstanceUtils.isConfiguredAsDistributedMode()
+    && RodaConstants.DistributedModeType.CENTRAL.equals(distributedModeType)) {
+    boolean isLocalInstance = retrieve.getInstanceId().equals(RODAInstanceUtils.getLocalInstanceIdentifier());
+    aipService.retrieveDistributedInstanceName(retrieve.getInstanceId(), isLocalInstance)
+      .ifPresent(retrieve::setInstanceName);
+    retrieve.setLocalInstance(isLocalInstance);
+  }
+
+  return retrieve;
+}
+```
+
+Ersätt med:
+```java
+@Override
+public IndexedAIP findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedAIP>() {
+    @Override
+    public IndexedAIP process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      IndexedAIP retrieve = requestContext.getIndexService().retrieve(IndexedAIP.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), retrieve);
+
+      RodaConstants.DistributedModeType distributedModeType = RodaCoreFactory.getDistributedModeType();
+      if (RODAInstanceUtils.isConfiguredAsDistributedMode()
+        && RodaConstants.DistributedModeType.CENTRAL.equals(distributedModeType)) {
+        boolean isLocalInstance = retrieve.getInstanceId()
+          .equals(RODAInstanceUtils.getLocalInstanceIdentifier());
+        aipService.retrieveDistributedInstanceName(retrieve.getInstanceId(), isLocalInstance)
+          .ifPresent(retrieve::setInstanceName);
+        retrieve.setLocalInstance(isLocalInstance);
+      }
+
+      return retrieve;
+    }
+  });
+}
+```
+
+`RODAException`, `RESTException`, `RequestContext` och `RequestControllerAssistant` är redan importerade i AIPController (används av `getAncestors`).
+
+- [ ] **Kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java && git commit -m 'feat: granskningslogg för AIPController.findByUuid'"
+```
+
+---
+
+### Task 3: Innehållscontrollers med checkObjectPermissions
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java:79`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java:201`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java:73`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java:48`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java:77`
+
+- [ ] **Ersätt RepresentationController.findByUuid**
+
+```java
+@Override
+public IndexedRepresentation findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedRepresentation>() {
+    @Override
+    public IndexedRepresentation process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      IndexedRepresentation obj = requestContext.getIndexService()
+        .retrieve(IndexedRepresentation.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+      return obj;
+    }
+  });
+}
+```
+
+- [ ] **Ersätt FilesController.findByUuid**
+
+```java
+@Override
+public IndexedFile findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedFile>() {
+    @Override
+    public IndexedFile process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      IndexedFile obj = requestContext.getIndexService()
+        .retrieve(IndexedFile.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+      return obj;
+    }
+  });
+}
+```
+
+- [ ] **Ersätt DIPController.findByUuid**
+
+```java
+@Override
+public IndexedDIP findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedDIP>() {
+    @Override
+    public IndexedDIP process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      IndexedDIP obj = requestContext.getIndexService()
+        .retrieve(IndexedDIP.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+      return obj;
+    }
+  });
+}
+```
+
+- [ ] **Ersätt DIPFileController.findByUuid**
+
+```java
+@Override
+public DIPFile findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<DIPFile>() {
+    @Override
+    public DIPFile process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      DIPFile obj = requestContext.getIndexService()
+        .retrieve(DIPFile.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+      return obj;
+    }
+  });
+}
+```
+
+- [ ] **Ersätt PreservationEventController.findByUuid**
+
+```java
+@Override
+public IndexedPreservationEvent findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedPreservationEvent>() {
+    @Override
+    public IndexedPreservationEvent process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      IndexedPreservationEvent obj = requestContext.getIndexService()
+        .retrieve(IndexedPreservationEvent.class, uuid, new ArrayList<>());
+      controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+      return obj;
+    }
+  });
+}
+```
+
+Om kompilatorn klagar på saknade importer, lägg till (se AIPController för referens):
+```java
+import org.roda.core.common.exceptions.RODAException;
+import org.roda.wui.api.v2.exceptions.RESTException;
+import org.roda.wui.common.model.RequestContext;
+import org.roda.wui.common.RequestControllerAssistant;
+```
+
+- [ ] **Kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java && git commit -m 'feat: granskningslogg för findByUuid i innehållscontrollers'"
+```
+
+---
+
+### Task 4: Enkla systemcontrollers
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java:358`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java:48`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java:859`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java:95`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java:245`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java:75`
+
+- [ ] **Ersätt JobsController.findByUuid**
+
+```java
+@Override
+public IndexedJob findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedJob>() {
+    @Override
+    public IndexedJob process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(IndexedJob.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Ersätt JobReportController.findByUuid**
+
+```java
+@Override
+public IndexedReport findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedReport>() {
+    @Override
+    public IndexedReport process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(IndexedReport.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Ersätt MembersController.findByUuid**
+
+```java
+@Override
+public RodaPrincipal findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<RodaPrincipal>() {
+    @Override
+    public RodaPrincipal process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(RodaPrincipal.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Ersätt NotificationController.findByUuid**
+
+```java
+@Override
+public Notification findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<Notification>() {
+    @Override
+    public Notification process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(Notification.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Ersätt TransferredResourceController.findByUuid**
+
+```java
+@Override
+public TransferredResource findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<TransferredResource>() {
+    @Override
+    public TransferredResource process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(TransferredResource.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Ersätt DisposalConfirmationController.findByUuid**
+
+```java
+@Override
+public DisposalConfirmation findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<DisposalConfirmation>() {
+    @Override
+    public DisposalConfirmation process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      return requestContext.getIndexService().retrieve(DisposalConfirmation.class, uuid, new ArrayList<>());
+    }
+  });
+}
+```
+
+- [ ] **Kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java && git commit -m 'feat: granskningslogg för findByUuid i enkla systemcontrollers'"
+```
+
+---
+
+### Task 5: Systemcontrollers med fieldsToReturn
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java:70`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java:70`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java:63`
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java:71`
+
+- [ ] **Ersätt AuditLogController.findByUuid**
+
+```java
+@Override
+public LogEntry findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<LogEntry>() {
+    @Override
+    public LogEntry process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      final List<String> fieldsToReturn = Arrays.asList(RodaConstants.INDEX_UUID, RodaConstants.LOG_ID,
+        RodaConstants.LOG_ACTION_COMPONENT, RodaConstants.LOG_ACTION_METHOD, RodaConstants.LOG_ADDRESS,
+        RodaConstants.LOG_DATETIME, RodaConstants.LOG_RELATED_OBJECT_ID, RodaConstants.LOG_USERNAME,
+        RodaConstants.LOG_PARAMETERS, RodaConstants.LOG_STATE, RodaConstants.LOG_REQUEST_HEADER_UUID,
+        RodaConstants.LOG_REQUEST_HEADER_REASON, RodaConstants.LOG_REQUEST_HEADER_TYPE);
+      return requestContext.getIndexService().retrieve(LogEntry.class, uuid, fieldsToReturn);
+    }
+  });
+}
+```
+
+- [ ] **Ersätt RiskController.findByUuid**
+
+```java
+@Override
+public IndexedRisk findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedRisk>() {
+    @Override
+    public IndexedRisk process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      final List<String> fieldsToReturn = Arrays.asList(RodaConstants.INDEX_UUID, RodaConstants.RISK_ID,
+        RodaConstants.RISK_NAME, RodaConstants.RISK_DESCRIPTION, RodaConstants.RISK_IDENTIFIED_ON,
+        RodaConstants.RISK_IDENTIFIED_BY, RodaConstants.RISK_CATEGORIES, RodaConstants.RISK_NOTES,
+        RodaConstants.RISK_PRE_MITIGATION_PROBABILITY, RodaConstants.RISK_PRE_MITIGATION_IMPACT,
+        RodaConstants.RISK_PRE_MITIGATION_SEVERITY, RodaConstants.RISK_POST_MITIGATION_PROBABILITY,
+        RodaConstants.RISK_POST_MITIGATION_IMPACT, RodaConstants.RISK_POST_MITIGATION_SEVERITY,
+        RodaConstants.RISK_PRE_MITIGATION_NOTES, RodaConstants.RISK_POST_MITIGATION_NOTES,
+        RodaConstants.RISK_MITIGATION_STRATEGY, RodaConstants.RISK_MITIGATION_OWNER,
+        RodaConstants.RISK_MITIGATION_OWNER_TYPE,
+        RodaConstants.RISK_MITIGATION_RELATED_EVENT_IDENTIFIER_TYPE,
+        RodaConstants.RISK_MITIGATION_RELATED_EVENT_IDENTIFIER_VALUE);
+      return requestContext.getIndexService().retrieve(IndexedRisk.class, uuid, fieldsToReturn);
+    }
+  });
+}
+```
+
+- [ ] **Ersätt RiskIncidenceController.findByUuid**
+
+```java
+@Override
+public RiskIncidence findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<RiskIncidence>() {
+    @Override
+    public RiskIncidence process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      final List<String> fieldsToReturn = Arrays.asList(RodaConstants.INDEX_UUID,
+        RodaConstants.RISK_INCIDENCE_ID, RodaConstants.RISK_INCIDENCE_RISK_ID,
+        RodaConstants.RISK_INCIDENCE_DESCRIPTION, RodaConstants.RISK_INCIDENCE_STATUS,
+        RodaConstants.RISK_INCIDENCE_SEVERITY, RodaConstants.RISK_INCIDENCE_DETECTED_BY,
+        RodaConstants.RISK_INCIDENCE_DETECTED_ON, RodaConstants.RISK_INCIDENCE_MITIGATED_ON,
+        RodaConstants.RISK_INCIDENCE_MITIGATED_BY, RodaConstants.RISK_INCIDENCE_MITIGATED_DESCRIPTION);
+      return requestContext.getIndexService().retrieve(RiskIncidence.class, uuid, fieldsToReturn);
+    }
+  });
+}
+```
+
+- [ ] **Ersätt PreservationAgentController.findByUuid**
+
+```java
+@Override
+public IndexedPreservationAgent findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<IndexedPreservationAgent>() {
+    @Override
+    public IndexedPreservationAgent process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      final List<String> fieldsToReturn = Arrays.asList(RodaConstants.INDEX_UUID,
+        RodaConstants.PRESERVATION_AGENT_ID, RodaConstants.PRESERVATION_AGENT_NAME,
+        RodaConstants.PRESERVATION_AGENT_TYPE, RodaConstants.PRESERVATION_AGENT_VERSION,
+        RodaConstants.PRESERVATION_AGENT_NOTE, RodaConstants.PRESERVATION_AGENT_EXTENSION);
+      return requestContext.getIndexService().retrieve(IndexedPreservationAgent.class, uuid, fieldsToReturn);
+    }
+  });
+}
+```
+
+- [ ] **Kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java && git commit -m 'feat: granskningslogg för findByUuid i fieldsToReturn-controllers'"
+```
+
+---
+
+### Task 6: RepresentationInformationController
+
+**Files:**
+- Modify: `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java:88`
+
+- [ ] **Ersätt RepresentationInformationController.findByUuid**
+
+```java
+@Override
+public RepresentationInformation findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(new RequestHandler.RequestProcessor<RepresentationInformation>() {
+    @Override
+    public RepresentationInformation process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant)
+        throws RODAException, RESTException {
+      controllerAssistant.setRelatedObjectId(uuid);
+      RepresentationInformation retrieve = requestContext.getIndexService()
+        .retrieve(RepresentationInformation.class, uuid, new ArrayList<>(), true);
+
+      retrieve.setFamilyI18n(
+        translationService.getTranslation(localeString,
+          "ri.family." + retrieve.getFamily(), retrieve.getFamily()));
+
+      representationInformationService.setIndexService(requestContext.getIndexService());
+
+      return representationInformationService
+        .enrichRepresentationInformationRelations(retrieve, localeString, requestContext);
+    }
+  });
+}
+```
+
+`translationService` och `representationInformationService` är @Autowired-fält i klassen och nås direkt från lambdan.
+
+- [ ] **Kompilera**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -5"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git add roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java && git commit -m 'feat: granskningslogg för RepresentationInformationController.findByUuid'"
+```
+
+---
+
+### Task 7: Slutverifiering
+
+- [ ] **Full Maven-kompilering**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && mvn install -pl roda-ui/roda-wui -am -DskipTests --no-transfer-progress 2>&1 | tail -10"
+```
+
+Förväntat: `BUILD SUCCESS`
+
+- [ ] **Verifiera att alla 17 controllers är wrappade**
+
+```bash
+wsl -d Ubuntu -- bash -c "grep -rn 'public.*findByUuid' /home/annajansson/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ --include='*.java' -A2 | grep -c 'processRequest'"
+```
+
+Förväntat: `17`
+
+- [ ] **Verifiera git log**
+
+```bash
+wsl -d Ubuntu -- bash -c "cd ~/ETERNA/.worktrees/eterna-v1-alpha-2026-05-20 && git log --oneline -10"
+```
+
+Förväntat: 6 commits från denna feature ovanpå de befintliga ghost-nod-commits.

--- a/docs/superpowers/specs/2026-05-20-katalogträd-ghost-noder-design.md
+++ b/docs/superpowers/specs/2026-05-20-katalogträd-ghost-noder-design.md
@@ -1,0 +1,108 @@
+# Design: Ghost-noder i katalogträdet för användare med begränsad behörighet
+
+**Datum:** 2026-05-20
+**Issues:** [#480](https://github.com/ETERNA-earkiv/ETERNA/issues/480), [#481](https://github.com/ETERNA-earkiv/ETERNA/issues/481)
+**Branch:** skapas från `eterna-v1-alpha`
+
+---
+
+## Problembeskrivning
+
+En användare som enbart har behörighet till ett objekt längre ner i katalogstrukturen ser ett tomt katalogträd. Objektet syns i sökvyn men inte i trädet. Orsaken är att `CatalogTreePanel.loadRootNodes()` filtrerar på `EmptyKeyFilterParameter(AIP_PARENT_ID)` — rotnoder utan förälder — och backend filtrerar bort de rotnoder användaren saknar behörighet till. Resultatet blir en tom lista.
+
+Breadcrumb-menyn hanterar redan detta korrekt: förfäder utan behörighet renderas som "spöknoder" (null-värden i ancestor-listan). Trädet saknar motsvarande logik.
+
+---
+
+## Lösning: Fallback-flöde med ghost-noder (Alternativ A)
+
+### Övergripande arkitektur
+
+Tre komponenter berörs:
+
+| Komponent | Förändring |
+|---|---|
+| `CatalogTreePanel` | Nytt fallback-flöde i `loadRootNodes()` |
+| `CatalogTreeNode` | Nytt ghost-tillstånd: grå, ej klickbar, alltid utfälld |
+| Backend (`AIPController`, `retrieveAncestors`) | Ingen förändring — returnerar redan `null` för noder utan behörighet |
+
+---
+
+### Dataflöde
+
+```
+loadRootNodes()
+  └─ Sökning: EmptyKeyFilterParameter(AIP_PARENT_ID)
+       ├─ Resultat > 0  →  normalt träd (oförändrat beteende)
+       └─ Resultat = 0  →  FALLBACK:
+            Sökning utan parent-filter, max 200 träffar, sorterat på titel
+            För varje träff:
+              getAncestors(aipId) → List<IndexedAIP>  (null = ej behörighet)
+
+            Bygg träd med merge-logik (uppifrån och ned):
+              - Nod redan i trädet → återanvänd (delade förfäder slås ihop)
+              - null-ancestor       → ghost-nod ("Åtkomst saknas")
+              - Leaf-nod (AIP med behörighet) → normal nod
+
+            Ghost-noder renderas:
+              - Text: "Åtkomst saknas" (grå/uttonad)
+              - Utfälld från start, toggle inaktiverad
+              - Ej klickbar
+```
+
+---
+
+### Ghost-nodernas utseende
+
+- Text: `"Åtkomst saknas"` (hämtas från `ClientMessages`)
+- Visuell stil: grå/uttonad, skiljer sig tydligt från vanliga noder
+- Toggle-knapp: inaktiverad eller borttagen (noden kan inte fällas in)
+- Klick: ingen action — noden är inte navigerbar
+- Utfälld från start: underliggande behöriga noder alltid synliga
+
+Konsekvent med befintlig ghost-node-logik i `BreadcrumbUtils` (rad 123–132).
+
+---
+
+### Merge-logik för delade förfäder
+
+Om två AIPs delar en gemensam förfader (med eller utan behörighet) ska förfadern visas en gång med båda barnen under sig. Implementeras via en `Map<String, CatalogTreeNode>` indexerad på AIP-ID som byggs upp under fallback-flödet.
+
+---
+
+### Felhantering
+
+| Scenario | Hantering |
+|---|---|
+| Fallback-sökning returnerar 0 resultat | Tom vy — samma beteende som idag |
+| `getAncestors()` misslyckas för enskilt AIP | Hoppa över det AIP:t, logga, fortsätt med övriga |
+| Fler än 200 behöriga AIPs | Visa de 200 första (sorterade på titel); ingen UI-notis i detta skede |
+| Cykliska ancestors | Kan inte uppstå (träd-invariant garanteras av backend) |
+
+---
+
+### Prestanda
+
+Fallback-flödet aktiveras **enbart** om root-sökningen returnerar 0 resultat — alltså bara för användare med starkt begränsad behörighet. Normalflödet (admin och användare med breda behörigheter) påverkas inte.
+
+---
+
+### Berörda filer
+
+| Fil | Förändring |
+|---|---|
+| `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java` | Fallback-flöde i `loadRootNodes()`, merge-logik |
+| `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java` | Ghost-tillstånd: konstruktor/factory-metod, rendering, inaktiverad toggle |
+| `roda-ui/roda-wui/src/main/resources/config/i18n/ClientMessages.properties` | Ny nyckel: `catalogTree.ghostNode.label = Access denied` |
+| `roda-ui/roda-wui/src/main/resources/config/i18n/ClientMessages_sv_SE.properties` | Ny nyckel: `catalogTree.ghostNode.label = Åtkomst saknas` |
+| `roda-ui/roda-wui/src/main/webapp/WEB-INF/static/css/main.gss` | Ny CSS-klass `.catalogTreeGhostNode`: grå text, reducerad opacity, cursor default |
+
+---
+
+### Acceptanskriterier (#481)
+
+- [x] Objekt med behörighet visas i trädet även om toppnoden saknar behörighet
+- [x] Förfäder utan behörighet renderas som ghost-noder ("Åtkomst saknas")
+- [x] Ghost-noder är inte klickbara
+- [x] Ghost-noder är utfällda från start och kan inte fällas in
+- [x] Beteendet är konsekvent med befintlig ghost-logik i breadcrumb-menyn

--- a/docs/superpowers/specs/2026-05-21-findbyuuid-granskningslogg-design.md
+++ b/docs/superpowers/specs/2026-05-21-findbyuuid-granskningslogg-design.md
@@ -1,0 +1,156 @@
+# Design: Granskningslogg för findByUuid i alla REST-controllers
+
+**Datum:** 2026-05-21
+**Kontext:** Del av feature/katalogträd-ghost-noder — säkerställer att AIP-åtkomst via katalogträdet loggas
+**Branch:** `feat/480-katalogträd-ghost-noder`
+
+---
+
+## Problembeskrivning
+
+`findByUuid()` i alla 17 REST-controllers är idag implementerade som direkta `indexService.retrieve()`-anrop utan `requestHandler.processRequest()`-omslutning. Det innebär att ingen `LogEntry` skapas när en användare hämtar ett enskilt objekt via UUID. Övriga läs-operationer (t.ex. `getAncestors()` i `AIPController`) är korrekt omslutna och loggar till granskningsloggen.
+
+Det primära behovet: när en användare klickar på en nod i katalogträdet triggas `BrowseAIP.getAndRefresh()` → `AIPController.findByUuid()`. Det anropet ska loggas. Eftersom `findByUuid` saknar loggning konsekvent i hela kodbasen åtgärdas detta för alla 17 controllers.
+
+---
+
+## Lösning
+
+### Övergripande
+
+Två lager ändras:
+
+| Lager | Förändring |
+|---|---|
+| 17 REST-controllers | `findByUuid()` wrappas i `requestHandler.processRequest()` |
+| `BrowseAIP.java` | `getAndRefresh()` skapar `Services` med orsakssträng |
+| `ClientMessages.java` + `.properties`-filer | Ny nyckel: `browseAIPReasonViewAIP` |
+
+---
+
+### Mönster för controllers
+
+**Typ A — innehållsentiteter med objektbehörighet** (AIP, Representation, File, DIP, DIPFile, PreservationEvent):
+
+```java
+@Override
+public <EntityType> findByUuid(String uuid, String localeString) {
+  return requestHandler.processRequest(
+    new RequestHandler.RequestProcessor<EntityType>() {
+      @Override
+      public EntityType process(RequestContext requestContext,
+          RequestControllerAssistant controllerAssistant)
+          throws RODAException, RESTException {
+        controllerAssistant.setRelatedObjectId(uuid);
+        EntityType obj = requestContext.getIndexService()
+          .retrieve(EntityType.class, uuid, new ArrayList<>());
+        controllerAssistant.checkObjectPermissions(requestContext.getUser(), obj);
+        return obj;
+      }
+    });
+}
+```
+
+`AIPController.findByUuid()` bevarar befintlig distributed mode-logik inuti `processRequest`.
+
+**Typ B — systementiteter utan per-objekt-behörighet** (AuditLog, Job, JobReport, Risk, RiskIncidence, RepresentationInformation, Members, Notification, PreservationAgent, TransferredResource, DisposalConfirmation):
+
+Samma mönster som Typ A men utan `checkObjectPermissions`. Rollen kontrolleras av `processRequest` via `checkRoles()`. Bestäms per controller baserat på om befintliga metoder i samma klass använder `checkObjectPermissions` eller inte — om de gör det, lägg till det; annars utelämna.
+
+---
+
+### BrowseAIP — orsakssträng
+
+`BrowseAIP.refresh()` (privat metod) skapar idag `new Services("Retrieve AIP", "get")` med en hårdkodad engelska sträng. Ersätts med i18n-nyckeln:
+
+```java
+// Före
+Services service = new Services("Retrieve AIP", "get");
+
+// Efter
+Services service = new Services(messages.browseAIPReasonViewAIP(), "get");
+```
+
+`Services`-instansen återanvänds för alla efterföljande anrop i `refresh()` (`getAncestors`, `retrieveAIPRuleProperties` etc.) — detta är befintligt beteende och ändras inte.
+
+---
+
+### i18n
+
+Ny nyckel i tre filer:
+
+| Fil | Nyckel | Värde |
+|---|---|---|
+| `ClientMessages.java` | `String browseAIPReasonViewAIP()` | — |
+| `ClientMessages.properties` | `browseAIPReasonViewAIP` | `View AIP` |
+| `ClientMessages_sv_SE.properties` | `browseAIPReasonViewAIP` | `Visa AIP` |
+
+---
+
+### Resultat i granskningsloggen
+
+Varje `findByUuid`-anrop skapar en `LogEntry` med:
+
+| Fält | Värde |
+|---|---|
+| `actionComponent` | Controllerns fullt kvalificerade klassnamn |
+| `actionMethod` | `findByUuid` |
+| `relatedObjectId` | Objektets UUID |
+| `state` | `SUCCESS` / `UNAUTHORIZED` / `FAILURE` |
+| `auditLogRequestHeaders.reason` | T.ex. `"Visa AIP"` (från BrowseAIP) |
+| `username` | Inloggad användare |
+| `datetime` | Tidsstämpel |
+
+---
+
+### Felhantering
+
+| Scenario | Hantering |
+|---|---|
+| `NotFoundException` | `state = FAILURE`, undantag propageras (HTTP 404) |
+| `AuthorizationDeniedException` | `state = UNAUTHORIZED`, undantag propageras (HTTP 403) |
+| Övriga undantag | `state = FAILURE`, undantag propageras |
+
+`processRequest` hanterar state-sättning automatiskt i sin finally-block.
+
+---
+
+### Berörda filer
+
+**Controllers (17 st):**
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AIPController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java`
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java`
+
+**Client:**
+- `roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java`
+
+**i18n:**
+- `roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java`
+- `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties`
+- `roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties`
+
+---
+
+### Acceptanskriterier
+
+- [ ] Klick på nod i katalogträdet skapar en `LogEntry` med `actionMethod = findByUuid` och korrekt `relatedObjectId`
+- [ ] `state = UNAUTHORIZED` loggas om användaren saknar behörighet till objektet
+- [ ] `state = FAILURE` loggas om objektet inte finns
+- [ ] `auditLogRequestHeaders.reason = "Visa AIP"` för katalogträd-navigering
+- [ ] Samtliga 17 controllers wrappar `findByUuid` konsekvent
+- [ ] Befintliga tester passerar

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2728,4 +2728,6 @@ public interface ClientMessages extends Messages {
   String catalogTreeReasonRetrieveAIP();
 
   String catalogTreeGhostNodeLabel();
+
+  String browseAIPReasonViewAIP();
 }

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2726,4 +2726,6 @@ public interface ClientMessages extends Messages {
   String catalogTreeReasonGetAncestors();
 
   String catalogTreeReasonRetrieveAIP();
+
+  String catalogTreeGhostNodeLabel();
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
@@ -289,7 +289,7 @@ public class BrowseAIP extends Composite {
 
   private static void refresh(String id, AsyncCallback<IndexedAIP> callback) {
 
-    Services service = new Services("Retrieve AIP", "get");
+    Services service = new Services(messages.browseAIPReasonViewAIP(), "get");
     service
       .rodaEntityRestService(s -> s.findByUuid(id, LocaleInfo.getCurrentLocale().getLocaleName()), IndexedAIP.class)
       .whenComplete((aip, error) -> {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -143,6 +143,7 @@ public class CatalogTreeNode extends Composite {
       rowPanel.add(indent);
     }
 
+    // Ghost-noder är alltid utfällda och icke-interaktiva — toggle lämnas tom avsiktligt.
     toggleHtml = new HTML("");
     toggleHtml.setStyleName("catalogTreeToggle");
     rowPanel.add(toggleHtml);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -64,8 +64,11 @@ public class CatalogTreeNode extends Composite {
   private boolean loaded = false;
   private boolean isLeaf = false;
   private Command pendingOnComplete = null;
+  private final boolean ghost;
+  private static int ghostCounter = 0;
 
   public CatalogTreeNode(String aipId, String title, String level, int depth) {
+    this.ghost = false;
     this.aipId = aipId;
     this.title = title;
     this.depth = depth;
@@ -118,8 +121,55 @@ public class CatalogTreeNode extends Composite {
     initWidget(rootPanel);
   }
 
+  /** Skapar en ghost-nod som representerar ett AIP utan behörighet. */
+  public static CatalogTreeNode createGhostNode(int depth) {
+    return new CatalogTreeNode(depth);
+  }
+
+  private CatalogTreeNode(int depth) {
+    this.ghost = true;
+    this.aipId = "__ghost__" + (ghostCounter++);
+    this.title = messages.catalogTreeGhostNodeLabel();
+    this.depth = depth;
+
+    rootPanel = new FlowPanel();
+
+    rowPanel = new FlowPanel();
+    rowPanel.setStyleName("catalogTreeNode ghost");
+
+    for (int i = 0; i < depth; i++) {
+      FlowPanel indent = new FlowPanel();
+      indent.setStyleName("catalogTreeIndent");
+      rowPanel.add(indent);
+    }
+
+    toggleHtml = new HTML("");
+    toggleHtml.setStyleName("catalogTreeToggle");
+    rowPanel.add(toggleHtml);
+
+    iconHtml = new HTML(DescriptionLevelUtils.getElementLevelIconSafeHtml(RodaConstants.AIP_GHOST, false));
+    iconHtml.setStyleName("catalogTreeIcon");
+    rowPanel.add(iconHtml);
+
+    titleLabel = new Label(this.title);
+    titleLabel.setStyleName("catalogTreeLabel");
+    rowPanel.add(titleLabel);
+
+    childrenPanel = new FlowPanel();
+    childrenPanel.setStyleName("catalogTreeNodeChildren");
+    childrenPanel.setVisible(true);
+
+    rootPanel.add(rowPanel);
+    rootPanel.add(childrenPanel);
+
+    loaded = true;
+    expanded = true;
+
+    initWidget(rootPanel);
+  }
+
   public void toggle() {
-    if (isLeaf) return;
+    if (ghost || isLeaf) return;
     if (expanded) {
       collapse();
     } else {
@@ -128,6 +178,10 @@ public class CatalogTreeNode extends Composite {
   }
 
   public void expand(Command onComplete) {
+    if (ghost) {
+      if (onComplete != null) onComplete.execute();
+      return;
+    }
     if (isLeaf) {
       if (onComplete != null) onComplete.execute();
       return;
@@ -208,9 +262,32 @@ public class CatalogTreeNode extends Composite {
   }
 
   public void collapse() {
+    if (ghost) return;
     childrenPanel.setVisible(false);
     expanded = false;
     toggleHtml.setHTML(ICON_TOGGLE_COLLAPSED);
+  }
+
+  /**
+   * Lägger till ett förkonstruerat barn (används vid fallback ghost-träd).
+   * Sätter noden som laddad och utfälld.
+   */
+  public void addPrebuiltChild(CatalogTreeNode child) {
+    if (childNodes.containsKey(child.getAipId())) {
+      return;
+    }
+    childNodes.put(child.getAipId(), child);
+    childrenPanel.add(child);
+    if (!ghost) {
+      loaded = true;
+      expanded = true;
+      childrenPanel.setVisible(true);
+      toggleHtml.setHTML(ICON_TOGGLE_EXPANDED);
+    }
+  }
+
+  public boolean isGhostNode() {
+    return ghost;
   }
 
   public void select() {
@@ -253,6 +330,7 @@ public class CatalogTreeNode extends Composite {
   }
 
   public void invalidateChildren() {
+    if (ghost) return;
     loaded = false;
     expanded = false;
     isLeaf = false;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -84,6 +84,7 @@ public class CatalogTreePanel extends Composite {
   private CatalogTreeNode selectedNode = null;
   private boolean rootsLoaded = false;
   private boolean rootsLoading = false;
+  private int loadGeneration = 0;
   private String pendingRevealAipId = null;
 
   public CatalogTreePanel() {
@@ -157,6 +158,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void loadRootNodes() {
+    loadGeneration++;
     clearSelection();
     treeBody.clear();
     rootNodes.clear();
@@ -208,7 +210,10 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void loadFallbackGhostTree() {
+    final int myGeneration = loadGeneration;
     rootsLoading = true;
+    // 200-gräns: varje AIP genererar ett getAncestors()-anrop — begränsa för att hålla nere fan-out.
+    // Användare med fler än 200 tillgängliga AIPs ser de 200 första (sorterade på titel).
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
       false)
@@ -223,15 +228,20 @@ public class CatalogTreePanel extends Composite {
       .whenComplete((result, error) -> {
         if (error != null) {
           LOGGER.error("Fallback ghost tree query failed", error);
+          if (myGeneration != loadGeneration) return;
           rootsLoading = false;
           rootsLoaded = true;
           return;
         }
         List<IndexedAIP> aips = result.getResults();
         if (aips.isEmpty()) {
+          if (myGeneration != loadGeneration) return;
           rootsLoading = false;
           rootsLoaded = true;
           return;
+        }
+        if (aips.size() == 200) {
+          LOGGER.warn("Fallback ghost tree capped at 200 AIPs; some accessible objects may not be shown");
         }
 
         Map<String, CatalogTreeNode> nodeMap = new LinkedHashMap<>();
@@ -250,7 +260,7 @@ public class CatalogTreePanel extends Composite {
               }
               remaining[0]--;
               if (remaining[0] == 0) {
-                finalizeFallbackTree(roots);
+                finalizeFallbackTree(roots, myGeneration);
               }
             });
         }
@@ -296,7 +306,8 @@ public class CatalogTreePanel extends Composite {
     }
   }
 
-  private void finalizeFallbackTree(List<CatalogTreeNode> roots) {
+  private void finalizeFallbackTree(List<CatalogTreeNode> roots, int expectedGeneration) {
+    if (expectedGeneration != loadGeneration) return;
     for (CatalogTreeNode root : roots) {
       rootNodes.put(root.getAipId(), root);
       treeBody.add(root);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -7,8 +7,10 @@
  */
 package org.roda.wui.client.browse;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -141,11 +143,15 @@ public class CatalogTreePanel extends Composite {
   }
 
   private boolean applyFilter(CatalogTreeNode node, String query) {
-    boolean selfMatches = query.isEmpty() || (node.getTitle() != null && node.getTitle().toLowerCase().contains(query));
     boolean childMatches = false;
     for (CatalogTreeNode child : node.getChildNodes().values()) {
       if (applyFilter(child, query)) childMatches = true;
     }
+    if (node.isGhostNode()) {
+      node.setVisible(query.isEmpty() || childMatches);
+      return query.isEmpty() || childMatches;
+    }
+    boolean selfMatches = query.isEmpty() || (node.getTitle() != null && node.getTitle().toLowerCase().contains(query));
     node.setVisible(selfMatches || childMatches);
     return selfMatches || childMatches;
   }
@@ -183,6 +189,10 @@ public class CatalogTreePanel extends Composite {
           treeBody.add(errorPanel);
           return;
         }
+        if (result.getResults().isEmpty()) {
+          loadFallbackGhostTree();
+          return;
+        }
         for (IndexedAIP aip : result.getResults()) {
           CatalogTreeNode node = new CatalogTreeNode(aip.getId(), aip.getTitle(), aip.getLevel(), 0);
           rootNodes.put(aip.getId(), node);
@@ -195,6 +205,109 @@ public class CatalogTreePanel extends Composite {
           doRevealAip(id);
         }
       });
+  }
+
+  private void loadFallbackGhostTree() {
+    rootsLoading = true;
+    FindRequest findRequest = new FindRequest.FindRequestBuilder(
+      new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+      false)
+      .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
+      .withSublist(new Sublist(0, 200))
+      .build();
+
+    Services service = new Services(messages.catalogTreeReasonListRoots(), "get");
+    service.rodaEntityRestService(
+      s -> s.find(findRequest, LocaleInfo.getCurrentLocale().getLocaleName()),
+      IndexedAIP.class)
+      .whenComplete((result, error) -> {
+        if (error != null) {
+          LOGGER.error("Fallback ghost tree query failed", error);
+          rootsLoading = false;
+          rootsLoaded = true;
+          return;
+        }
+        List<IndexedAIP> aips = result.getResults();
+        if (aips.isEmpty()) {
+          rootsLoading = false;
+          rootsLoaded = true;
+          return;
+        }
+
+        Map<String, CatalogTreeNode> nodeMap = new LinkedHashMap<>();
+        List<CatalogTreeNode> roots = new ArrayList<>();
+        int[] remaining = {aips.size()};
+
+        for (IndexedAIP aip : aips) {
+          Services s2 = new Services(messages.catalogTreeReasonGetAncestors(), "get");
+          s2.aipResource(srv -> srv.getAncestors(aip.getId()))
+            .whenComplete((ancestors, err) -> {
+              if (err != null) {
+                LOGGER.warn("Could not get ancestors for fallback AIP " + aip.getId() + ", skipping");
+              } else {
+                Collections.reverse(ancestors);
+                insertFallbackChain(ancestors, aip, nodeMap, roots);
+              }
+              remaining[0]--;
+              if (remaining[0] == 0) {
+                finalizeFallbackTree(roots);
+              }
+            });
+        }
+      });
+  }
+
+  private void insertFallbackChain(List<IndexedAIP> ancestors, IndexedAIP targetAip,
+      Map<String, CatalogTreeNode> nodeMap, List<CatalogTreeNode> roots) {
+    CatalogTreeNode parent = null;
+
+    for (int i = 0; i < ancestors.size(); i++) {
+      IndexedAIP anc = ancestors.get(i);
+      CatalogTreeNode node;
+
+      if (anc == null) {
+        node = CatalogTreeNode.createGhostNode(i);
+      } else if (nodeMap.containsKey(anc.getId())) {
+        parent = nodeMap.get(anc.getId());
+        continue;
+      } else {
+        node = new CatalogTreeNode(anc.getId(), anc.getTitle(), anc.getLevel(), i);
+        nodeMap.put(anc.getId(), node);
+      }
+
+      if (parent == null) {
+        roots.add(node);
+      } else {
+        parent.addPrebuiltChild(node);
+      }
+      parent = node;
+    }
+
+    if (nodeMap.containsKey(targetAip.getId())) {
+      return;
+    }
+    CatalogTreeNode targetNode = new CatalogTreeNode(
+      targetAip.getId(), targetAip.getTitle(), targetAip.getLevel(), ancestors.size());
+    nodeMap.put(targetAip.getId(), targetNode);
+    if (parent == null) {
+      roots.add(targetNode);
+    } else {
+      parent.addPrebuiltChild(targetNode);
+    }
+  }
+
+  private void finalizeFallbackTree(List<CatalogTreeNode> roots) {
+    for (CatalogTreeNode root : roots) {
+      rootNodes.put(root.getAipId(), root);
+      treeBody.add(root);
+    }
+    rootsLoading = false;
+    rootsLoaded = true;
+    if (pendingRevealAipId != null) {
+      String id = pendingRevealAipId;
+      pendingRevealAipId = null;
+      doRevealAip(id);
+    }
   }
 
   public void revealAip(String aipId) {
@@ -226,7 +339,12 @@ public class CatalogTreePanel extends Composite {
       selectNode(targetId);
       return;
     }
-    CatalogTreeNode node = findNode(ancestors.get(index).getId(), rootNodes);
+    IndexedAIP ancestor = ancestors.get(index);
+    if (ancestor == null) {
+      expandChain(ancestors, index + 1, targetId);
+      return;
+    }
+    CatalogTreeNode node = findNode(ancestor.getId(), rootNodes);
     if (node == null) {
       selectNode(targetId);
       return;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3569,6 +3569,20 @@ body.catalogTreeResizing * {
     align-items: center;
 }
 
+.catalogTreeNode.ghost {
+    cursor: default;
+    color: #aaaaaa;
+    font-style: italic;
+}
+
+.catalogTreeNode.ghost:hover {
+    background: transparent;
+}
+
+.catalogTreeNode.ghost .catalogTreeIcon {
+    color: #cccccc;
+}
+
 .browseSidePanel .actionable-menu {
     display: flex;
     flex-direction: column;

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1881,3 +1881,4 @@ catalogTreeReasonListChildren: List AIP children
 catalogTreeReasonListRoots: List root AIPs
 catalogTreeReasonGetAncestors: Get AIP ancestors
 catalogTreeReasonRetrieveAIP: Retrieve AIP
+catalogTreeGhostNodeLabel: Access denied

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1882,3 +1882,4 @@ catalogTreeReasonListRoots: List root AIPs
 catalogTreeReasonGetAncestors: Get AIP ancestors
 catalogTreeReasonRetrieveAIP: Retrieve AIP
 catalogTreeGhostNodeLabel: Access denied
+browseAIPReasonViewAIP: View AIP

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1798,3 +1798,4 @@ catalogTreeReasonListChildren: Lista AIP-barn
 catalogTreeReasonListRoots: Lista rot-AIPs
 catalogTreeReasonGetAncestors: Hämta AIP-förfäder
 catalogTreeReasonRetrieveAIP: Hämta AIP
+catalogTreeGhostNodeLabel: Åtkomst saknas

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1799,3 +1799,4 @@ catalogTreeReasonListRoots: Lista rot-AIPs
 catalogTreeReasonGetAncestors: Hämta AIP-förfäder
 catalogTreeReasonRetrieveAIP: Hämta AIP
 catalogTreeGhostNodeLabel: Åtkomst saknas
+browseAIPReasonViewAIP: Visa AIP


### PR DESCRIPTION
## Sammanfattning

Löser #480 och #481.

Användare med behörighet enbart till objekt djupt i katalogstrukturen såg ett tomt katalogträd. Rotnoder utan behörighet filtrerades bort av backend, vilket resulterade i en tom lista.

- Nytt fallback-flöde i `CatalogTreePanel`: när root-sökningen returnerar tomt hämtas alla tillgängliga AIPs (max 200), ancestor-kedjor byggs upp och förfäder utan behörighet visas som ghost-noder ("Åtkomst saknas")
- Ghost-noder är grå, icke-klickbara och alltid utfällda — konsekvent med befintlig ghost-logik i breadcrumb-menyn
- Korsande ancestor-kedjor dedupliceras korrekt för att respektera GWTs enkla DOM-förälder-krav
- Ny loggningsorsak i `BrowseAIP` för granskningsloggen ("Visa AIP")

## Berörda filer

- `CatalogTreePanel.java` — fallback ghost-träd, merge-logik, generation-guard
- `CatalogTreeNode.java` — ghost-konstruktor, `addPrebuiltChild`, toggle/expand/collapse-skydd
- `main.gss` — CSS-stil för ghost-noder
- `ClientMessages.java` + `.properties`-filer — nya i18n-nycklar
- `BrowseAIP.java` — loggningsorsak

## Testplan

- [ ] Logga in som användare med behörighet enbart till djupt objekt — katalogträdet ska visa ghost-noder för förfäder och det tillgängliga objektet under dem
- [ ] Ghost-noder ska inte vara klickbara
- [ ] Ghost-noder ska vara utfällda från start och inte kunna fällas in
- [ ] Admin-användare ska se normalt träd (oförändrat beteende)
- [ ] Granskningsloggen ska visa en post med reason "Visa AIP" vid klick på nod i katalogträdet

## Manuella steg / risker

Inga migrationer eller konfigurationsändringar krävs. Fallback-flödet aktiveras enbart när root-sökningen returnerar tomt — normalt flöde påverkas inte.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog tree now displays inaccessible ancestor nodes as grayed-out, non-clickable "ghost nodes" when users have limited permissions, replacing the previously empty tree view.
  * All item lookups via UUID are now automatically recorded in the audit log for accountability and compliance tracking.

* **Documentation**
  * Added design specifications and implementation plans for ghost node functionality and audit logging enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->