### PR TITLE
feat: standard inleveransprocess som förvald vid inleverans (#466)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateIngestJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateIngestJob.java
@@ -54,11 +54,17 @@ public class CreateIngestJob extends CreateSelectedJob<TransferredResource> {
   private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
   private static PluginType[] pluginTypes = {PluginType.INGEST};
+  private static final String PREFERRED_INGEST_PLUGIN_ID = "org.roda.core.plugins.base.ingest.v2.ConfigurableIngestPlugin";
 
   public CreateIngestJob() {
     super(Arrays.asList(pluginTypes));
     super.setCategoryListBoxVisible(false);
     super.getButtonSchedule().setVisible(false);
+  }
+
+  @Override
+  protected String getPreferredPluginId() {
+    return PREFERRED_INGEST_PLUGIN_ID;
   }
 
   @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
@@ -321,7 +321,30 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
         }
       }
 
+      String preferredPluginId = getPreferredPluginId();
+      if (preferredPluginId != null) {
+        selectPreferredPluginInWorkflowList(preferredPluginId);
+      }
+
       updateWorkflowOptions();
+    }
+  }
+
+  protected String getPreferredPluginId() {
+    return null;
+  }
+
+  private void selectPreferredPluginInWorkflowList(String preferredPluginId) {
+    for (int i = 0; i < workflowList.getWidgetCount(); i++) {
+      Widget panelWidget = workflowList.getWidget(i);
+      if (preferredPluginId.equals(panelWidget.getElement().getAttribute("data-id"))) {
+        for (int j = 0; j < workflowList.getWidgetCount(); j++) {
+          workflowList.getWidget(j).removeStyleName("plugin-list-item-selected");
+        }
+        panelWidget.addStyleName("plugin-list-item-selected");
+        this.selectedPlugin = lookupPlugin(preferredPluginId);
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #466

## Sammanfattning

Vid inleverans var **Minimal inleveransprocess** automatiskt förvald — eftersom plugins sorteras alfabetiskt (`PluginUtils.sortByName`) och första pluginen markeras. Issue #466 begär att **Standard inleveransprocess** ska vara förvald istället.

## Ändring

Två filer, 29 rader tillagda:

- `CreateSelectedJob.java` — ny hook-metod `getPreferredPluginId()` (default `null`) som subklasser kan override:a, och privat helper `selectPreferredPluginInWorkflowList()` som efter den befintliga loopen byter selectedPlugin till den föredragna **om den finns i listan**.
- `CreateIngestJob.java` — override som returnerar `org.roda.core.plugins.base.ingest.v2.ConfigurableIngestPlugin` (= "Standard inleveransprocess").

Lösningen är generisk: andra `CreateSelectedJob`-subklasser (`CreateActionJob` m.fl.) påverkas inte, och om Configurable-pluginen skulle saknas i listan behåller den nuvarande alfabetiska beteendet.

## Risker / migrationer

- Inga schema-ändringar, inga nya beroenden, ingen omindexering krävs.
- Rent UI-default-värde — påverkar bara vad som är förvalt när användaren öppnar inleveranssidan. Användaren kan fortfarande välja vilken som helst.

## Test plan

- [x] Lokalt: `mvn -pl roda-ui/roda-wui -am compile` SUCCESS
- [x] GWT-compile (`mvn gwt:compile -Pdebug-main -Dscope.gwt-dev=compile`) SUCCESS (52s)
- [x] Manuell test via http://localhost:8080: "Standard inleveransprocess" är förvald vid inleverans — bekräftat av Anna
- [x] CI / CodeRabbit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Förbättringar**
  * Vid skapande av ingest-jobb väljs en föredragen plugin automatiskt när sådan är konfigurerad, vilket förenklar och snabbar upp arbetsflödet för användare.
  * Systemet kan nu konfigureras med en standardplugin som automatiskt väljs under arbetsflödeskonfigureringen istället för manuell val varje gång.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->