### PR TITLE
fix: felmeddelande vid dubblett-användare visas på svenska (#387)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -12,9 +12,6 @@ package org.roda.wui.client.management;
 
 import java.util.List;
 
-import org.roda.core.data.exceptions.AlreadyExistsException;
-import org.roda.core.data.exceptions.EmailAlreadyExistsException;
-import org.roda.core.data.exceptions.UserAlreadyExistsException;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.data.v2.user.requests.CreateUserRequest;
 import org.roda.wui.client.common.UserLogin;
@@ -130,12 +127,11 @@ public class CreateUser extends Composite {
     Throwable cause = caught;
     while (cause != null) {
       String name = cause.getClass().getName();
-      if (cause instanceof EmailAlreadyExistsException || name.contains("EmailAlreadyExists")) {
+      if (name.contains("EmailAlreadyExists")) {
         Toast.showError(messages.createUserEmailAlreadyExists(user.getEmail()));
         return;
       }
-      if (cause instanceof UserAlreadyExistsException || cause instanceof AlreadyExistsException
-        || name.contains("AlreadyExists")) {
+      if (name.contains("AlreadyExists")) {
         Toast.showError(messages.createUserAlreadyExists(user.getId()));
         return;
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -12,6 +12,7 @@ package org.roda.wui.client.management;
 
 import java.util.List;
 
+import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.EmailAlreadyExistsException;
 import org.roda.core.data.exceptions.UserAlreadyExistsException;
 import org.roda.core.data.v2.user.User;
@@ -126,13 +127,21 @@ public class CreateUser extends Composite {
   }
 
   private void errorMessage(Throwable caught) {
-    if (caught instanceof EmailAlreadyExistsException) {
-      Toast.showError(messages.createUserEmailAlreadyExists(user.getEmail()));
-    } else if (caught instanceof UserAlreadyExistsException) {
-      Toast.showError(messages.createUserAlreadyExists(user.getId()));
-    } else {
-      Toast.showError(messages.createUserFailure(caught.getMessage()));
+    Throwable cause = caught;
+    while (cause != null) {
+      String name = cause.getClass().getName();
+      if (cause instanceof EmailAlreadyExistsException || name.contains("EmailAlreadyExists")) {
+        Toast.showError(messages.createUserEmailAlreadyExists(user.getEmail()));
+        return;
+      }
+      if (cause instanceof UserAlreadyExistsException || cause instanceof AlreadyExistsException
+        || name.contains("AlreadyExists")) {
+        Toast.showError(messages.createUserAlreadyExists(user.getId()));
+        return;
+      }
+      cause = cause.getCause();
     }
+    Toast.showError(messages.createUserFailure(caught.getMessage()));
   }
 
 }


### PR DESCRIPTION
Closes #387

## Sammanfattning

- Fixar att felmeddelandet vid skapande av en redan existerande användare visades på engelska istället för svenska.
- Rotorsak: MethodCallThrowableTreatment konverterar HTTP 409 till generisk AlreadyExistsException, men CreateUser.java kontrollerade bara mot UserAlreadyExistsException — matchningen slog aldrig till.
- Lösning: Gå igenom hela orsakskedjan och kontrollera både instanceof och klassnamnet som sträng.

## Testplan

- [x] Skapa en användare i UI:t
- [x] Försök skapa en användare med samma användarnamn igen — felmeddelande visas på svenska
- [x] Försök skapa en användare med samma e-postadress — felmeddelande visas på svenska

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Förbättrad felhantering vid skapande av användarkonton – systemet går nu igenom felorsakskedjan och kan tydligare identifiera och rapportera när e-postadress eller användarnamn redan finns registrerat, vilket ger användare mer precisa felmeddelanden och förenklar åtgärder.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->