### PR TITLE
i18n(sv): översätt FOLDERS/CREATED/MODIFIED på representationskortet

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -567,8 +567,11 @@ representationId:Identifierare
 representationOriginal:Original
 representationType:Typ
 representationFiles:Filer
+representationFolders:Mappar
 objectCreatedDate:Skapad datum
+objectCreatedDateShort:Skapad
 objectLastModified:Senaste ändring
+objectLastModifiedShort:Ändrad
 # Preservation Event List
 preservationEventListHeaderDate:Datum
 preservationEventListHeaderType:Typ


### PR DESCRIPTION
## Summary

- Tre etiketter på AIP-representationskortet (`AIPRepresentationCardList`) saknade svensk översättning och visades på engelska i `sv_SE`-läget: **FOLDERS**, **CREATED**, **MODIFIED**.
- Lägger till de saknade nycklarna i `ClientMessages_sv_SE.properties`:
  - `representationFolders` → **Mappar**
  - `objectCreatedDateShort` → **Skapad**
  - `objectLastModifiedShort` → **Ändrad**
- Värdet **"Other"** (representationtyp) lämnas oförändrat — det är ett admin-konfigurerbart datavärde från `IndexedRepresentation.getType()` som visas direkt utan i18n-uppslagning (se `AIPRepresentationCardList.java:49`).

## Resultat på kortet

| Före | Efter |
|---|---|
| FOLDERS 0 | **MAPPAR 0** |
| CREATED 2026-05-19 | **SKAPAD 2026-05-19** |
| MODIFIED 2026-05-21 | **ÄNDRAD 2026-05-21** |

Övriga etiketter (`FILER`, `STORLEK`, `ORIGINAL`-badge) var redan korrekt översatta.

## Test plan

- [ ] GWT-recompile (`mvn gwt:compile` eller via `/dev-up`) så att properties-ändringen kommer ut i klientbundlen.
- [ ] Öppna en AIP med minst en representation i `sv_SE`-läge och verifiera att etiketterna på representationskortet visas som **MAPPAR**, **SKAPAD**, **ÄNDRAD**.
- [ ] Kontrollera att engelskt läge (`en`) inte påverkas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Lokalisering**
  * Lade till svenska språköversättningar för representationsmapplistor, vilket förbättrar lokaliseringen för svenska användare.
  * Introduktion av kortare datumformat och etiketter för skapnings- och ändringstidpunkter, vilket möjliggör mer effektiv och kompakt visning av tidsmarkeringar i användargränssnittet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->