### PR TITLE
fix(i18n): översätt "Edit permissions"-knappen till svenska

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -905,6 +905,7 @@ newSublevel:Skapa strukturenhet
 sublevels:Strukturenheter
 moveArchivalPackage:Flytta
 archivalPackagePermissions:Behörigheter
+editArchivalPackagePermissions:Redigera behörigheter
 archivalPackagePermissionsTitle:Behörigheter arkivpaket
 disseminationPermissions:Behörigheter
 removeArchivalPackage:Ta bort


### PR DESCRIPTION
Closes #521

## Sammanfattning

På BEHÖRIGHETER-fliken för ett AIP visades knappen "Edit permissions" på engelska trots att resten av gränssnittet var på svenska.

## Ändring

En rad tillagd i `ClientMessages_sv_SE.properties`:

```
editArchivalPackagePermissions:Redigera behörigheter
```

Nyckeln `editArchivalPackagePermissions` fanns i den engelska basfilen (`ClientMessages.properties`) men saknades helt i den svenska lokaliseringsfilen, vilket fick GWT att falla tillbaka på engelska.

## Risker / migrationer

- Ingen schema-ändring, inga nya beroenden, ingen omindexering krävs.
- Rent textbyte i UI — påverkar bara etiketten på länken i behörighetsfliken.

## Test plan

- [x] GWT-compile SUCCESS
- [x] Manuell test via http://localhost:8080: knappen visar "Redigera behörigheter" på BEHÖRIGHETER-fliken — bekräftat av Anna
- [x] CI / CodeRabbit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Lokalisering**
  * Tillagd svensk etikett för behörighetshantering av arkivpaket.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->