### PR TITLE
fix(ui): förbättrad läsbarhet i hjälpsidor — kontrast, typsnitt, rubriknivåer

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2748,7 +2748,10 @@ td.datePickerMonth, td.datePickerYear {
     line-height: 1.6;
 }
 
-.wui-home h3 {
+.wui-home h3,
+.wui-home h4,
+.wui-home h5,
+.wui-home h6 {
     font-family: FONT_PRIMARY;
     font-size: 14px !important;
     font-weight: 700;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2749,10 +2749,11 @@ td.datePickerMonth, td.datePickerYear {
 }
 
 .wui-home h3 {
-    font-size: 16px;
-    font-weight: 600;
-    margin-top: 28px;
-    margin-bottom: 6px;
+    font-size: 14px;
+    font-weight: 700;
+    font-style: normal;
+    margin-top: 20px;
+    margin-bottom: 4px;
 }
 
 .content > .gwt-HTML > h1 {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2749,8 +2749,10 @@ td.datePickerMonth, td.datePickerYear {
 }
 
 .wui-home h3 {
+    font-size: 16px;
+    font-weight: 600;
     margin-top: 28px;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .content > .gwt-HTML > h1 {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2748,6 +2748,11 @@ td.datePickerMonth, td.datePickerYear {
     line-height: 1.6;
 }
 
+.wui-home h3 {
+    margin-top: 28px;
+    margin-bottom: 8px;
+}
+
 .content > .gwt-HTML > h1 {
 	margin-top: 0;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2736,7 +2736,16 @@ td.datePickerMonth, td.datePickerYear {
 }
 
 .wui-home {
-    color: #58595b;
+    color: #222222;
+}
+
+.wui-home p {
+    font-size: 14px;
+}
+
+.wui-home li {
+    font-size: 14px;
+    line-height: 1.6;
 }
 
 .content > .gwt-HTML > h1 {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2749,9 +2749,11 @@ td.datePickerMonth, td.datePickerYear {
 }
 
 .wui-home h3 {
-    font-size: 14px;
+    font-family: FONT_PRIMARY;
+    font-size: 14px !important;
     font-weight: 700;
     font-style: normal;
+    letter-spacing: normal;
     margin-top: 20px;
     margin-bottom: 4px;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
@@ -239,19 +239,21 @@ public class ContentPanel extends SimplePanel {
     if (!resolved) {
       String lastToken = historyTokens.get(historyTokens.size() - 1);
 
-      // strip file extension
+      // strip file extension and normalize title
       if (lastToken.endsWith(".html")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".html".length());
+        // strip locale suffix (e.g. _sv_SE, _pt_BR) and underscores
+        lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
+        lastToken = lastToken.replace("_", " ");
+        // transform camel case to spaces (html files may use camelCase naming)
+        lastToken = lastToken.replaceAll("([A-Z])", " $1");
       } else if (lastToken.endsWith(".md")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".md".length());
         // strip locale suffix (e.g. _sv_SE, _pt_BR)
         lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
-        // underscores → spaces
+        // underscores → spaces; skip camelCase to avoid double spaces after underscore→space
         lastToken = lastToken.replace("_", " ");
       }
-
-      // transform camel case to spaces
-      lastToken = lastToken.replaceAll("([A-Z])", " $1");
 
       // upper-case and trim
       lastToken = lastToken.toUpperCase().trim();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/ContentPanel.java
@@ -239,16 +239,22 @@ public class ContentPanel extends SimplePanel {
     if (!resolved) {
       String lastToken = historyTokens.get(historyTokens.size() - 1);
 
-      // TODO generalize suffix approach
+      // strip file extension
       if (lastToken.endsWith(".html")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".html".length());
+      } else if (lastToken.endsWith(".md")) {
+        lastToken = lastToken.substring(0, lastToken.length() - ".md".length());
+        // strip locale suffix (e.g. _sv_SE, _pt_BR)
+        lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
+        // underscores → spaces
+        lastToken = lastToken.replace("_", " ");
       }
 
       // transform camel case to spaces
       lastToken = lastToken.replaceAll("([A-Z])", " $1");
 
-      // upper-case
-      lastToken = lastToken.toUpperCase();
+      // upper-case and trim
+      lastToken = lastToken.toUpperCase().trim();
       tokenI18N = lastToken;
     }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
@@ -188,16 +188,22 @@ public class ContentPanelPortal extends SimplePanel {
     if (!resolved) {
       String lastToken = historyTokens.get(historyTokens.size() - 1);
 
-      // TODO generalize suffix approach
+      // strip file extension
       if (lastToken.endsWith(".html")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".html".length());
+      } else if (lastToken.endsWith(".md")) {
+        lastToken = lastToken.substring(0, lastToken.length() - ".md".length());
+        // strip locale suffix (e.g. _sv_SE, _pt_BR)
+        lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
+        // underscores → spaces
+        lastToken = lastToken.replace("_", " ");
       }
 
       // transform camel case to spaces
       lastToken = lastToken.replaceAll("([A-Z])", " $1");
 
-      // upper-case
-      lastToken = lastToken.toUpperCase();
+      // upper-case and trim
+      lastToken = lastToken.toUpperCase().trim();
       tokenI18N = lastToken;
     }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/portal/ContentPanelPortal.java
@@ -188,19 +188,21 @@ public class ContentPanelPortal extends SimplePanel {
     if (!resolved) {
       String lastToken = historyTokens.get(historyTokens.size() - 1);
 
-      // strip file extension
+      // strip file extension and normalize title
       if (lastToken.endsWith(".html")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".html".length());
+        // strip locale suffix (e.g. _sv_SE, _pt_BR) and underscores
+        lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
+        lastToken = lastToken.replace("_", " ");
+        // transform camel case to spaces (html files may use camelCase naming)
+        lastToken = lastToken.replaceAll("([A-Z])", " $1");
       } else if (lastToken.endsWith(".md")) {
         lastToken = lastToken.substring(0, lastToken.length() - ".md".length());
         // strip locale suffix (e.g. _sv_SE, _pt_BR)
         lastToken = lastToken.replaceAll("_[a-z]{2,3}_[A-Z]{2}$", "");
-        // underscores → spaces
+        // underscores → spaces; skip camelCase to avoid double spaces after underscore→space
         lastToken = lastToken.replace("_", " ");
       }
-
-      // transform camel case to spaces
-      lastToken = lastToken.replaceAll("([A-Z])", " $1");
 
       // upper-case and trim
       lastToken = lastToken.toUpperCase().trim();


### PR DESCRIPTION
Closes #527

## Sammanfattning

Tre separata läsbarhetsproblem i hjälpsidor (`.wui-home`) åtgärdade:

1. **Kontrast** — textfärg från `#58595b` → `#222222`
2. **Teckenstorlek p/li** — brödtext och listor fick explicit `font-size: 14px`
3. **Rubrikhierarki h3–h6** — använde Barlow Condensed (display-font) via `theme.css`; nu styrd till Inter (FONT_PRIMARY), 14px, bold — inkluderar h4/h5/h6 (används t.ex. i Overview_sv_SE.md)

Dessutom **sidtitel i webbläsarfliken**: `.md`-filer visade råfilnamnet med underscore och lokalsuffix (t.ex. `OVERVIEW_SV_SE.MD`). Nu strippas filändelse, lokalsuffix (`_sv_SE` etc.) och understreck ersätts med mellanslag.

## Ändrade filer

| Fil | Vad |
|-----|-----|
| `main.gss` | `.wui-home` — ny färg, p/li font-size, h3–h6-regler med FONT_PRIMARY |
| `ContentPanel.java` | `setWindowTitle` — hanterar `.md`-suffix och lokalsuffix |
| `ContentPanelPortal.java` | Identisk fix som ContentPanel.java |

## Risker / migrationer

- Ingen schema-ändring, inga nya beroenden, ingen omindexering krävs.
- CSS-ändring i GWT CssResource — kräver GWT-compile (redan gjort).
- `.wui-home` används av: Help, Theme, Welcome, Statistics, WelcomePortal, AcknowledgeNotification — alla får förbättrad läsbarhet.

## Test plan

- [x] GWT-compile SUCCESS
- [x] Manuell test: hjälpsidor läsliga, rubrikhierarki Inter/bold, rätt färg
- [x] Overview_sv_SE.md: Inleverans/Process/Ankomstkontroll (h4) visas korrekt
- [x] Sidtitel: `#theme/reference/Overview_sv_SE.md` → "OVERVIEW" i webbläsarfliken
- [ ] CI / CodeRabbit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Uppdaterad hemvys-styling: ny basfärg (`#222222`), gemensamt typsnitt, förbättrade typografiregler för stycken, listor och rubriker (h3–h6) inklusive justerade storlekar, vikter och marginaler.

* **Bug Fixes**
  * Förbättrad normalisering av fönstertitlar för HTML och Markdown: hantering av filändelser, språksuffix, understreck→mellanslag, skillnad i camelCase-behandling, samt trimning och versalisering innan titel visas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->