### PR TITLE
fix(#470): katalogträdet uppdateras vid borttagning av AIP

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipActions.java
@@ -494,13 +494,13 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
                         @Override
                         public void onFailure(Throwable caught) {
                           Toast.showInfo(messages.removingSuccessTitle(), messages.removingSuccessMessage(1L));
-                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), parentAipId);
                           doActionCallbackDestroyed();
                         }
 
                         @Override
                         public void onSuccess(final Void nothing) {
-                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), parentAipId);
                           doActionCallbackNone();
                           HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                         }
@@ -514,6 +514,18 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
           }
         }
       });
+  }
+
+  private void removeCatalogTreeNodes(SelectedItems<IndexedAIP> selected) {
+    if (selected instanceof SelectedItemsList) {
+      for (String id : ((SelectedItemsList<IndexedAIP>) selected).getIds()) {
+        CatalogTreePanel.getInstance().removeNode(id, parentAipId);
+      }
+    } else if (parentAipId == null) {
+      CatalogTreePanel.getInstance().reloadRootNodes();
+    } else {
+      CatalogTreePanel.getInstance().refreshSubtree(parentAipId);
+    }
   }
 
   private void remove(final SelectedItems<IndexedAIP> selected, final AsyncCallback<ActionImpact> callback) {
@@ -548,12 +560,13 @@ public class AipActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
-
+                              removeCatalogTreeNodes(selected);
                               doActionCallbackDestroyed();
                             }
 
                             @Override
                             public void onSuccess(final Void nothing) {
+                              removeCatalogTreeNodes(selected);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/AipSearchWrapperActions.java
@@ -486,13 +486,13 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
                         @Override
                         public void onFailure(Throwable caught) {
                           Toast.showInfo(messages.removingSuccessTitle(), messages.removingSuccessMessage(1L));
-                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), parentAipId);
                           doActionCallbackDestroyed();
                         }
 
                         @Override
                         public void onSuccess(final Void nothing) {
-                          CatalogTreePanel.getInstance().removeNode(aip.getId(), aip.getParentID());
+                          CatalogTreePanel.getInstance().removeNode(aip.getId(), parentAipId);
                           doActionCallbackNone();
                           HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                         }
@@ -506,6 +506,18 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
           }
         }
       });
+  }
+
+  private void removeCatalogTreeNodes(SelectedItems<IndexedAIP> selected) {
+    if (selected instanceof SelectedItemsList) {
+      for (String id : ((SelectedItemsList<IndexedAIP>) selected).getIds()) {
+        CatalogTreePanel.getInstance().removeNode(id, parentAipId);
+      }
+    } else if (parentAipId == null) {
+      CatalogTreePanel.getInstance().reloadRootNodes();
+    } else {
+      CatalogTreePanel.getInstance().refreshSubtree(parentAipId);
+    }
   }
 
   private void remove(final SelectedItems<IndexedAIP> selected, final AsyncCallback<ActionImpact> callback) {
@@ -540,12 +552,13 @@ public class AipSearchWrapperActions extends AbstractActionable<IndexedAIP> {
 
                             @Override
                             public void onFailure(Throwable caught) {
-
+                              removeCatalogTreeNodes(selected);
                               doActionCallbackDestroyed();
                             }
 
                             @Override
                             public void onSuccess(final Void nothing) {
+                              removeCatalogTreeNodes(selected);
                               doActionCallbackNone();
                               HistoryUtils.newHistory(ShowJob.RESOLVER, value.getId());
                             }


### PR DESCRIPTION
Closes #470

## Sammanfattning

Katalogträdet (vänsterpanelen) uppdaterades inte visuellt när en AIP togs bort via "Förvaringsenheter > Ta bort".

**Rotorsak:** `aip.getParentID()` returnerade `null` eftersom fältet `parentID` inte ingår i `fieldsToReturn` för undertabell-frågan i `AsyncTableCell`. Det ledde till att `removeNode()` försökte ta bort noden som en rotnod, hittade den inte och misslyckades tyst.

**Fix:** Använder `parentAipId` (instansfält på actions-objektet, satt till den för tillfället visade AIP:ens ID) i stället för `aip.getParentID()`.

## Ändringar

- `AipSearchWrapperActions.java`: `aip.getParentID()` → `parentAipId` i `remove(IndexedAIP, callback)`; lägger till `removeCatalogTreeNodes()` för flervals-borttagning
- `AipActions.java`: samma fix

## Testplan

- [x] Stå på en AIP i katalogträdet, bocka i en under-AIP i tabellen "Förvaringsenheter", klicka "Ta bort" — katalogträdet ska uppdateras direkt
- [x] Kontrollera att "Skapa strukturenhet" och "Flytta" fortfarande fungerar korrekt
- [x] Kontrollera att flervals-borttagning uppdaterar trädet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Felkorrigeringar

* Katalogträdet synkroniseras nu korrekt vid borttagning av arkivbeskrivningar
* Borttagning av flera arkivbeskrivningar samtidigt uppdaterar trädhierarkin konsekvent, oavsett om operationen lyckas eller misslyckas

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->