### PR TITLE
fix: representationskort — layout, klickbarhet och långa typnamn

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -124,17 +124,8 @@ jobs:
 
       - name: Copy JAR to Docker build context
         run: |
-          rm -rf docker/target
           mkdir -p docker/target
-          # Resolve exact runtime JAR by version, mirrors docker/build.sh
-          VERSION=$(mvn $MAVEN_CLI_OPTS -q -N help:evaluate -Dexpression=project.version -DforceStdout)
-          JAR="roda-ui/roda-wui/target/roda-wui-${VERSION}.jar"
-          if [ ! -f "$JAR" ]; then
-            echo "Runtime JAR not found: $JAR"
-            ls -la roda-ui/roda-wui/target/
-            exit 1
-          fi
-          cp "$JAR" docker/target/
+          cp roda-ui/roda-wui/target/roda-wui-*.jar docker/target/
 
       - name: Docker meta for test images
         id: meta

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -124,8 +124,17 @@ jobs:
 
       - name: Copy JAR to Docker build context
         run: |
+          rm -rf docker/target
           mkdir -p docker/target
-          cp roda-ui/roda-wui/target/roda-wui-*.jar docker/target/
+          # Resolve exact runtime JAR by version, mirrors docker/build.sh
+          VERSION=$(mvn $MAVEN_CLI_OPTS -q -N help:evaluate -Dexpression=project.version -DforceStdout)
+          JAR="roda-ui/roda-wui/target/roda-wui-${VERSION}.jar"
+          if [ ! -f "$JAR" ]; then
+            echo "Runtime JAR not found: $JAR"
+            ls -la roda-ui/roda-wui/target/
+            exit 1
+          fi
+          cp "$JAR" docker/target/
 
       - name: Docker meta for test images
         id: meta

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPDisseminationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPDisseminationCardList.java
@@ -8,7 +8,7 @@
 package org.roda.wui.client.common.cards;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,8 +50,8 @@ public class AIPDisseminationCardList extends ThumbnailCardList<IndexedDIP> {
           // Tags
           List<Tag> tags = new ArrayList<>();
 
-          // Attributes
-          Map<String, String> attributes = new HashMap<>();
+          // LinkedHashMap so CSS nth-child column order is stable across cards
+          Map<String, String> attributes = new LinkedHashMap<>();
           attributes.put(messages.disseminationFiles(), Long.toString(dip.getFileIds().size()));
           if (dip.getDateCreated() != null) {
             attributes.put(messages.objectCreatedDateShort(), Humanize.formatDate(dip.getDateCreated()));
@@ -64,7 +64,8 @@ public class AIPDisseminationCardList extends ThumbnailCardList<IndexedDIP> {
             HistoryUtils.newHistory(BrowseDIP.RESOLVER, dip.getId());
           };
 
-          return new ThumbnailCard(title, iconThumbnailHTML, tags, attributes, thumbnailClickHandler);
+          return new ThumbnailCard(title, iconThumbnailHTML, tags, attributes, thumbnailClickHandler)
+            .enableWholeCardClick();
         }
       });
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPRepresentationCardList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/AIPRepresentationCardList.java
@@ -74,7 +74,8 @@ public class AIPRepresentationCardList extends ThumbnailCardList<IndexedRepresen
             HistoryUtils.newHistory(BrowseRepresentation.RESOLVER, aipId, representation.getId());
           };
 
-          return new ThumbnailCard(title, iconThumbnailHTML, tags, attributes, thumbnailClickHandler);
+          return new ThumbnailCard(title, iconThumbnailHTML, tags, attributes, thumbnailClickHandler)
+            .enableWholeCardClick();
         }
       });
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCard.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/cards/ThumbnailCard.java
@@ -13,14 +13,15 @@ import java.util.Map;
 import org.roda.wui.client.common.labels.Tag;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.FocusPanel;
-import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -47,36 +48,53 @@ public class ThumbnailCard extends Composite {
 
   private boolean collapsed = true;
 
+  private ClickHandler thumbnailClickHandler;
+
   public ThumbnailCard(String title, Widget iconThumbnail, List<Tag> tags, Map<String, String> attributes,
     ClickHandler thumbnailClickHandler) {
-    // INIT
     initWidget(uiBinder.createAndBindUi(this));
+    this.thumbnailClickHandler = thumbnailClickHandler;
 
     collapse();
 
-    // Click handler
     this.clickable.addClickHandler(thumbnailClickHandler);
 
-    // Title
     this.title.setText(title);
     this.title.addClickHandler(event -> toggleCollapse());
 
-    // Thumbnail
     iconThumbnail.addStyleName("thumbnailCardIconThumbnail");
     this.thumbnail.add(iconThumbnail);
 
-    // Tags
     for (Tag tag : tags) {
       this.tags.add(tag);
     }
 
-    // Attributes
+    // Label auto-escapes HTML; safe for user-supplied metadata
     for (Map.Entry<String, String> attribute : attributes.entrySet()) {
       FlowPanel attributePanel = new FlowPanel();
-      attributePanel.add(new HTML(SafeHtmlUtils.fromSafeConstant(attribute.getKey())));
-      attributePanel.add(new HTML(SafeHtmlUtils.fromSafeConstant(attribute.getValue())));
+      attributePanel.add(new Label(attribute.getKey()));
+      attributePanel.add(new Label(attribute.getValue()));
       this.attributes.add(attributePanel);
     }
+  }
+
+  /** Make the whole card surface clickable and keyboard-activatable. */
+  public ThumbnailCard enableWholeCardClick() {
+    // Stop propagation so the root handler doesn't fire twice
+    this.clickable.addClickHandler(event -> event.stopPropagation());
+
+    addDomHandler(thumbnailClickHandler, ClickEvent.getType());
+
+    getElement().setTabIndex(0);
+    addDomHandler(event -> {
+      int keyCode = event.getNativeKeyCode();
+      if (keyCode == KeyCodes.KEY_ENTER || keyCode == KeyCodes.KEY_SPACE) {
+        event.preventDefault();
+        thumbnailClickHandler.onClick(null);
+      }
+    }, KeyDownEvent.getType());
+
+    return this;
   }
 
   public void toggleCollapse() {

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1595,22 +1595,24 @@ a.btn-hero:visited, a.btn-welcome:visited {
     background: rgba(0,0,0,0.2);
 }
 
-/* ===================================================
-   Inline Representation Section (Design 1)
-   Representations shown as compact rows below metadata
-   =================================================== */
+/* Representations section */
 
 .representationSection {
-    /* Match the 30px padding of upperContent so left edge aligns */
-    padding: 0 30px 16px 30px;
-    /* Shrink to content so nothing bleeds full-width */
-    display: inline-flex !important;
+    padding: 0 30px 24px 30px;
+    display: flex !important;
     flex-direction: column;
-    width: fit-content;
-    max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
 }
 
-/* Header "Representationer" — same style as eterna-section-header */
+/* 296px right padding aligns with metadata card: 30px upperContent padding
+   + 16px gap + 250px side panel */
+@media (min-width: 768px) {
+    .representationSection {
+        padding-right: 296px;
+    }
+}
+
 .representationSection .thumbnailCardListTitle .rodaTitleHeader {
     font-family: var(--eterna-font-display) !important;
     font-size: 22px !important;
@@ -1628,113 +1630,218 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .representationSection .thumbnailCardListCards {
     display: flex !important;
     flex-direction: column !important;
-    align-items: flex-start !important;
+    align-items: stretch !important;
 }
 
 .representationCardContainer {
-    gap: 6px;
+    gap: 8px;
     margin-bottom: 8px;
+    width: 100%;
 }
 
-/* Intermediate GWT containers: shrink to content */
 .representationSection .thumbnailCardList,
 .representationSection .thumbnailCardListCards {
-    width: fit-content !important;
+    width: 100% !important;
 }
 
 .representationSection .thumbnailCardList {
-    gap: 4px !important;
-}
-
-.representationSection .thumbnailCardListCards {
     gap: 6px !important;
 }
 
-.representationSection .thumbnailCard,
-.representationSection .clickable,
-.representationSection .thumbnailCardExpandable .thumbnailCardDetails,
-.representationSection .thumbnailCardCollapsible .thumbnailCardDetails {
-    display: flex !important;
-    flex-direction: row !important;
-    align-items: center !important;
-    width: fit-content !important;
-    min-height: 0 !important;
+.representationSection .thumbnailCardListCards {
+    gap: 8px !important;
 }
 
-.representationSection .thumbnailCardTags,
-.representationSection .thumbnailCardAttributes {
-    display: flex !important;
-    flex-direction: row !important;
-    flex-wrap: nowrap !important;
-    width: fit-content !important;
-    margin: 0 !important;
-    padding: 0 !important;
+/* Title column auto-fits widest title across cards; 1fr absorbs leftover
+   width so columns never overflow the container */
+.representationSection .thumbnailCardListCards {
+    display: grid !important;
+    grid-template-columns:
+        minmax(auto, max-content)
+        max-content
+        max-content
+        max-content
+        max-content
+        max-content
+        1fr;
+    row-gap: 8px !important;
+    width: 100% !important;
+    box-sizing: border-box;
 }
 
-/* Override vertical thumbnail card to compact horizontal row */
+@supports not (grid-template-columns: subgrid) {
+    .representationSection .thumbnailCardListCards {
+        display: flex !important;
+        flex-direction: column !important;
+        grid-template-columns: none !important;
+        gap: 8px !important;
+    }
+}
+
 .representationSection .thumbnailCard {
-    min-width: 240px !important;
-    padding: 8px 14px !important;
+    display: grid !important;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    box-sizing: border-box !important;
+    padding: 18px 24px !important;
     background: var(--eterna-white, #fff) !important;
     border: 1px solid var(--eterna-border, #e4e4e4) !important;
     border-radius: 6px !important;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06) !important;
+    column-gap: 24px !important;
+    row-gap: 12px !important;
     height: auto !important;
-    box-sizing: border-box !important;
     margin: 0 !important;
-    cursor: default;
+    cursor: pointer;
 }
 
-/* Hide large icon thumbnail */
+@supports not (grid-template-columns: subgrid) {
+    .representationSection .thumbnailCard {
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+        grid-template-columns: none !important;
+        grid-column: auto !important;
+    }
+}
+
+/* display:contents lets title/tag/attribute children become direct grid
+   items of .thumbnailCard so they share the outer subgrid columns */
+.representationSection .clickable,
+.representationSection .thumbnailCardExpandable .thumbnailCardDetails,
+.representationSection .thumbnailCardCollapsible .thumbnailCardDetails,
+.representationSection .thumbnailCardAttributes {
+    display: contents !important;
+}
+
 .representationSection .thumbnailCardIconThumbnail {
     display: none !important;
 }
+.representationSection .thumbnailCardExpandable .thumbnailCardDetails > div:not(.thumbnailCardTags):not(.thumbnailCardAttributes),
+.representationSection .thumbnailCardCollapsible .thumbnailCardDetails > div:not(.thumbnailCardTags):not(.thumbnailCardAttributes) {
+    display: none !important;
+}
 
-/* Title on the left */
 .representationSection .thumbnailCardTitle {
+    grid-column: 1;
     font-size: 14px !important;
     font-weight: 600 !important;
     width: auto !important;
-    max-width: none !important;
+    max-width: 100% !important;
     margin: 0 !important;
-    padding: 0 10px 0 0 !important;
-    white-space: nowrap;
-    flex-shrink: 0;
-    justify-content: flex-start !important;
-}
-
-/* Details row: tags + attributes inline — always visible */
-.representationSection .thumbnailCardExpandable .thumbnailCardDetails,
-.representationSection .thumbnailCardCollapsible .thumbnailCardDetails {
-    gap: 10px !important;
     padding: 0 !important;
-    background: none !important;
-    border-radius: 0 !important;
-}
-
-/* Tags inline */
-.representationSection .thumbnailCardTags {
-    gap: 5px !important;
-}
-
-/* Attributes beside tags */
-.representationSection .thumbnailCardAttributes {
-    gap: 12px !important;
-    font-size: 13px;
-    color: #666;
-}
-
-/* Each attribute key-value pair inline */
-.representationSection .thumbnailCardAttributes > div {
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: normal;
+    align-self: center;
     display: flex !important;
-    flex-direction: row !important;
-    gap: 3px;
-    align-items: center;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    cursor: pointer;
+    box-sizing: border-box;
 }
 
-/* Expand/collapse arrow indicator — hide in inline mode */
 .representationSection .thumbnailCardTitle::after {
     display: none !important;
+}
+
+.representationSection .thumbnailCardTags {
+    grid-column: 2;
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 6px !important;
+    align-items: center;
+    align-self: center;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.representationSection .thumbnailCardAttributes > div:nth-child(1) { grid-column: 3; }
+.representationSection .thumbnailCardAttributes > div:nth-child(2) { grid-column: 4; }
+.representationSection .thumbnailCardAttributes > div:nth-child(3) { grid-column: 5; }
+.representationSection .thumbnailCardAttributes > div:nth-child(4) { grid-column: 6; }
+.representationSection .thumbnailCardAttributes > div:nth-child(5) { grid-column: 7; }
+
+.representationSection .thumbnailCardAttributes > div {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 2px;
+    align-items: flex-start;
+    white-space: nowrap;
+}
+
+.representationSection .thumbnailCardAttributes > div > *:first-child {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    color: #999;
+    text-transform: uppercase;
+}
+
+.representationSection .thumbnailCardAttributes > div > *:nth-child(2) {
+    font-size: 14px;
+    font-weight: 500;
+    color: #333;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.representationSection .thumbnailCardAttributes > div:nth-child(1) { min-width: 50px; }
+.representationSection .thumbnailCardAttributes > div:nth-child(2) { min-width: 60px; }
+.representationSection .thumbnailCardAttributes > div:nth-child(3) { min-width: 80px; }
+.representationSection .thumbnailCardAttributes > div:nth-child(4) { min-width: 100px; }
+.representationSection .thumbnailCardAttributes > div:nth-child(5) { min-width: 100px; }
+
+/* Below 1100px the subgrid columns would crowd; reflow as wrapping flex */
+@media (max-width: 1100px) {
+    .representationSection .thumbnailCardListCards {
+        display: flex !important;
+        flex-direction: column !important;
+        gap: 8px !important;
+        grid-template-columns: none !important;
+    }
+    .representationSection .thumbnailCard {
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+        align-items: center !important;
+        grid-template-columns: none !important;
+        grid-column: auto !important;
+        column-gap: 24px !important;
+        row-gap: 10px !important;
+    }
+    .representationSection .thumbnailCardTitle {
+        grid-column: auto !important;
+        order: 1;
+        flex: 0 0 auto;
+        min-width: 0;
+    }
+    .representationSection .thumbnailCardTags {
+        grid-column: auto !important;
+        order: 2;
+        flex-basis: 100%;
+        margin-top: 4px !important;
+    }
+    .representationSection .thumbnailCardAttributes {
+        display: flex !important;
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+        order: 3;
+        flex: 1 1 100%;
+        gap: 8px 20px !important;
+    }
+    .representationSection .thumbnailCardAttributes > div {
+        grid-column: auto !important;
+    }
+}
+
+@media (max-width: 700px) {
+    .representationSection .thumbnailCardAttributes > div {
+        min-width: 0 !important;
+    }
 }
 
 /* Description toggle */


### PR DESCRIPTION
## Summary

Closes #531

Fixar två problem på representationskorten under `BrowseAIP`:

1. **Långa typnamn skapade konstig layout vid olika fönsterstorlekar.**
2. **Det gick inte att klicka var som helst på kortet — bara på en smal FocusPanel-yta.**

## Vad har gjorts

### Layout (CSS Grid + subgrid)
- Korten är nu ett **7-kolumns subgrid** delat över alla kort i sektionen. Title-kolumnen `minmax(auto, max-content)` växer till bredaste titeln (så `KONVERTERADE TILL PDF/A` får plats på en rad om utrymme finns), och `1fr` på sista kolumnen absorberar resterande bredd så grid:en aldrig sticker ut.
- ORIGINAL-taggen och varje attribut (FILER / FOLDERS / STORLEK / CREATED / MODIFIED) hamnar i fasta kolumner som alignar perfekt mellan korten.
- Kortets bredd är beräknad så att höger- och vänster-kant alignar exakt med metadata-kortet ovanför (`30px / 296px` section padding).
- **Smal viewport (≤ 1100px)**: faller tillbaka till flex-wrap där ORIGINAL hamnar på egen rad direkt under titeln. Attributen wrappar naturligt.
- **Mobil (< 700px)**: min-widths nollställs så texten flyter.
- `@supports not (grid-template-columns: subgrid)`: säker fallback till flex för webbläsare utan subgrid-stöd.

### Klickbarhet och tangentbordsstöd
- Ny opt-in metod `ThumbnailCard.enableWholeCardClick()` som:
  - Lägger ClickHandler på rotelementet — hela kortet (inkl padding och whitespace mellan grid-kolumner) navigerar till representationen.
  - Sätter `tabIndex(0)` + KeyDownEvent-handler så kortet är tangentbordsfokuserbart och kan aktiveras med **Enter** eller **Mellanslag**.
  - Stoppar event-propagation från den inre FocusPanel så root-handlern inte triggas dubbelt.
- Anropas från `AIPRepresentationCardList` och `AIPDisseminationCardList`.
- **Default-beteendet** för andra ThumbnailCard-konsumenter (FocusPanel-klick + title togglar collapse) är **bevarat**.

### Säkerhet
- `ThumbnailCard` använder nu `Label` istället för `SafeHtmlUtils.fromSafeConstant(...)` för attribut-text. Framtida user-supplied metadata HTML-escapas automatiskt.

### Övrigt
- `AIPDisseminationCardList` använder `LinkedHashMap` (var `HashMap`) så kolumnordningen är stabil under CSS `nth-child`-styling.
- CI: `test-build.yml` kopierar nu exakt runtime-JAR via Maven-version (samma mönster som `docker/build.sh`) istället för `roda-wui-*.jar`-wildcard — robustare om `-sources.jar` etc skulle produceras framöver.

## Test plan
- [ ] Verifiera att representationskorten renderar korrekt på desktop (> 1100px) — alla 7 kolumner aligneras, KONVERTERADE-titlar fits på en rad om plats finns.
- [ ] Verifiera fönsterbredd mellan 700-1100px — ORIGINAL wrappar till egen rad under titeln, attributen wrappar naturligt.
- [ ] Verifiera mobil (< 700px) — content reflows utan att sticka ut.
- [ ] Klicka var som helst på ett kort (titel, ORIGINAL, attribut, padding/whitespace) — navigation till representationen ska fungera överallt.
- [ ] Tab-navigera till ett kort, tryck Enter eller Mellanslag — ska navigera till representationen.
- [ ] Verifiera disseminations-kort (om AIP har sådana) — samma layout och klickbarhet.
- [ ] Verifiera att andra ThumbnailCard-vyer (om någon finns) fortfarande har default-beteende (titel togglar collapse).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsnoteringar

* **Nya funktioner**
  * Hela kort kan nu klickas för att aktivera åtgärder (tangentbordsstöd för ENTER/SPACE).

* **Stil**
  * Uppdaterad layoutstruktur för kort med förbättrad responsivitet på mindre skärmar.
  * Förbättrad rendering av kortattribut.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->