### PR TITLE
docs: add WIP disclaimer to original-mets and hide help links

### DIFF
--- a/documentation/administration/original-mets.md
+++ b/documentation/administration/original-mets.md
@@ -1,6 +1,9 @@
 
 # **Original-METS**
 
+> **⚠️ Work in progress**
+> This feature is currently under development and may change. Do not rely on this documentation as final.
+
 ## **Functionality**
 
   - When a logical AIP is created, a METS file will also be created.

--- a/documentation/administration/original-mets_sv_SE.md
+++ b/documentation/administration/original-mets_sv_SE.md
@@ -1,6 +1,9 @@
 
 # **Original-METS**
 
+> **⚠️ Under utveckling**
+> Denna funktion är under aktiv utveckling och kan komma att förändras. Betrakta inte denna dokumentation som slutgiltig.
+
 ## **Funktionalitet**
 
   - När man skapar en logisk AIP kommer även en METS fil att skapas.

--- a/documentation/reference/Help.md
+++ b/documentation/reference/Help.md
@@ -42,7 +42,7 @@ Guides for system administrators and archive managers.
 - **[Disposal](administration/Disposal.md)** - Processes for data management
 - **[Permissions](administration/Permissions.md)** - Managing user permissions
 - **[Risk Assessment](administration/Risk_Assessment.md)** - Evaluation of archiving risks
-- **[Original-METS](administration/original-mets.md)** - Handles METS files
+<!-- - **[Original-METS](administration/original-mets.md)** - Handles METS files -->
 
 ### Developer Resources
 

--- a/documentation/reference/Help_sv_SE.md
+++ b/documentation/reference/Help_sv_SE.md
@@ -42,7 +42,7 @@ Guider för systemadministratörer och ansvariga för arkivet.
 - **[Gallring](administration/Disposal_sv_SE.md)** - Processer för datahantering
 - **[Behörigheter](administration/Permissions_sv_SE.md)** - Hantering av användarbehörigheter
 - **[Riskbedömning](administration/Risk_Assessment_sv_SE.md)** - Utvärdering av arkiveringsrisker
-- **[Original-METS](administration/original-mets_sv_SE.md)** - Hanterar METS filer
+<!-- - **[Original-METS](administration/original-mets_sv_SE.md)** - Hanterar METS filer -->
 
 ### Utvecklarresurser
 


### PR DESCRIPTION
## Summary

- Added a work-in-progress disclaimer at the top of `original-mets.md` and `original-mets_sv_SE.md` to signal that the feature is still under development.
- Commented out the Original-METS links in `Help.md` and `Help_sv_SE.md` so the feature is not exposed in the help navigation until it is ready.

## Test Plan
- [x] Verify that the disclaimer renders correctly in documentation viewer
- [x] Verify that Original-METS links are no longer visible in the help pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Versionsfakta

* **Dokumentation**
  * Varningsmeddelanden tillagda för att informera om att Original-METS-funktionen är under utveckling och dokumentationen kan komma att förändras
  * Original-METS-referensen har tillfälligt dölts från hjälpsektionen under utvecklingsfasen

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->