### PR TITLE
feat(i18n): add Swedish translations for set password screen

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1306,11 +1306,13 @@ recoverLoginSuccessDialogMessage:Om det här användarnamnet eller e-postadresse
 recoverLoginSuccessDialogButton:Ok
 # Reset Password
 resetPasswordTitle:Återställ lösenord
+setPasswordTitle:Ange lösenord
 resetPasswordUsername:Användarnamn
 resetPasswordToken:Lösenord för verifiering
 resetPasswordNewPassword:Nytt lösenord
 resetPasswordRepeatPassword:Bekräfta lösenord
 resetPasswordSubmit:ÄNDRA
+setPasswordSubmit:ANGE
 resetPasswordCancel:Avbryt
 resetPasswordInvalidToken:Återställningslösenordet är ogiltigt. Kontrollera att du har angett rätt lösenord eller be om ett nytt.
 resetPasswordNoSuchUser:Användarnamnet finns inte. Vänligen kontrollera om du har angett rätt användarnamn.


### PR DESCRIPTION
closes #534 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Lokalisering**
  * Lade till svenska översättningar för lösenordsflödet, inklusive titel och knapptext.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->