### PR TITLE
feat: add COOP/COEP headers for cross-origin isolation

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/SecurityHeadersFilter.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/filter/SecurityHeadersFilter.java
@@ -77,6 +77,17 @@ public class SecurityHeadersFilter implements Filter {
       httpServletResponse.setHeader("Service-Worker-Allowed", REPLAY_SW_ALLOWED_SCOPE);
     }
 
+    // Cross-origin isolation for SharedArrayBuffer support (required by ReplayWeb.page in Firefox).
+    // COOP is safe globally since CAS auth uses redirects, not popups.
+    // COEP uses "require-corp" on replay paths (all resources are same-origin) and
+    // "credentialless" elsewhere so third-party scripts (Google Analytics) are not blocked.
+    httpServletResponse.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    if (requestPath.startsWith(replayPathPrefix) || requestPath.equals(replayViewerPath)) {
+      httpServletResponse.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+    } else {
+      httpServletResponse.setHeader("Cross-Origin-Embedder-Policy", "credentialless");
+    }
+
     httpServletResponse.setHeader("X-XSS-Protection", "1; mode=block");
     httpServletResponse.setHeader("X-Permitted-Cross-Domain-Policies", "none");
     httpServletResponse.setHeader("Feature-Policy", "camera 'none'; fullscreen 'self'; geolocation *; " + "microphone 'self'");


### PR DESCRIPTION
Enable SharedArrayBuffer support required by ReplayWeb.page in Firefox. Use require-corp on replay paths and credentialless elsewhere to avoid blocking third-party scripts like Google Analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Förbättrad säkerhet genom implementering av moderna isoleringsmekanismer på alla HTTP-förfrågningar. Detta skyddar användarsessioner och förhindrar obehörig åtkomst från externa webbplatser genom tillämpning av striktare ursprungskontroll.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->