### PR TITLE
fix(catalog-tree): exclude destroyed AIPs from catalog tree panel

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -173,7 +173,7 @@ public class CatalogTreePanel extends Composite {
       new Filter(
         new EmptyKeyFilterParameter(RodaConstants.AIP_PARENT_ID),
         new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
-      false)
+      true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
@@ -223,7 +223,7 @@ public class CatalogTreePanel extends Composite {
   private void loadSupplementaryGhostRoots(Set<String> accessibleRootIds, int myGeneration) {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
-      false)
+      true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();
@@ -328,7 +328,7 @@ public class CatalogTreePanel extends Composite {
     rootsLoading = true;
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
-      false)
+      true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
       .build();


### PR DESCRIPTION
## Problem
Gallrade objekt (AIP:er med tillståndet `DESTROYED`) visades i katalogträdet i sidopanelen, trots att de inte ska vara synliga för användare.

## Rotorsak
De tre Solr-sökningarna i `CatalogTreePanel` använde `onlyActive = false`, vilket innebar att inga begränsningar gjordes på AIP-tillstånd. Den vanliga AIP-listan i `BrowseTop` filtrerar korrekt med `onlyActive = true` (genererar Solr-filtret `state:active`), men katalogträdet saknade motsvarande filter.

## Fix
Ändrade `onlyActive = false` → `true` i de tre `FindRequest`-builders i `CatalogTreePanel`:
- `loadRootNodes()`
- `loadSupplementaryGhostRoots()`
- `loadFallbackGhostTree()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Utgåvor

* **Bugfixar**
  * Förbättrad hantering av katalogträdets laddning av rotöver vid initialisering och uppdatering av trädstrukturen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ETERNA-earkiv/ETERNA/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->