### PR TITLE
feat(storage): konfigurerbar papperskorg i FileStorageService

### DIFF
--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
@@ -17,8 +17,12 @@ import java.nio.file.attribute.BasicFileAttributes;
 import org.roda.core.TestsHelper;
 import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.RODAException;
+import org.roda.core.data.v2.ip.StoragePath;
 import org.roda.core.storage.AbstractStorageServiceTest;
+import org.roda.core.storage.ContentPayload;
+import org.roda.core.storage.DefaultStoragePath;
 import org.roda.core.storage.StorageService;
+import org.roda.core.storage.StringContentPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -143,5 +147,37 @@ public class FileStorageServiceTest extends AbstractStorageServiceTest<FileStora
   // TODO test get binary while IO Error occurs
   // TODO test create binary as reference while IO Error occurs
   // TODO test update binary while IO Error occurs
+
+  @Test
+  public void testDeleteResourcePermanentlyWhenTrashDisabled() throws RODAException, IOException {
+    Path basePath2 = TestsHelper.createBaseTempDir(FileStorageServiceTest.class, true);
+    try {
+      // Given: storage with trash disabled (trashEnabled=false, createTrash=false)
+      // createTrash=false prevents the trash directory from being created at init
+      FileStorageService storageNoTrash = new FileStorageService(basePath2, false, false, "trash", true);
+
+      StoragePath containerPath = DefaultStoragePath.parse("testContainer");
+      storageNoTrash.createContainer(containerPath);
+
+      StoragePath resourcePath = DefaultStoragePath.parse("testContainer", "testFile.txt");
+      ContentPayload payload = new StringContentPayload("test content");
+      storageNoTrash.createBinary(resourcePath, payload, false);
+      Assert.assertTrue(storageNoTrash.exists(resourcePath), "Resource should exist before deletion");
+
+      // When: delete the resource
+      storageNoTrash.deleteResource(resourcePath);
+
+      // Then: resource should be permanently deleted
+      Assert.assertFalse(storageNoTrash.exists(resourcePath), "Resource should be gone after deletion");
+
+      // And: trash directory should not have been created
+      Path trashDir = basePath2.getParent().resolve("trash");
+      Assert.assertFalse(Files.exists(trashDir),
+        "Trash directory should not exist when trash is disabled");
+    } finally {
+      FSUtils.deletePath(basePath2);
+      FSUtils.deletePathQuietly(basePath2.getParent().resolve("trash"));
+    }
+  }
 
 }

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/fs/FileStorageServiceTest.java
@@ -151,10 +151,11 @@ public class FileStorageServiceTest extends AbstractStorageServiceTest<FileStora
   @Test
   public void testDeleteResourcePermanentlyWhenTrashDisabled() throws RODAException, IOException {
     Path basePath2 = TestsHelper.createBaseTempDir(FileStorageServiceTest.class, true);
+    String uniqueTrashName = "trash-" + basePath2.getFileName();
     try {
       // Given: storage with trash disabled (trashEnabled=false, createTrash=false)
       // createTrash=false prevents the trash directory from being created at init
-      FileStorageService storageNoTrash = new FileStorageService(basePath2, false, false, "trash", true);
+      FileStorageService storageNoTrash = new FileStorageService(basePath2, false, false, uniqueTrashName, true);
 
       StoragePath containerPath = DefaultStoragePath.parse("testContainer");
       storageNoTrash.createContainer(containerPath);
@@ -171,12 +172,12 @@ public class FileStorageServiceTest extends AbstractStorageServiceTest<FileStora
       Assert.assertFalse(storageNoTrash.exists(resourcePath), "Resource should be gone after deletion");
 
       // And: trash directory should not have been created
-      Path trashDir = basePath2.getParent().resolve("trash");
+      Path trashDir = basePath2.getParent().resolve(uniqueTrashName);
       Assert.assertFalse(Files.exists(trashDir),
         "Trash directory should not exist when trash is disabled");
     } finally {
       FSUtils.deletePath(basePath2);
-      FSUtils.deletePathQuietly(basePath2.getParent().resolve("trash"));
+      FSUtils.deletePathQuietly(basePath2.getParent().resolve(uniqueTrashName));
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -884,14 +884,17 @@ public class RodaCoreFactory {
     if (StringUtils.isNotBlank(newStorageService)) {
       try {
         Class<?> storageClass = Class.forName(newStorageService);
-        Constructor<?> constructor = storageClass.getConstructor(Path.class, String.class);
+        Constructor<?> constructor = storageClass.getConstructor(Path.class, boolean.class, boolean.class,
+          String.class, boolean.class);
 
         LOGGER.debug("Going to instantiate '{}' on '{}'", storageClass.getSimpleName(),
           configurationManager.getStoragePath());
         String trashDirName = getRodaConfiguration().getString("core.storage.filesystem.trash",
           RodaConstants.TRASH_CONTAINER);
+        boolean trashEnabled = getRodaConfiguration().getBoolean("core.storage.filesystem.trash.enabled", true);
 
-        return (StorageService) constructor.newInstance(configurationManager.getStoragePath(), trashDirName);
+        return (StorageService) constructor.newInstance(configurationManager.getStoragePath(), trashEnabled,
+          true, trashDirName, true);
       } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException
         | InvocationTargetException e) {
         LOGGER.warn("Error instantiating storage service defined on properties, falling back to a default service", e);
@@ -904,7 +907,9 @@ public class RodaCoreFactory {
       LOGGER.debug("Going to instantiate Filesystem on '{}'", configurationManager.getStoragePath());
       String trashDirName = getRodaConfiguration().getString("core.storage.filesystem.trash",
         RodaConstants.TRASH_CONTAINER);
-      StorageService fileStorageService = new FileStorageService(configurationManager.getStoragePath(), trashDirName);
+      boolean trashEnabled = getRodaConfiguration().getBoolean("core.storage.filesystem.trash.enabled", true);
+      StorageService fileStorageService = new FileStorageService(configurationManager.getStoragePath(), trashEnabled,
+        true, trashDirName, true);
       return fileStorageService;
     } else {
       LOGGER.error("Unknown storage service '{}'", storageType.name());

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -902,12 +902,14 @@ public class RodaCoreFactory {
         try {
           return (StorageService) storageClass
             .getConstructor(Path.class, boolean.class, String.class, boolean.class)
-            .newInstance(storagePath, true, trashDirName, true);
+            .newInstance(storagePath, trashEnabled, trashDirName, true);
         } catch (NoSuchMethodException ignored) {
           // fall through to older signatures
         }
-        // Try 2-arg: (Path, String trashDirName)
+        // Try 2-arg: (Path, String trashDirName) — no trash flag; warn that trashEnabled is ignored
         try {
+          LOGGER.warn("Custom storage '{}' has no trashEnabled constructor; configured trashEnabled={} will be ignored",
+            storageClass.getSimpleName(), trashEnabled);
           return (StorageService) storageClass
             .getConstructor(Path.class, String.class)
             .newInstance(storagePath, trashDirName);

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -884,19 +884,39 @@ public class RodaCoreFactory {
     if (StringUtils.isNotBlank(newStorageService)) {
       try {
         Class<?> storageClass = Class.forName(newStorageService);
-        Constructor<?> constructor = storageClass.getConstructor(Path.class, boolean.class, boolean.class,
-          String.class, boolean.class);
-
-        LOGGER.debug("Going to instantiate '{}' on '{}'", storageClass.getSimpleName(),
-          configurationManager.getStoragePath());
         String trashDirName = getRodaConfiguration().getString("core.storage.filesystem.trash",
           RodaConstants.TRASH_CONTAINER);
         boolean trashEnabled = getRodaConfiguration().getBoolean("core.storage.filesystem.trash.enabled", true);
+        Path storagePath = configurationManager.getStoragePath();
+        LOGGER.debug("Going to instantiate '{}' on '{}'", storageClass.getSimpleName(), storagePath);
 
-        return (StorageService) constructor.newInstance(configurationManager.getStoragePath(), trashEnabled,
-          true, trashDirName, true);
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException
-        | InvocationTargetException e) {
+        // Try 5-arg: (Path, boolean trashEnabled, boolean createTrash, String trashDirName, boolean createHistory)
+        try {
+          return (StorageService) storageClass
+            .getConstructor(Path.class, boolean.class, boolean.class, String.class, boolean.class)
+            .newInstance(storagePath, trashEnabled, true, trashDirName, true);
+        } catch (NoSuchMethodException ignored) {
+          // fall through to older signatures
+        }
+        // Try 4-arg: (Path, boolean createTrash, String trashDirName, boolean createHistory)
+        try {
+          return (StorageService) storageClass
+            .getConstructor(Path.class, boolean.class, String.class, boolean.class)
+            .newInstance(storagePath, true, trashDirName, true);
+        } catch (NoSuchMethodException ignored) {
+          // fall through to older signatures
+        }
+        // Try 2-arg: (Path, String trashDirName)
+        try {
+          return (StorageService) storageClass
+            .getConstructor(Path.class, String.class)
+            .newInstance(storagePath, trashDirName);
+        } catch (NoSuchMethodException ignored) {
+          // fall through
+        }
+        LOGGER.warn("No compatible constructor found for '{}', falling back to a default service",
+          storageClass.getSimpleName());
+      } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
         LOGGER.warn("Error instantiating storage service defined on properties, falling back to a default service", e);
       }
     }

--- a/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/RodaCoreFactory.java
@@ -900,9 +900,14 @@ public class RodaCoreFactory {
         }
         // Try 4-arg: (Path, boolean createTrash, String trashDirName, boolean createHistory)
         try {
+          if (!trashEnabled) {
+            LOGGER.warn(
+              "Custom storage '{}' has no trashEnabled constructor; configured trashEnabled=false will be ignored",
+              storageClass.getSimpleName());
+          }
           return (StorageService) storageClass
             .getConstructor(Path.class, boolean.class, String.class, boolean.class)
-            .newInstance(storagePath, trashEnabled, trashDirName, true);
+            .newInstance(storagePath, true, trashDirName, true);
         } catch (NoSuchMethodException ignored) {
           // fall through to older signatures
         }

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
@@ -91,10 +91,12 @@ public class FileStorageService implements StorageService {
   private final Path historyDataPath;
   private final Path historyMetadataPath;
   private final Path trashPath;
+  private final boolean trashEnabled;
 
-  public FileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
-    throws GenericException {
+  public FileStorageService(Path basePath, boolean trashEnabled, boolean createTrash, String trashDirName,
+    boolean createHistory) throws GenericException {
     this.basePath = basePath;
+    this.trashEnabled = trashEnabled;
     rodaDataPath = this.basePath.getParent();
     historyPath = rodaDataPath.resolve(basePath.getFileName() + HISTORY_SUFFIX);
     historyDataPath = historyPath.resolve(HISTORY_DATA_FOLDER);
@@ -110,7 +112,11 @@ public class FileStorageService implements StorageService {
     if (createTrash) {
       initialize(trashPath);
     }
+  }
 
+  public FileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
+    throws GenericException {
+    this(basePath, true, createTrash, trashDirName, createHistory);
   }
 
   public FileStorageService(Path basePath, String trashDirName) throws GenericException {
@@ -208,6 +214,11 @@ public class FileStorageService implements StorageService {
   }
 
   private void trash(Path fromPath) throws GenericException, NotFoundException {
+    if (!trashEnabled) {
+      LOGGER.debug("Trash disabled, permanently deleting '{}'", fromPath);
+      FSUtils.deletePath(fromPath);
+      return;
+    }
     if (trashPath == null) {
       LOGGER.warn("Skipping trash '{}' because no trash folder is defined!", fromPath);
       return;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
@@ -74,6 +74,13 @@ import org.slf4j.LoggerFactory;
  * them to a 'trash' folder with the same folder structure
  * </p>
  *
+ * <p>
+ * 20260527 WhiteRed: trash behaviour is configurable via
+ * {@code core.storage.filesystem.trash.enabled} in {@code roda-core.properties}.
+ * When set to {@code false}, delete operations permanently remove files instead
+ * of moving them to the trash folder.
+ * </p>
+ *
  * @author Luis Faria <lfaria@keep.pt>
  * @author Hélder Silva <hsilva@keep.pt>
  */

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
@@ -100,6 +100,20 @@ public class FileStorageService implements StorageService {
   private final Path trashPath;
   private final boolean trashEnabled;
 
+  /**
+   * Creates a new FileStorageService with full control over trash and history initialisation.
+   *
+   * <p>Sets {@code rodaDataPath} to {@code basePath.getParent()}, resolves history paths under
+   * {@code <baseName>-history/} and the trash path as {@code rodaDataPath/<trashDirName>}.
+   *
+   * @param basePath      root storage directory; its parent must be writable when the directory does not yet exist
+   * @param trashEnabled  when {@code false} deleted resources are permanently removed rather than moved to trash
+   * @param createTrash   whether to create (and initialise) the trash directory during construction
+   * @param trashDirName  name of the trash directory relative to {@code basePath}'s parent; falls back to
+   *                      {@link org.roda.core.data.common.RodaConstants#TRASH_CONTAINER} when {@code null}
+   * @param createHistory whether to create the AIP history directory tree ({@code data/} and {@code metadata/}) during construction
+   * @throws GenericException if a required directory cannot be created
+   */
   public FileStorageService(Path basePath, boolean trashEnabled, boolean createTrash, String trashDirName,
     boolean createHistory) throws GenericException {
     this.basePath = basePath;
@@ -121,6 +135,17 @@ public class FileStorageService implements StorageService {
     }
   }
 
+  /**
+   * Convenience constructor that defaults {@code trashEnabled} to {@code true}.
+   *
+   * @param basePath      root storage directory
+   * @param createTrash   whether to create the trash directory during construction
+   * @param trashDirName  name of the trash directory; falls back to
+   *                      {@link org.roda.core.data.common.RodaConstants#TRASH_CONTAINER} when {@code null}
+   * @param createHistory whether to create the AIP history directory tree during construction
+   * @throws GenericException if a required directory cannot be created
+   * @see #FileStorageService(Path, boolean, boolean, String, boolean)
+   */
   public FileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
     throws GenericException {
     this(basePath, true, createTrash, trashDirName, createHistory);

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
@@ -78,12 +78,14 @@ public class ScatteredFileStorageService extends FileStorageService  {
   private final Path historyDataPath;
   private final Path historyMetadataPath;
   private final Path trashPath;
+  private final boolean trashEnabled;
 
-  public ScatteredFileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
-          throws GenericException {
-    super(basePath, createTrash, trashDirName, createHistory);
+  public ScatteredFileStorageService(Path basePath, boolean trashEnabled, boolean createTrash, String trashDirName,
+    boolean createHistory) throws GenericException {
+    super(basePath, trashEnabled, createTrash, trashDirName, createHistory);
 
     this.basePath = basePath;
+    this.trashEnabled = trashEnabled;
     rodaDataPath = this.basePath.getParent();
     Path historyPath = rodaDataPath.resolve(basePath.getFileName() + HISTORY_SUFFIX);
     historyDataPath = historyPath.resolve(HISTORY_DATA_FOLDER);
@@ -96,6 +98,11 @@ public class ScatteredFileStorageService extends FileStorageService  {
       LOGGER.error("Error! Could not initialize scattered fs.");
       throw exception;
     }
+  }
+
+  public ScatteredFileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
+    throws GenericException {
+    this(basePath, true, createTrash, trashDirName, createHistory);
   }
 
   public ScatteredFileStorageService(Path basePath, String trashDirName) throws GenericException {
@@ -171,6 +178,11 @@ public class ScatteredFileStorageService extends FileStorageService  {
   }
 
   private void trash(Path fromPath) throws GenericException, NotFoundException {
+    if (!trashEnabled) {
+      LOGGER.debug("Trash disabled, permanently deleting '{}'", fromPath);
+      FSUtils.deletePath(fromPath);
+      return;
+    }
     if (trashPath == null) {
       LOGGER.warn("Skipping trash '{}' because no trash folder is defined!", fromPath);
       return;

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/scatteredfs/ScatteredFileStorageService.java
@@ -80,6 +80,20 @@ public class ScatteredFileStorageService extends FileStorageService  {
   private final Path trashPath;
   private final boolean trashEnabled;
 
+  /**
+   * Creates a new ScatteredFileStorageService with full control over trash and history initialisation.
+   *
+   * <p>Delegates path setup to the parent {@link FileStorageService} constructor and then calls
+   * {@link ScatteredFSUtils#initialize()} to prepare the scattered-filesystem layer.
+   *
+   * @param basePath      root storage directory
+   * @param trashEnabled  when {@code false} deleted resources are permanently removed rather than moved to trash
+   * @param createTrash   whether to create the trash directory during construction
+   * @param trashDirName  name of the trash directory relative to {@code basePath}'s parent; falls back to
+   *                      {@link org.roda.core.data.common.RodaConstants#TRASH_CONTAINER} when {@code null}
+   * @param createHistory whether to create the AIP history directory tree during construction
+   * @throws GenericException if a required directory cannot be created or {@link ScatteredFSUtils#initialize()} fails
+   */
   public ScatteredFileStorageService(Path basePath, boolean trashEnabled, boolean createTrash, String trashDirName,
     boolean createHistory) throws GenericException {
     super(basePath, trashEnabled, createTrash, trashDirName, createHistory);
@@ -100,6 +114,17 @@ public class ScatteredFileStorageService extends FileStorageService  {
     }
   }
 
+  /**
+   * Convenience constructor that defaults {@code trashEnabled} to {@code true}.
+   *
+   * @param basePath      root storage directory
+   * @param createTrash   whether to create the trash directory during construction
+   * @param trashDirName  name of the trash directory; falls back to
+   *                      {@link org.roda.core.data.common.RodaConstants#TRASH_CONTAINER} when {@code null}
+   * @param createHistory whether to create the AIP history directory tree during construction
+   * @throws GenericException if a required directory cannot be created or {@link ScatteredFSUtils#initialize()} fails
+   * @see #ScatteredFileStorageService(Path, boolean, boolean, String, boolean)
+   */
   public ScatteredFileStorageService(Path basePath, boolean createTrash, String trashDirName, boolean createHistory)
     throws GenericException {
     this(basePath, true, createTrash, trashDirName, createHistory);

--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -83,6 +83,9 @@ core.api.basicAuth.whitelist[] = admin
 ##########################################################################
 core.storage.type=FILESYSTEM
 #core.storage.filesystem.trash = trash
+# When set to false, deleted objects are permanently removed instead of moved to the trash folder.
+# Status: in use
+#core.storage.filesystem.trash.enabled = true
 #core.storage.new_service = org.roda.core.storage.scatteredfs.ScatteredFileStorageService
 #core.storage.filesystem = aip
 #core.storage.filesystem.aip.scatter_method = ranges


### PR DESCRIPTION
## Sammanfattning

- Lägger till konfigurationsnyckel `core.storage.filesystem.trash.enabled` (standardvärde: `true`)
- När den sätts till `false` raderas filer permanent vid borttagning istället för att flyttas till papperskorgen
- Bakåtkompatibel – befintligt beteende bevaras om inget konfigureras

## Ändringar

- `roda-core.properties` – ny dokumenterad konfigurationsnyckel
- `FileStorageService` – ny 5-argument konstruktor med separat `trashEnabled`-parameter; `trash()` anropar `FSUtils.deletePath()` när flaggan är inaktiverad
- `ScatteredFileStorageService` – samma ändringar (har en egen kopia av `trash()`)
- `RodaCoreFactory` – läser `trash.enabled` från konfigurationen och skickar vidare till både direktanrop och reflection-baserad instansiering
- `FileStorageServiceTest` – nytt test `testDeleteResourcePermanentlyWhenTrashDisabled`

## Notering

`trashEnabled`-flaggan hålls avsiktligt separat från den befintliga `createTrash`-parametern för att bevara dess ursprungliga semantik (kataloginitiering vid uppstart).

Gallringsflödet (`DestroyRecordsPlugin`, `PermanentlyDeleteRecordsPlugin`) påverkas inte avseende revisionsspår – gallrade AIP:er kvarstår i Solr-indexet med tillståndet `DESTROYED` oavsett denna inställning.

Closes #570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Konfigurabel radering: Administratörer kan nu styra om borttagna objekt permanent raderas eller flyttas till en trash-mapp via en ny konfigurationsinställning (kommenterad i konfigurationsfilen). Inställningen styr filesystem-baserade lagringstyper och tillämpas konsistent vid initiering.
* **Tests**
  * Ny enhetstest som verifierar att resurser tas bort permanent när trash är inaktiverat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->