### PR TITLE
feat: utöka export-modulen till att täcka alla entitetstyper (#519)

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -42,6 +42,7 @@ import org.roda.core.data.v2.LiteOptionalWithCause;
 import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.jobs.IndexedJob;
 import org.roda.core.data.v2.jobs.IndexedReport;
 import org.roda.core.data.v2.jobs.Job;
@@ -50,6 +51,7 @@ import org.roda.core.data.v2.log.LogEntry;
 import org.roda.core.data.v2.jobs.PluginParameter.PluginParameterType;
 import org.roda.core.data.v2.jobs.PluginType;
 import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.data.v2.user.RODAMember;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.index.IndexService;
 import org.roda.core.index.utils.IterableIndexResult;
@@ -162,7 +164,7 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getDescription() {
-    return "Exports search results to a CSV file. Supports AIP, job, report, and log entry lists. The result is available as a job attachment in Internal Actions.";
+    return "Exports search results to a CSV file. Supports AIP, job, report, log entry, transferred resource, and member lists. The result is available as a job attachment in Internal Actions.";
   }
 
   @Override
@@ -287,6 +289,22 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
             exportFields)) {
             for (LogEntry entry : results) {
               printer.printRecord(buildCsvRowLogEntry(entry, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ip.TransferredResource":
+          try (IterableIndexResult<TransferredResource> results = index.findAll(TransferredResource.class, filter,
+            user, true, exportFields)) {
+            for (TransferredResource resource : results) {
+              printer.printRecord(buildCsvRowTransferredResource(resource, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.user.RODAMember":
+          try (IterableIndexResult<RODAMember> results = index.findAll(RODAMember.class, filter, user, true,
+            exportFields)) {
+            for (RODAMember member : results) {
+              printer.printRecord(buildCsvRowMember(member, exportFields));
             }
           }
           break;
@@ -469,6 +487,49 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  public static List<String> buildCsvRowTransferredResource(TransferredResource resource, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueTransferredResource(resource, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueTransferredResource(TransferredResource resource, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "uuid": return nullToEmpty(resource.getUUID());
+      case "name": return nullToEmpty(resource.getName());
+      case "fullPath": return nullToEmpty(resource.getFullPath());
+      case "relativePath": return nullToEmpty(resource.getRelativePath());
+      case "size": return String.valueOf(resource.getSize());
+      case "creationDate": return formatDateTime(resource.getCreationDate());
+      case "file": return resource.isFile() ? "Ja" : "Nej";
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowMember(RODAMember member, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueMember(member, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueMember(RODAMember member, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(member.getId());
+      case "name": return nullToEmpty(member.getName());
+      case "fullName": return nullToEmpty(member.getFullName());
+      case "active": return member.isActive() ? "Ja" : "Nej";
+      case "directRoles":
+        return member.getDirectRoles() != null ? String.join("; ", member.getDirectRoles()) : "";
+      default: return "";
+    }
+  }
+
   private static String nullToEmpty(String s) {
     return s != null ? s : "";
   }
@@ -488,6 +549,8 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
       case "org.roda.core.data.v2.jobs.IndexedJob": return "ui.export.job";
       case "org.roda.core.data.v2.jobs.IndexedReport": return "ui.export.report";
       case "org.roda.core.data.v2.log.LogEntry": return "ui.export.logentry";
+      case "org.roda.core.data.v2.ip.TransferredResource": return "ui.export.transferredresource";
+      case "org.roda.core.data.v2.user.RODAMember": return "ui.export.member";
       default: return null;
     }
   }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -174,7 +174,7 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
 
   @Override
   public String getDescription() {
-    return "Exports search results to a CSV file. Supports AIP, job, report, log entry, transferred resource, and member lists. The result is available as a job attachment in Internal Actions.";
+    return "Exports search results to a CSV file for all major entity types. The result is available as a job attachment in Internal Actions.";
   }
 
   @Override
@@ -745,10 +745,14 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     if (field == null) return "";
     switch (field.trim()) {
       case "uuid": return nullToEmpty(rep.getUUID());
+      case "aipId": return nullToEmpty(rep.getAipId());
+      case "type": return nullToEmpty(rep.getType());
       case "title": return nullToEmpty(rep.getTitle());
       case "sizeInBytes": return String.valueOf(rep.getSizeInBytes());
       case "numberOfDataFiles": return String.valueOf(rep.getNumberOfDataFiles());
       case "numberOfDataFolders": return String.valueOf(rep.getNumberOfDataFolders());
+      case "createdOn": return rep.getCreatedOn() != null ? rep.getCreatedOn().toString() : "";
+      case "updatedOn": return rep.getUpdatedOn() != null ? rep.getUpdatedOn().toString() : "";
       default: return "";
     }
   }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -577,6 +577,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for a {@link TransferredResource} using the specified fields.
+   *
+   * @param resource the transferred resource to export
+   * @param fields   ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowTransferredResource(TransferredResource resource, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -599,6 +606,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for a {@link RODAMember} (user or group) using the specified fields.
+   *
+   * @param member the RODA member to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowMember(RODAMember member, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -620,6 +634,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedDIP} using the specified fields.
+   *
+   * @param dip    the indexed DIP to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowDIP(IndexedDIP dip, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -641,6 +662,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedRisk} using the specified fields.
+   *
+   * @param risk   the indexed risk to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowRisk(IndexedRisk risk, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -667,6 +695,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for a {@link RiskIncidence} using the specified fields.
+   *
+   * @param incidence the risk incidence to export
+   * @param fields    ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowRiskIncidence(RiskIncidence incidence, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -691,6 +726,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedRepresentation} using the specified fields.
+   *
+   * @param rep    the indexed representation to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowRepresentation(IndexedRepresentation rep, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -711,6 +753,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedPreservationEvent} using the specified fields.
+   *
+   * @param event  the indexed preservation event to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowPreservationEvent(IndexedPreservationEvent event, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -732,6 +781,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedPreservationAgent} using the specified fields.
+   *
+   * @param agent  the indexed preservation agent to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowPreservationAgent(IndexedPreservationAgent agent, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -752,6 +808,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for a {@link Notification} using the specified fields.
+   *
+   * @param notification the notification to export
+   * @param fields       ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowNotification(Notification notification, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -774,6 +837,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for a {@link DisposalConfirmation} using the specified fields.
+   *
+   * @param confirmation the disposal confirmation to export
+   * @param fields       ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowDisposalConfirmation(DisposalConfirmation confirmation, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -797,6 +867,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  /**
+   * Builds a CSV row for an {@link IndexedFile} using the specified fields.
+   *
+   * @param file   the indexed file to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowFile(IndexedFile file, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {
@@ -805,6 +882,13 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     return row;
   }
 
+  /**
+   * Builds a CSV row for a {@link RepresentationInformation} using the specified fields.
+   *
+   * @param ri     the representation information entry to export
+   * @param fields ordered list of field names to include in the row
+   * @return ordered list of string values forming one CSV row
+   */
   public static List<String> buildCsvRowRepresentationInformation(RepresentationInformation ri, List<String> fields) {
     List<String> row = new ArrayList<>();
     for (String field : fields) {

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -50,6 +50,7 @@ import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent;
 import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
 import org.roda.core.data.v2.notifications.Notification;
+import org.roda.core.data.v2.ri.RepresentationInformation;
 import org.roda.core.data.v2.risks.IndexedRisk;
 import org.roda.core.data.v2.risks.RiskIncidence;
 import org.roda.core.data.v2.jobs.IndexedJob;
@@ -386,6 +387,14 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
             exportFields)) {
             for (IndexedFile file : results) {
               printer.printRecord(buildCsvRowFile(file, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ri.RepresentationInformation":
+          try (IterableIndexResult<RepresentationInformation> results = index.findAll(RepresentationInformation.class,
+            filter, user, true, exportFields)) {
+            for (RepresentationInformation ri : results) {
+              printer.printRecord(buildCsvRowRepresentationInformation(ri, exportFields));
             }
           }
           break;
@@ -796,6 +805,29 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     return row;
   }
 
+  public static List<String> buildCsvRowRepresentationInformation(RepresentationInformation ri, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueRepresentationInformation(ri, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueRepresentationInformation(RepresentationInformation ri, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(ri.getId());
+      case "name": return nullToEmpty(ri.getName());
+      case "description": return nullToEmpty(ri.getDescription());
+      case "family": return nullToEmpty(ri.getFamily());
+      case "tags": return ri.getTags() != null ? String.join("; ", ri.getTags()) : "";
+      case "support": return ri.getSupport() != null ? ri.getSupport().toString() : "";
+      case "createdOn": return formatDateTime(ri.getCreatedOn());
+      case "updatedOn": return formatDateTime(ri.getUpdatedOn());
+      default: return "";
+    }
+  }
+
   private static String getFieldValueFile(IndexedFile file, String field) {
     if (field == null) return "";
     switch (field.trim()) {
@@ -840,6 +872,7 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
       case "org.roda.core.data.v2.notifications.Notification": return "ui.export.notification";
       case "org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation": return "ui.export.disposalconfirmation";
       case "org.roda.core.data.v2.ip.IndexedFile": return "ui.export.file";
+      case "org.roda.core.data.v2.ri.RepresentationInformation": return "ui.export.representationinformation";
       default: return null;
     }
   }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/SearchExportPlugin.java
@@ -41,8 +41,17 @@ import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
 import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation;
 import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.ip.IndexedDIP;
+import org.roda.core.data.v2.ip.IndexedFile;
+import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.TransferredResource;
+import org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent;
+import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
+import org.roda.core.data.v2.notifications.Notification;
+import org.roda.core.data.v2.risks.IndexedRisk;
+import org.roda.core.data.v2.risks.RiskIncidence;
 import org.roda.core.data.v2.jobs.IndexedJob;
 import org.roda.core.data.v2.jobs.IndexedReport;
 import org.roda.core.data.v2.jobs.Job;
@@ -308,6 +317,78 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
             }
           }
           break;
+        case "org.roda.core.data.v2.ip.IndexedDIP":
+          try (IterableIndexResult<IndexedDIP> results = index.findAll(IndexedDIP.class, filter, user, true,
+            exportFields)) {
+            for (IndexedDIP dip : results) {
+              printer.printRecord(buildCsvRowDIP(dip, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.risks.IndexedRisk":
+          try (IterableIndexResult<IndexedRisk> results = index.findAll(IndexedRisk.class, filter, user, true,
+            exportFields)) {
+            for (IndexedRisk risk : results) {
+              printer.printRecord(buildCsvRowRisk(risk, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.risks.RiskIncidence":
+          try (IterableIndexResult<RiskIncidence> results = index.findAll(RiskIncidence.class, filter, user, true,
+            exportFields)) {
+            for (RiskIncidence incidence : results) {
+              printer.printRecord(buildCsvRowRiskIncidence(incidence, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ip.IndexedRepresentation":
+          try (IterableIndexResult<IndexedRepresentation> results = index.findAll(IndexedRepresentation.class, filter,
+            user, true, exportFields)) {
+            for (IndexedRepresentation rep : results) {
+              printer.printRecord(buildCsvRowRepresentation(rep, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent":
+          try (IterableIndexResult<IndexedPreservationEvent> results = index.findAll(IndexedPreservationEvent.class,
+            filter, user, true, exportFields)) {
+            for (IndexedPreservationEvent event : results) {
+              printer.printRecord(buildCsvRowPreservationEvent(event, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent":
+          try (IterableIndexResult<IndexedPreservationAgent> results = index.findAll(IndexedPreservationAgent.class,
+            filter, user, true, exportFields)) {
+            for (IndexedPreservationAgent agent : results) {
+              printer.printRecord(buildCsvRowPreservationAgent(agent, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.notifications.Notification":
+          try (IterableIndexResult<Notification> results = index.findAll(Notification.class, filter, user, true,
+            exportFields)) {
+            for (Notification notification : results) {
+              printer.printRecord(buildCsvRowNotification(notification, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation":
+          try (IterableIndexResult<DisposalConfirmation> results = index.findAll(DisposalConfirmation.class, filter,
+            user, true, exportFields)) {
+            for (DisposalConfirmation confirmation : results) {
+              printer.printRecord(buildCsvRowDisposalConfirmation(confirmation, exportFields));
+            }
+          }
+          break;
+        case "org.roda.core.data.v2.ip.IndexedFile":
+          try (IterableIndexResult<IndexedFile> results = index.findAll(IndexedFile.class, filter, user, true,
+            exportFields)) {
+            for (IndexedFile file : results) {
+              printer.printRecord(buildCsvRowFile(file, exportFields));
+            }
+          }
+          break;
         default:
           try (IterableIndexResult<IndexedAIP> results = index.findAll(IndexedAIP.class, filter, user, true,
             exportFields)) {
@@ -530,6 +611,205 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
     }
   }
 
+  public static List<String> buildCsvRowDIP(IndexedDIP dip, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueDIP(dip, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueDIP(IndexedDIP dip, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(dip.getId());
+      case "title": return nullToEmpty(dip.getTitle());
+      case "description": return nullToEmpty(dip.getDescription());
+      case "type": return nullToEmpty(dip.getType());
+      case "dateCreated": return formatDateTime(dip.getDateCreated());
+      case "lastModified": return formatDateTime(dip.getLastModified());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowRisk(IndexedRisk risk, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueRisk(risk, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueRisk(IndexedRisk risk, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(risk.getId());
+      case "name": return nullToEmpty(risk.getName());
+      case "description": return nullToEmpty(risk.getDescription());
+      case "identifiedOn": return formatDate(risk.getIdentifiedOn());
+      case "identifiedBy": return nullToEmpty(risk.getIdentifiedBy());
+      case "preMitigationSeverityLevel":
+        return risk.getPreMitigationSeverityLevel() != null ? risk.getPreMitigationSeverityLevel().toString() : "";
+      case "postMitigationSeverityLevel":
+        return risk.getPostMitigationSeverityLevel() != null ? risk.getPostMitigationSeverityLevel().toString() : "";
+      case "incidencesCount": return String.valueOf(risk.getIncidencesCount());
+      case "unmitigatedIncidencesCount": return String.valueOf(risk.getUnmitigatedIncidencesCount());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowRiskIncidence(RiskIncidence incidence, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueRiskIncidence(incidence, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueRiskIncidence(RiskIncidence incidence, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(incidence.getId());
+      case "riskId": return nullToEmpty(incidence.getRiskId());
+      case "aipId": return nullToEmpty(incidence.getAipId());
+      case "status": return incidence.getStatus() != null ? incidence.getStatus().toString() : "";
+      case "severity": return incidence.getSeverity() != null ? incidence.getSeverity().toString() : "";
+      case "detectedOn": return formatDateTime(incidence.getDetectedOn());
+      case "detectedBy": return nullToEmpty(incidence.getDetectedBy());
+      case "mitigatedOn": return formatDateTime(incidence.getMitigatedOn());
+      case "mitigatedBy": return nullToEmpty(incidence.getMitigatedBy());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowRepresentation(IndexedRepresentation rep, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueRepresentation(rep, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueRepresentation(IndexedRepresentation rep, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "uuid": return nullToEmpty(rep.getUUID());
+      case "title": return nullToEmpty(rep.getTitle());
+      case "sizeInBytes": return String.valueOf(rep.getSizeInBytes());
+      case "numberOfDataFiles": return String.valueOf(rep.getNumberOfDataFiles());
+      case "numberOfDataFolders": return String.valueOf(rep.getNumberOfDataFolders());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowPreservationEvent(IndexedPreservationEvent event, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValuePreservationEvent(event, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValuePreservationEvent(IndexedPreservationEvent event, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(event.getId());
+      case "aipID": return nullToEmpty(event.getAipID());
+      case "eventDateTime": return formatDateTime(event.getEventDateTime());
+      case "eventType": return nullToEmpty(event.getEventType());
+      case "eventOutcome": return nullToEmpty(event.getEventOutcome());
+      case "eventDetail": return nullToEmpty(event.getEventDetail());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowPreservationAgent(IndexedPreservationAgent agent, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValuePreservationAgent(agent, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValuePreservationAgent(IndexedPreservationAgent agent, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(agent.getId());
+      case "name": return nullToEmpty(agent.getName());
+      case "type": return nullToEmpty(agent.getType());
+      case "version": return nullToEmpty(agent.getVersion());
+      case "createdOn": return formatDateTime(agent.getCreatedOn());
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowNotification(Notification notification, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueNotification(notification, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueNotification(Notification notification, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(notification.getId());
+      case "subject": return nullToEmpty(notification.getSubject());
+      case "sentOn": return formatDateTime(notification.getSentOn());
+      case "fromUser": return nullToEmpty(notification.getFromUser());
+      case "recipientUsers":
+        return notification.getRecipientUsers() != null ? String.join("; ", notification.getRecipientUsers()) : "";
+      case "state": return notification.getState() != null ? notification.getState().toString() : "";
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowDisposalConfirmation(DisposalConfirmation confirmation, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueDisposalConfirmation(confirmation, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueDisposalConfirmation(DisposalConfirmation confirmation, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "id": return nullToEmpty(confirmation.getId());
+      case "title": return nullToEmpty(confirmation.getTitle());
+      case "state": return confirmation.getState() != null ? confirmation.getState().toString() : "";
+      case "createdOn": return formatDateTime(confirmation.getCreatedOn());
+      case "createdBy": return nullToEmpty(confirmation.getCreatedBy());
+      case "executedOn": return formatDateTime(confirmation.getExecutedOn());
+      case "size": return confirmation.getSize() != null ? String.valueOf(confirmation.getSize()) : "";
+      case "numberOfAIPs": return confirmation.getNumberOfAIPs() != null ? String.valueOf(confirmation.getNumberOfAIPs()) : "";
+      default: return "";
+    }
+  }
+
+  public static List<String> buildCsvRowFile(IndexedFile file, List<String> fields) {
+    List<String> row = new ArrayList<>();
+    for (String field : fields) {
+      row.add(getFieldValueFile(file, field));
+    }
+    return row;
+  }
+
+  private static String getFieldValueFile(IndexedFile file, String field) {
+    if (field == null) return "";
+    switch (field.trim()) {
+      case "uuid": return nullToEmpty(file.getUUID());
+      case "id": return nullToEmpty(file.getId());
+      case "aipId": return nullToEmpty(file.getAipId());
+      case "representationId": return nullToEmpty(file.getRepresentationId());
+      case "originalName": return nullToEmpty(file.getOriginalName());
+      case "size": return String.valueOf(file.getSize());
+      case "isDirectory": return file.isDirectory() ? "Ja" : "Nej";
+      default: return "";
+    }
+  }
+
   private static String nullToEmpty(String s) {
     return s != null ? s : "";
   }
@@ -551,6 +831,15 @@ public class SearchExportPlugin extends AbstractPlugin<Void> {
       case "org.roda.core.data.v2.log.LogEntry": return "ui.export.logentry";
       case "org.roda.core.data.v2.ip.TransferredResource": return "ui.export.transferredresource";
       case "org.roda.core.data.v2.user.RODAMember": return "ui.export.member";
+      case "org.roda.core.data.v2.ip.IndexedDIP": return "ui.export.dip";
+      case "org.roda.core.data.v2.risks.IndexedRisk": return "ui.export.risk";
+      case "org.roda.core.data.v2.risks.RiskIncidence": return "ui.export.riskincidence";
+      case "org.roda.core.data.v2.ip.IndexedRepresentation": return "ui.export.representation";
+      case "org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent": return "ui.export.preservationevent";
+      case "org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent": return "ui.export.preservationagent";
+      case "org.roda.core.data.v2.notifications.Notification": return "ui.export.notification";
+      case "org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation": return "ui.export.disposalconfirmation";
+      case "org.roda.core.data.v2.ip.IndexedFile": return "ui.export.file";
       default: return null;
     }
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -34,8 +34,16 @@ import org.roda.core.data.v2.index.select.SelectedItemsList;
 import org.roda.core.data.v2.index.sort.SortParameter;
 import org.roda.core.data.v2.index.sort.Sorter;
 import org.roda.core.data.v2.index.sublist.Sublist;
+import org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation;
 import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.ip.IndexedDIP;
+import org.roda.core.data.v2.ip.IndexedFile;
+import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.TransferredResource;
+import org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent;
+import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
+import org.roda.core.data.v2.risks.IndexedRisk;
+import org.roda.core.data.v2.risks.RiskIncidence;
 import org.roda.core.data.v2.jobs.IndexedJob;
 import org.roda.core.data.v2.jobs.IndexedReport;
 import org.roda.core.data.v2.log.LogEntry;
@@ -417,6 +425,33 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
       } else if (RODAMember.class.equals(clazz)) {
         configKeyPrefix = "ui.export.member";
         exportClass = "org.roda.core.data.v2.user.RODAMember";
+      } else if (IndexedDIP.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.dip";
+        exportClass = "org.roda.core.data.v2.ip.IndexedDIP";
+      } else if (IndexedRisk.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.risk";
+        exportClass = "org.roda.core.data.v2.risks.IndexedRisk";
+      } else if (RiskIncidence.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.riskincidence";
+        exportClass = "org.roda.core.data.v2.risks.RiskIncidence";
+      } else if (IndexedRepresentation.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.representation";
+        exportClass = "org.roda.core.data.v2.ip.IndexedRepresentation";
+      } else if (IndexedPreservationEvent.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.preservationevent";
+        exportClass = "org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent";
+      } else if (IndexedPreservationAgent.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.preservationagent";
+        exportClass = "org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent";
+      } else if (Notification.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.notification";
+        exportClass = "org.roda.core.data.v2.notifications.Notification";
+      } else if (DisposalConfirmation.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.disposalconfirmation";
+        exportClass = "org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation";
+      } else if (IndexedFile.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.file";
+        exportClass = "org.roda.core.data.v2.ip.IndexedFile";
       }
       if (configKeyPrefix != null) {
         long total = (getResult() != null && getResult().getTotalCount() > 0) ? getResult().getTotalCount() : 0;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -40,6 +40,7 @@ import org.roda.core.data.v2.jobs.IndexedJob;
 import org.roda.core.data.v2.jobs.IndexedReport;
 import org.roda.core.data.v2.log.LogEntry;
 import org.roda.core.data.v2.notifications.Notification;
+import org.roda.core.data.v2.user.RODAMember;
 import org.roda.wui.client.common.ActionsToolbar;
 import org.roda.wui.client.common.NoAsyncCallback;
 import org.roda.wui.client.common.actions.Actionable;
@@ -410,6 +411,12 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
       } else if (LogEntry.class.equals(clazz)) {
         configKeyPrefix = "ui.export.logentry";
         exportClass = "org.roda.core.data.v2.log.LogEntry";
+      } else if (TransferredResource.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.transferredresource";
+        exportClass = "org.roda.core.data.v2.ip.TransferredResource";
+      } else if (RODAMember.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.member";
+        exportClass = "org.roda.core.data.v2.user.RODAMember";
       }
       if (configKeyPrefix != null) {
         long total = (getResult() != null && getResult().getTotalCount() > 0) ? getResult().getTotalCount() : 0;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -42,6 +42,7 @@ import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent;
 import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
+import org.roda.core.data.v2.ri.RepresentationInformation;
 import org.roda.core.data.v2.risks.IndexedRisk;
 import org.roda.core.data.v2.risks.RiskIncidence;
 import org.roda.core.data.v2.jobs.IndexedJob;
@@ -452,6 +453,9 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
       } else if (IndexedFile.class.equals(clazz)) {
         configKeyPrefix = "ui.export.file";
         exportClass = "org.roda.core.data.v2.ip.IndexedFile";
+      } else if (RepresentationInformation.class.equals(clazz)) {
+        configKeyPrefix = "ui.export.representationinformation";
+        exportClass = "org.roda.core.data.v2.ri.RepresentationInformation";
       }
       if (configKeyPrefix != null) {
         long total = (getResult() != null && getResult().getTotalCount() > 0) ? getResult().getTotalCount() : 0;

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2918,7 +2918,7 @@ ui.export.transferredresource.fields.file.label=Är fil
 ##################################
 ui.export.member.fields=id,name,fullName,active,directRoles
 ui.export.member.defaultCheckedFields=id,name,active
-ui.export.member.fields.id.label=Användarnamn
+ui.export.member.fields.id.label=Identifierare
 ui.export.member.fields.name.label=Namn
 ui.export.member.fields.fullName.label=Fullständigt namn
 ui.export.member.fields.active.label=Aktiv

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2923,3 +2923,118 @@ ui.export.member.fields.name.label=Namn
 ui.export.member.fields.fullName.label=Fullständigt namn
 ui.export.member.fields.active.label=Aktiv
 ui.export.member.fields.directRoles.label=Roller
+
+##################################
+# Export: DIP
+##################################
+ui.export.dip.fields=id,title,description,type,dateCreated,lastModified
+ui.export.dip.defaultCheckedFields=id,title,type,dateCreated
+ui.export.dip.fields.id.label=Identifierare
+ui.export.dip.fields.title.label=Titel
+ui.export.dip.fields.description.label=Beskrivning
+ui.export.dip.fields.type.label=Typ
+ui.export.dip.fields.dateCreated.label=Skapad
+ui.export.dip.fields.lastModified.label=Senast ändrad
+
+##################################
+# Export: Risk
+##################################
+ui.export.risk.fields=id,name,description,identifiedOn,identifiedBy,preMitigationSeverityLevel,postMitigationSeverityLevel,incidencesCount,unmitigatedIncidencesCount
+ui.export.risk.defaultCheckedFields=id,name,preMitigationSeverityLevel,incidencesCount
+ui.export.risk.fields.id.label=Identifierare
+ui.export.risk.fields.name.label=Namn
+ui.export.risk.fields.description.label=Beskrivning
+ui.export.risk.fields.identifiedOn.label=Identifierad
+ui.export.risk.fields.identifiedBy.label=Identifierad av
+ui.export.risk.fields.preMitigationSeverityLevel.label=Allvarlighetsgrad (före)
+ui.export.risk.fields.postMitigationSeverityLevel.label=Allvarlighetsgrad (efter)
+ui.export.risk.fields.incidencesCount.label=Antal incidenter
+ui.export.risk.fields.unmitigatedIncidencesCount.label=Ohanterade incidenter
+
+##################################
+# Export: Riskincident
+##################################
+ui.export.riskincidence.fields=id,riskId,aipId,status,severity,detectedOn,detectedBy,mitigatedOn,mitigatedBy
+ui.export.riskincidence.defaultCheckedFields=riskId,aipId,status,severity,detectedOn
+ui.export.riskincidence.fields.id.label=Identifierare
+ui.export.riskincidence.fields.riskId.label=Risk-ID
+ui.export.riskincidence.fields.aipId.label=AIP-ID
+ui.export.riskincidence.fields.status.label=Status
+ui.export.riskincidence.fields.severity.label=Allvarlighetsgrad
+ui.export.riskincidence.fields.detectedOn.label=Detekterad
+ui.export.riskincidence.fields.detectedBy.label=Detekterad av
+ui.export.riskincidence.fields.mitigatedOn.label=Hanterad
+ui.export.riskincidence.fields.mitigatedBy.label=Hanterad av
+
+##################################
+# Export: Representation
+##################################
+ui.export.representation.fields=uuid,title,sizeInBytes,numberOfDataFiles,numberOfDataFolders
+ui.export.representation.defaultCheckedFields=uuid,title,sizeInBytes,numberOfDataFiles
+ui.export.representation.fields.uuid.label=Identifierare
+ui.export.representation.fields.title.label=Titel
+ui.export.representation.fields.sizeInBytes.label=Storlek (byte)
+ui.export.representation.fields.numberOfDataFiles.label=Antal datafiler
+ui.export.representation.fields.numberOfDataFolders.label=Antal datakataloger
+
+##################################
+# Export: Bevarandehändelse
+##################################
+ui.export.preservationevent.fields=id,aipID,eventDateTime,eventType,eventOutcome,eventDetail
+ui.export.preservationevent.defaultCheckedFields=aipID,eventDateTime,eventType,eventOutcome
+ui.export.preservationevent.fields.id.label=Identifierare
+ui.export.preservationevent.fields.aipID.label=AIP-ID
+ui.export.preservationevent.fields.eventDateTime.label=Tidpunkt
+ui.export.preservationevent.fields.eventType.label=Typ
+ui.export.preservationevent.fields.eventOutcome.label=Utfall
+ui.export.preservationevent.fields.eventDetail.label=Detaljer
+
+##################################
+# Export: Bevarandeagent
+##################################
+ui.export.preservationagent.fields=id,name,type,version,createdOn
+ui.export.preservationagent.defaultCheckedFields=id,name,type,version
+ui.export.preservationagent.fields.id.label=Identifierare
+ui.export.preservationagent.fields.name.label=Namn
+ui.export.preservationagent.fields.type.label=Typ
+ui.export.preservationagent.fields.version.label=Version
+ui.export.preservationagent.fields.createdOn.label=Skapad
+
+##################################
+# Export: Notifikation
+##################################
+ui.export.notification.fields=id,subject,sentOn,fromUser,recipientUsers,state
+ui.export.notification.defaultCheckedFields=subject,sentOn,fromUser,state
+ui.export.notification.fields.id.label=Identifierare
+ui.export.notification.fields.subject.label=Ämne
+ui.export.notification.fields.sentOn.label=Skickad
+ui.export.notification.fields.fromUser.label=Från
+ui.export.notification.fields.recipientUsers.label=Mottagare
+ui.export.notification.fields.state.label=Status
+
+##################################
+# Export: Kassationsbekräftelse
+##################################
+ui.export.disposalconfirmation.fields=id,title,state,createdOn,createdBy,executedOn,size,numberOfAIPs
+ui.export.disposalconfirmation.defaultCheckedFields=title,state,createdOn,numberOfAIPs
+ui.export.disposalconfirmation.fields.id.label=Identifierare
+ui.export.disposalconfirmation.fields.title.label=Titel
+ui.export.disposalconfirmation.fields.state.label=Status
+ui.export.disposalconfirmation.fields.createdOn.label=Skapad
+ui.export.disposalconfirmation.fields.createdBy.label=Skapad av
+ui.export.disposalconfirmation.fields.executedOn.label=Utförd
+ui.export.disposalconfirmation.fields.size.label=Storlek (byte)
+ui.export.disposalconfirmation.fields.numberOfAIPs.label=Antal AIP
+
+##################################
+# Export: Fil
+##################################
+ui.export.file.fields=uuid,id,aipId,representationId,originalName,size,isDirectory
+ui.export.file.defaultCheckedFields=originalName,aipId,representationId,size
+ui.export.file.fields.uuid.label=Identifierare
+ui.export.file.fields.id.label=Fil-ID
+ui.export.file.fields.aipId.label=AIP-ID
+ui.export.file.fields.representationId.label=Representations-ID
+ui.export.file.fields.originalName.label=Originalnamn
+ui.export.file.fields.size.label=Storlek (byte)
+ui.export.file.fields.isDirectory.label=Är katalog

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2899,3 +2899,27 @@ ui.export.logentry.fields.address.label=IP-adress
 ui.export.logentry.fields.relatedObjectID.label=Relaterat objekt
 ui.export.logentry.fields.duration.label=Varaktighet (ms)
 ui.export.logentry.fields.state.label=Status
+
+##################################
+# Export: Inleverans (TransferredResource)
+##################################
+ui.export.transferredresource.fields=uuid,name,fullPath,relativePath,size,creationDate,file
+ui.export.transferredresource.defaultCheckedFields=name,fullPath,size
+ui.export.transferredresource.fields.uuid.label=Identifierare
+ui.export.transferredresource.fields.name.label=Namn
+ui.export.transferredresource.fields.fullPath.label=Sökväg
+ui.export.transferredresource.fields.relativePath.label=Relativ sökväg
+ui.export.transferredresource.fields.size.label=Storlek (byte)
+ui.export.transferredresource.fields.creationDate.label=Skapad
+ui.export.transferredresource.fields.file.label=Är fil
+
+##################################
+# Export: Användare och grupper (RODAMember)
+##################################
+ui.export.member.fields=id,name,fullName,active,directRoles
+ui.export.member.defaultCheckedFields=id,name,active
+ui.export.member.fields.id.label=Användarnamn
+ui.export.member.fields.name.label=Namn
+ui.export.member.fields.fullName.label=Fullständigt namn
+ui.export.member.fields.active.label=Aktiv
+ui.export.member.fields.directRoles.label=Roller

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -3038,3 +3038,17 @@ ui.export.file.fields.representationId.label=Representations-ID
 ui.export.file.fields.originalName.label=Originalnamn
 ui.export.file.fields.size.label=Storlek (byte)
 ui.export.file.fields.isDirectory.label=Är katalog
+
+##################################
+# Export: Representationsinformation
+##################################
+ui.export.representationinformation.fields=id,name,description,family,tags,support,createdOn,updatedOn
+ui.export.representationinformation.defaultCheckedFields=id,name,family,support
+ui.export.representationinformation.fields.id.label=Identifierare
+ui.export.representationinformation.fields.name.label=Namn
+ui.export.representationinformation.fields.description.label=Beskrivning
+ui.export.representationinformation.fields.family.label=Familj
+ui.export.representationinformation.fields.tags.label=Taggar
+ui.export.representationinformation.fields.support.label=Support
+ui.export.representationinformation.fields.createdOn.label=Skapad
+ui.export.representationinformation.fields.updatedOn.label=Uppdaterad

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -2836,7 +2836,20 @@ ui.welcome.action.auditlog.icon = ☰
 ui.welcome.action.auditlog.description = Händelselogg för systemaktivitet
 
 ##########################################################################
-# Konfigurerbar AIP-export (issue #160)
+# CSV export configuration
+#
+# Each entity type has three keys:
+#   .fields               - ordered, comma-separated list of exportable field names
+#   .defaultCheckedFields - subset of .fields pre-selected in the export dialog
+#   .fields.<name>.label  - display label shown in the export dialog for each field
+#
+# The export dialog (ExportSearchDialog) reads these keys at runtime.
+# Adding a field here without a corresponding case in SearchExportPlugin will
+# produce an empty column in the CSV output.
+##########################################################################
+
+##########################################################################
+# Export: AIP
 ##########################################################################
 ui.export.aip.fields=uuid,title,level,dateInitial,dateFinal,parentId,ingestSIPIds,createdOn,updatedOn
 
@@ -2852,7 +2865,7 @@ ui.export.aip.fields.updatedOn.label=Uppdaterad
 ui.export.aip.defaultCheckedFields=uuid,title,level,dateInitial,dateFinal
 
 ##########################################################################
-# Konfigurerbar export — Arkivvårdsjobb (IndexedJob)
+# Export: Job
 ##########################################################################
 ui.export.job.fields=id,name,username,startDate,endDate,state,priority,pluginType,plugin
 ui.export.job.defaultCheckedFields=id,name,state
@@ -2868,7 +2881,7 @@ ui.export.job.fields.pluginType.label=Typ
 ui.export.job.fields.plugin.label=Plugin
 
 ##########################################################################
-# Konfigurerbar export — Processer (IndexedReport)
+# Export: Report
 ##########################################################################
 ui.export.report.fields=id,jobId,jobName,sourceObjectId,sourceObjectOriginalName,outcomeObjectId,pluginState,dateCreated,plugin,pluginDetails
 ui.export.report.defaultCheckedFields=id,jobId,pluginState
@@ -2885,7 +2898,7 @@ ui.export.report.fields.plugin.label=Plugin
 ui.export.report.fields.pluginDetails.label=Detaljer
 
 ##########################################################################
-# Konfigurerbar export — Loggar (LogEntry)
+# Export: Log entry
 ##########################################################################
 ui.export.logentry.fields=uuid,datetime,username,actionComponent,actionMethod,address,relatedObjectID,duration,state
 ui.export.logentry.defaultCheckedFields=datetime,username,actionComponent,actionMethod
@@ -2901,7 +2914,7 @@ ui.export.logentry.fields.duration.label=Varaktighet (ms)
 ui.export.logentry.fields.state.label=Status
 
 ##################################
-# Export: Inleverans (TransferredResource)
+# Export: Transferred resource
 ##################################
 ui.export.transferredresource.fields=uuid,name,fullPath,relativePath,size,creationDate,file
 ui.export.transferredresource.defaultCheckedFields=name,fullPath,size
@@ -2914,7 +2927,7 @@ ui.export.transferredresource.fields.creationDate.label=Skapad
 ui.export.transferredresource.fields.file.label=Är fil
 
 ##################################
-# Export: Användare och grupper (RODAMember)
+# Export: Users and groups
 ##################################
 ui.export.member.fields=id,name,fullName,active,directRoles
 ui.export.member.defaultCheckedFields=id,name,active
@@ -2952,7 +2965,7 @@ ui.export.risk.fields.incidencesCount.label=Antal incidenter
 ui.export.risk.fields.unmitigatedIncidencesCount.label=Ohanterade incidenter
 
 ##################################
-# Export: Riskincident
+# Export: Risk incidence
 ##################################
 ui.export.riskincidence.fields=id,riskId,aipId,status,severity,detectedOn,detectedBy,mitigatedOn,mitigatedBy
 ui.export.riskincidence.defaultCheckedFields=riskId,aipId,status,severity,detectedOn
@@ -2969,16 +2982,20 @@ ui.export.riskincidence.fields.mitigatedBy.label=Hanterad av
 ##################################
 # Export: Representation
 ##################################
-ui.export.representation.fields=uuid,title,sizeInBytes,numberOfDataFiles,numberOfDataFolders
-ui.export.representation.defaultCheckedFields=uuid,title,sizeInBytes,numberOfDataFiles
+ui.export.representation.fields=uuid,aipId,type,title,sizeInBytes,numberOfDataFiles,numberOfDataFolders,createdOn,updatedOn
+ui.export.representation.defaultCheckedFields=aipId,type,title,sizeInBytes,numberOfDataFiles
 ui.export.representation.fields.uuid.label=Identifierare
+ui.export.representation.fields.aipId.label=AIP-ID
+ui.export.representation.fields.type.label=Typ
 ui.export.representation.fields.title.label=Titel
 ui.export.representation.fields.sizeInBytes.label=Storlek (byte)
 ui.export.representation.fields.numberOfDataFiles.label=Antal datafiler
 ui.export.representation.fields.numberOfDataFolders.label=Antal datakataloger
+ui.export.representation.fields.createdOn.label=Skapad
+ui.export.representation.fields.updatedOn.label=Uppdaterad
 
 ##################################
-# Export: Bevarandehändelse
+# Export: Preservation event
 ##################################
 ui.export.preservationevent.fields=id,aipID,eventDateTime,eventType,eventOutcome,eventDetail
 ui.export.preservationevent.defaultCheckedFields=aipID,eventDateTime,eventType,eventOutcome
@@ -2990,7 +3007,7 @@ ui.export.preservationevent.fields.eventOutcome.label=Utfall
 ui.export.preservationevent.fields.eventDetail.label=Detaljer
 
 ##################################
-# Export: Bevarandeagent
+# Export: Preservation agent
 ##################################
 ui.export.preservationagent.fields=id,name,type,version,createdOn
 ui.export.preservationagent.defaultCheckedFields=id,name,type,version
@@ -3001,7 +3018,7 @@ ui.export.preservationagent.fields.version.label=Version
 ui.export.preservationagent.fields.createdOn.label=Skapad
 
 ##################################
-# Export: Notifikation
+# Export: Notification
 ##################################
 ui.export.notification.fields=id,subject,sentOn,fromUser,recipientUsers,state
 ui.export.notification.defaultCheckedFields=subject,sentOn,fromUser,state
@@ -3013,7 +3030,7 @@ ui.export.notification.fields.recipientUsers.label=Mottagare
 ui.export.notification.fields.state.label=Status
 
 ##################################
-# Export: Kassationsbekräftelse
+# Export: Disposal confirmation
 ##################################
 ui.export.disposalconfirmation.fields=id,title,state,createdOn,createdBy,executedOn,size,numberOfAIPs
 ui.export.disposalconfirmation.defaultCheckedFields=title,state,createdOn,numberOfAIPs
@@ -3027,7 +3044,7 @@ ui.export.disposalconfirmation.fields.size.label=Storlek (byte)
 ui.export.disposalconfirmation.fields.numberOfAIPs.label=Antal AIP
 
 ##################################
-# Export: Fil
+# Export: File
 ##################################
 ui.export.file.fields=uuid,id,aipId,representationId,originalName,size,isDirectory
 ui.export.file.defaultCheckedFields=originalName,aipId,representationId,size
@@ -3040,7 +3057,7 @@ ui.export.file.fields.size.label=Storlek (byte)
 ui.export.file.fields.isDirectory.label=Är katalog
 
 ##################################
-# Export: Representationsinformation
+# Export: Representation information
 ##################################
 ui.export.representationinformation.fields=id,name,description,family,tags,support,createdOn,updatedOn
 ui.export.representationinformation.defaultCheckedFields=id,name,family,support


### PR DESCRIPTION
## Sammanfattning

Löser #519 — export-modulen (`SearchExportPlugin`) används nu för **alla** entitetstyper som har en CSV-exportknapp i gränssnittet. Tidigare gick export för tolv entitetstyper direkt via REST-streaming och skapade varken jobb eller logg.

Direkt REST-exporten (`Exportable`-interfacet) är **bibehållen** för bakåtkompatibilitet med externa API-anrop.

### Berörda entitetstyper (tidigare direkt REST, nu via export-modul)

| Entitet | Klass |
|---|---|
| Inleverans | `TransferredResource` |
| Användare och grupper | `RODAMember` |
| DIP | `IndexedDIP` |
| Risk | `IndexedRisk` |
| Riskincident | `RiskIncidence` |
| Representation | `IndexedRepresentation` |
| Bevarandehändelse | `IndexedPreservationEvent` |
| Bevarandeagent | `IndexedPreservationAgent` |
| Notifikation | `Notification` |
| Kassationsbekräftelse | `DisposalConfirmation` |
| Fil | `IndexedFile` |
| Representationsinformation | `RepresentationInformation` |

### Ändringar

- **`SearchExportPlugin.java`** — 12 nya `case`-grenar i `afterAllExecute`, motsvarande `buildCsvRow*`-metoder och `getConfigKeyPrefix`-mappningar
- **`AsyncTableCell.java`** — routing till `ExportSearchDialog` för alla 12 nya typer (import + `else if`-grenar)
- **`roda-wui.properties`** — 12 nya `ui.export.*`-block med fältdefinitioner och svenska etiketter

## Testplan

- [ ] Klicka "Exportera CSV" i Inleveranslistan → `ExportSearchDialog` visas, jobb skapas
- [ ] Klicka "Exportera CSV" i Användarlistan → `ExportSearchDialog` visas, jobb skapas
- [ ] Verifiera att jobbresultatet (CSV) finns tillgängligt som bilaga i Interna åtgärder
- [ ] Verifiera att direkt REST-anrop till `/export/csv` fortfarande fungerar
- [ ] Upprepa stickprov för minst 2 ytterligare entitetstyper (t.ex. Risk, Notifikation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nya funktioner**
  * CSV-exporten stödjer nu fler objekttyper: överförda resurser, medlemmar, DIP:er, risker, riskincidenter, representationer, bevarandehändelser, bevarandeagenter, notifikationer, kassationsbekräftelser, filer och representationsinformation.
  * UI för export har uppdaterats med nya exportinställningar och fältval/etiketter så att dessa typer kan väljas och konfigureras i exportdialogen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->