### PR TITLE
fix: katalogträdet uppdateras efter gallring + saknade svenska översättningar

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
@@ -170,6 +170,7 @@ public class BrowseTop extends Composite {
     CatalogTreePanel treePanel = CatalogTreePanel.getInstance();
     catalogTreeContainer.add(treePanel);
     treePanel.clearSelection();
+    treePanel.reloadIfStale();
   }
 
   @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -619,6 +619,16 @@ public class CatalogTreePanel extends Composite {
     loadRootNodes();
   }
 
+  public void markStale() {
+    rootsLoaded = false;
+  }
+
+  public void reloadIfStale() {
+    if (!rootsLoaded && !rootsLoading) {
+      loadRootNodes();
+    }
+  }
+
   public void refreshAfterMove(String oldParentId, String newParentId) {
     boolean rootInvolved = (oldParentId == null || oldParentId.isEmpty())
       || (newParentId == null || newParentId.isEmpty());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActions.java
@@ -140,14 +140,14 @@ public class DisposalConfirmationActions extends AbstractActionable<DisposalConf
     ActionableBundle<DisposalConfirmation> confirmationActionableBundle = new ActionableBundle<>();
 
     // management
-    ActionableGroup<DisposalConfirmation> actionsGroup = new ActionableGroup<>("Disposal confirmation");
+    ActionableGroup<DisposalConfirmation> actionsGroup = new ActionableGroup<>(messages.sidebarDisposalConfirmationTitle());
     actionsGroup.addButton(messages.newDisposalConfirmationButton(), DisposalConfirmationAction.NEW,
       ActionImpact.UPDATED, "btn-plus-circle");
     actionsGroup.addButton(messages.applyDisposalScheduleButton(), DisposalConfirmationAction.DESTROY,
       ActionImpact.DESTROYED, "btn-trash-alt");
 
     // disposal bin
-    ActionableGroup<DisposalConfirmation> disposalBinGroup = new ActionableGroup<>("Disposal bin");
+    ActionableGroup<DisposalConfirmation> disposalBinGroup = new ActionableGroup<>(messages.sidebarDisposalBinTitle());
     disposalBinGroup.addButton(messages.permanentlyDeleteFromBinButton(), DisposalConfirmationAction.PERM_DELETE,
       ActionImpact.UPDATED, "btn-delete-forever");
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActionsUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalConfirmationActionsUtils.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 
 import org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation;
 import org.roda.core.data.v2.generics.select.SelectedItemsListRequest;
+import org.roda.wui.client.browse.CatalogTreePanel;
 import org.roda.wui.client.common.actions.callbacks.ActionNoAsyncCallback;
 import org.roda.wui.client.common.dialogs.Dialogs;
 import org.roda.wui.client.disposal.DisposalConfirmations;
@@ -87,6 +88,7 @@ public class DisposalConfirmationActionsUtils {
                 if (throwable != null) {
                   callback.onFailure(throwable);
                 } else {
+                  CatalogTreePanel.getInstance().markStale();
                   Dialogs.showJobRedirectDialog(messages.jobCreatedMessage(), new AsyncCallback<Void>() {
 
                     @Override
@@ -128,6 +130,7 @@ public class DisposalConfirmationActionsUtils {
                 if (throwable != null) {
                   callback.onFailure(throwable);
                 } else {
+                  CatalogTreePanel.getInstance().markStale();
                   Dialogs.showJobRedirectDialog(messages.jobCreatedMessage(), new AsyncCallback<Void>() {
 
                     @Override

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -1591,6 +1591,8 @@ deleteConfirmationReportDialogTitle:Bekräfta borttagning av gallringsbekräftel
 deleteConfirmationReportDialogMessage:Är du säker på att du vill ta bort gallringsbekräftelsen?
 deleteConfirmationReportSuccessTitle:Raderar gallringsbekräftelse
 deleteConfirmationReportSuccessMessage:Utför åtgärd för att radera gallringsbekräftelse
+destroyDisposalConfirmationContentDialogTitle:Gallra strukturenheter
+destroyDisposalConfirmationContentDialogMessage:Är du säker på att du vill gallra strukturenheterna från denna gallringsbekräftelse?
 disposalConfirmationDataPanelTitle:Titel
 disposalConfirmationDataNote:(*) Obligatoriska fält
 disposalRuleTitle:Titel


### PR DESCRIPTION
## Sammanfattning

- Katalogträdet märks som inaktuellt (`markStale`) när ett gallrings- eller återställningsjobb skapas, och laddas om nästa gång användaren besöker Arkivbestånd — utan att behöva ladda om sidan manuellt
- Hårdkodade engelska grupptitlar i `DisposalConfirmationActions` ersatta med i18n-nycklar
- Saknade svenska översättningar för gallringsdialogen tillagda

Stänger #576

## Testplan

- [ ] Kör en gallringsbekräftelse och navigera tillbaka till Arkivbestånd — det gallrade objektet ska inte längre synas i katalogträdet
- [ ] Återställ ett gallrat objekt och kontrollera att det dyker upp i katalogträdet efter navigering
- [ ] Verifiera att "Gallringsbekräftelse" och "Papperskorg" visas korrekt i sidopanelen (inte engelska)
- [ ] Verifiera att gallringsdialogen visas på svenska

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Ändringar

* **Buggfixar**
  * Katalogträdet uppdateras nu automatiskt när panelen återansluts till användargränssnittet. Detta säkerställer att du alltid ser aktuell information vid navigering i katalogen.

* **Lokalisering**
  * Nya svenska översättningar tillagda för gallringsbekräftelsedialoger och bekräftelsemeddelanden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->