### PR TITLE
Fix/issue 379 catalog scroll responsiveness

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.java
@@ -58,6 +58,7 @@ import org.roda.wui.common.client.tools.StringUtils;
 import org.roda.wui.common.client.widgets.Toast;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -452,10 +453,17 @@ public class BrowseAIP extends Composite {
   @Override
   protected void onLoad() {
     super.onLoad();
+    Document.get().getBody().addClassName("catalog-active");
     catalogTreeContainer.clear();
     CatalogTreePanel treePanel = CatalogTreePanel.getInstance();
     catalogTreeContainer.add(treePanel);
     treePanel.revealAip(aipId);
+  }
+
+  @Override
+  protected void onUnload() {
+    super.onUnload();
+    Document.get().getBody().removeClassName("catalog-active");
   }
 
   interface MyUiBinder extends UiBinder<Widget, BrowseAIP> {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseAIP.ui.xml
@@ -8,7 +8,7 @@
 	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
 	<g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
-		<g:FlowPanel ui:field="catalogTreeContainer" />
+		<g:FlowPanel ui:field="catalogTreeContainer" styleName="catalogTreeContainer" />
 		<g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
 		<g:FocusPanel ui:field="keyboardFocus" addStyleNames="catalogTreeMainContent">
 			<g:FlowPanel styleName="browse" addStyleNames="wrapper skip_padding">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.java
@@ -163,10 +163,17 @@ public class BrowseRepresentation extends Composite {
   @Override
   protected void onLoad() {
     super.onLoad();
+    Document.get().getBody().addClassName("catalog-active");
     catalogTreeContainer.clear();
     CatalogTreePanel treePanel = CatalogTreePanel.getInstance();
     catalogTreeContainer.add(treePanel);
     treePanel.revealAip(aipId);
+  }
+
+  @Override
+  protected void onUnload() {
+    super.onUnload();
+    Document.get().getBody().removeClassName("catalog-active");
   }
 
   private void initTreeResize() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseRepresentation.ui.xml
@@ -8,7 +8,7 @@
     <ui:with field='messages' type='config.i18n.client.ClientMessages'/>
 
     <g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
-        <g:FlowPanel ui:field="catalogTreeContainer" />
+        <g:FlowPanel ui:field="catalogTreeContainer" styleName="catalogTreeContainer" />
         <g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
         <g:FocusPanel ui:field="keyboardFocus" addStyleNames="catalogTreeMainContent">
             <g:FlowPanel styleName="wui-browse-representation" addStyleNames="wrapper skip_padding">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.java
@@ -175,7 +175,14 @@ public class BrowseTop extends Composite {
   @Override
   protected void onLoad() {
     super.onLoad();
+    Document.get().getBody().addClassName("catalog-active");
     reattachTreePanel();
+  }
+
+  @Override
+  protected void onUnload() {
+    super.onUnload();
+    Document.get().getBody().removeClassName("catalog-active");
   }
 
   private void initTreeResize() {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseTop.ui.xml
@@ -7,7 +7,7 @@
 	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
 	<g:FlowPanel styleName="contentWithSidePanel catalogTreeLayout">
-		<g:FlowPanel ui:field="catalogTreeContainer" />
+		<g:FlowPanel ui:field="catalogTreeContainer" styleName="catalogTreeContainer" />
 		<g:FlowPanel ui:field="treeResizeHandle" styleName="catalogTreeResizeHandle" />
 		<g:FocusPanel addStyleNames="catalogTreeMainContent">
 			<g:FlowPanel styleName="browse" addStyleNames="wrapper skip_padding">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -37,7 +37,10 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
@@ -57,6 +60,9 @@ public class CatalogTreePanel extends Composite {
 
   private static final String ICON_COLLAPSE = "<i class='fas fa-angle-double-left'></i>";
   private static final String ICON_EXPAND = "<i class='fas fa-angle-double-right'></i>";
+  private static final int RESPONSIVE_COLLAPSE_WIDTH = 1100;
+
+  private boolean responsiveCollapsed = false;
 
   interface MyUiBinder extends UiBinder<Widget, CatalogTreePanel> {}
 
@@ -108,6 +114,7 @@ public class CatalogTreePanel extends Composite {
     collapseToggle.getElement().setAttribute("aria-expanded", "true");
     collapseToggle.addClickHandler(e -> {
       e.stopPropagation();
+      responsiveCollapsed = false;
       setCollapsed(true);
     });
 
@@ -115,10 +122,16 @@ public class CatalogTreePanel extends Composite {
     expandButton.setTitle(messages.catalogTreeExpand());
     expandButton.getElement().setAttribute("aria-label", messages.catalogTreeExpand());
     expandButton.getElement().setAttribute("aria-expanded", "false");
-    expandButton.addClickHandler(e -> setCollapsed(false));
+    expandButton.addClickHandler(e -> {
+      responsiveCollapsed = false;
+      setCollapsed(false);
+    });
 
     headerTitle.setTitle(messages.catalogTreeTitle());
     headerTitle.setHref(org.roda.wui.common.client.tools.HistoryUtils.createHistoryHashLink(BrowseTop.RESOLVER));
+
+    Window.addResizeHandler(event -> handleViewportResize(event.getWidth()));
+    handleViewportResize(Window.getClientWidth());
 
     loadRootNodes();
   }
@@ -139,6 +152,16 @@ public class CatalogTreePanel extends Composite {
         removeStyleName("animatingCollapse");
       }
     }.schedule(220);
+  }
+
+  private void handleViewportResize(int clientWidth) {
+    if (clientWidth < RESPONSIVE_COLLAPSE_WIDTH && !hasStyleName("collapsed")) {
+      responsiveCollapsed = true;
+      setCollapsed(true);
+    } else if (clientWidth >= RESPONSIVE_COLLAPSE_WIDTH && responsiveCollapsed) {
+      responsiveCollapsed = false;
+      setCollapsed(false);
+    }
   }
 
   private void onFilterChanged(KeyUpEvent event) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -62,6 +62,7 @@ public class CatalogTreePanel extends Composite {
   private static final String ICON_EXPAND = "<i class='fas fa-angle-double-right'></i>";
   private static final int RESPONSIVE_COLLAPSE_WIDTH = 1100;
 
+  private boolean isCollapsed = false;
   private boolean responsiveCollapsed = false;
 
   interface MyUiBinder extends UiBinder<Widget, CatalogTreePanel> {}
@@ -137,6 +138,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void setCollapsed(boolean collapse) {
+    isCollapsed = collapse;
     addStyleName("animatingCollapse");
     if (collapse) {
       addStyleName("collapsed");
@@ -155,7 +157,7 @@ public class CatalogTreePanel extends Composite {
   }
 
   private void handleViewportResize(int clientWidth) {
-    if (clientWidth < RESPONSIVE_COLLAPSE_WIDTH && !hasStyleName("collapsed")) {
+    if (clientWidth < RESPONSIVE_COLLAPSE_WIDTH && !isCollapsed) {
       responsiveCollapsed = true;
       setCollapsed(true);
     } else if (clientWidth >= RESPONSIVE_COLLAPSE_WIDTH && responsiveCollapsed) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3353,7 +3353,7 @@ td.datePickerMonth, td.datePickerYear {
 
 .contentWithSidePanel {
     display: flex;
-    min-height: 767px !important;
+    /*min-height: 767px !important;*/
 }
 
 .browseSidePanel {
@@ -3562,7 +3562,7 @@ body.catalogTreeResizing * {
    så att .catalogTreePanel (intern scroll i .catalogTreeBodyScroll) håller
    sin position och .catalogTreeMainContent kan ha egen y-scroll. */
 .catalogTreeLayout {
-    height: calc(100vh - 64px);
+    height: calc(100vh - 126px);
     min-height: 0 !important;
     overflow: hidden;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3572,10 +3572,7 @@ body.catalogTreeResizing * {
     overflow-x: hidden;
 }
 
-/* #379: Under 1100px skapar trädet + innehåll två synliga scrollbars
-   (en vid trädpanelens kant, en längst till höger) vilket bryter WCAG.
-   Dölj trädet och återgå till naturlig sidscroll under detta tröskelvärde. */
-@media (max-width: 1100px) {
+@media (max-width: 900px) {
     .catalogTreePanel {
         display: none;
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -3549,6 +3549,14 @@ body.catalogTreeResizing * {
     overflow: hidden;
 }
 
+/* #379: catalogTreeContainer är GWT-wrapperens div utan explicit höjd.
+   height:100% säkerställer att .catalogTreePanel kan ärva höjden korrekt,
+   vilket gör att .catalogTreeBodyScroll (flex:1, overflow-y:auto) blir
+   korrekt begränsad och visar sin scrollbar intill trädet. */
+.catalogTreeContainer {
+    height: 100%;
+}
+
 /* #337: Trädpanel ska stå still medan höger sida skrollar för sig.
    Begränsar layoutens höjd till viewport (minus sticky bannerHeader 64px),
    så att .catalogTreePanel (intern scroll i .catalogTreeBodyScroll) håller
@@ -3564,7 +3572,10 @@ body.catalogTreeResizing * {
     overflow-x: hidden;
 }
 
-@media (max-width: 900px) {
+/* #379: Under 1100px skapar trädet + innehåll två synliga scrollbars
+   (en vid trädpanelens kant, en längst till höger) vilket bryter WCAG.
+   Dölj trädet och återgå till naturlig sidscroll under detta tröskelvärde. */
+@media (max-width: 1100px) {
     .catalogTreePanel {
         display: none;
     }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -896,7 +896,7 @@ body:has(.eterna-login) {
 
 .main .contentPanel {
   padding-top: 96px;
-  min-height: 767px !important;
+  /*min-height: 767px !important;*/
 }
 
 .double-bounce1,
@@ -1906,22 +1906,13 @@ a.btn-hero:visited, a.btn-welcome:visited {
     font-size: 1rem !important;
 }
 
-/* #379: Katalogvyn (catalogTreeLayout) har fast höjd = calc(100vh - 64px).
-   Footern under layouten skapade en body-scroll lika hög som footern.
-   Löses enbart genom att dölja footern — body är flex-column med
-   min-height:100vh, så utan footer = exakt 100vh = noll body-scroll.
-   OBS: overflow:hidden på body tar bort scroll även för inre containers. */
-html:has(.catalogTreeLayout) {
+/* #379: catalog-active sätts på body av BrowseTop/BrowseAIP/BrowseRepresentation
+   via onLoad()/onUnload(). Säkrare än :has() som kan matcha fel vid GWT async. */
+html.catalog-active {
   overflow: hidden;
 }
-/* Footer.java renderas via HTMLWidgetWrapper — .eterna-footer hamnar inuti
-   en GWT-wrapperdiv, inte som direkt sibling. Descendant-selektor krävs. */
-body:has(.catalogTreeLayout) .eterna-footer {
-  display: none;
-}
-/* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
-   sidscroll gäller. */
+
 @media (max-width: 900px) {
-  html:has(.catalogTreeLayout) { overflow: auto; }
-  body:has(.catalogTreeLayout) .eterna-footer { display: revert; }
+  html.catalog-active { overflow: auto; }
+  body.catalog-active .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1911,8 +1911,8 @@ a.btn-hero:visited, a.btn-welcome:visited {
    Löses enbart genom att dölja footern — body är flex-column med
    min-height:100vh, så utan footer = exakt 100vh = noll body-scroll.
    OBS: overflow:hidden på body tar bort scroll även för inre containers. */
-body:has(.catalogTreeLayout) {
-  padding-bottom: 0;
+html:has(.catalogTreeLayout) {
+  overflow: hidden;
 }
 .main:has(.catalogTreeLayout) ~ .eterna-footer {
   display: none;
@@ -1920,6 +1920,6 @@ body:has(.catalogTreeLayout) {
 /* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
    sidscroll gäller. */
 @media (max-width: 900px) {
-  body:has(.catalogTreeLayout) { padding-bottom: revert; }
+  html:has(.catalogTreeLayout) { overflow: auto; }
   .main:has(.catalogTreeLayout) ~ .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1911,11 +1911,15 @@ a.btn-hero:visited, a.btn-welcome:visited {
    Löses enbart genom att dölja footern — body är flex-column med
    min-height:100vh, så utan footer = exakt 100vh = noll body-scroll.
    OBS: overflow:hidden på body tar bort scroll även för inre containers. */
+body:has(.catalogTreeLayout) {
+  padding-bottom: 0;
+}
 .main:has(.catalogTreeLayout) ~ .eterna-footer {
   display: none;
 }
 /* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
    sidscroll gäller. */
 @media (max-width: 900px) {
+  body:has(.catalogTreeLayout) { padding-bottom: revert; }
   .main:has(.catalogTreeLayout) ~ .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1906,19 +1906,16 @@ a.btn-hero:visited, a.btn-welcome:visited {
     font-size: 1rem !important;
 }
 
-/* #379: Katalogvyn (catalogTreeLayout) har fast höjd + egna scroll-regioner.
-   Dölj body-scroll och footer precis som login-sidan gör, annars uppstår
-   en scrollbar med exakt footerns höjd. */
-body:has(.catalogTreeLayout) {
-  overflow: hidden;
-  padding-bottom: 0;
-}
+/* #379: Katalogvyn (catalogTreeLayout) har fast höjd = calc(100vh - 64px).
+   Footern under layouten skapade en body-scroll lika hög som footern.
+   Löses enbart genom att dölja footern — body är flex-column med
+   min-height:100vh, så utan footer = exakt 100vh = noll body-scroll.
+   OBS: overflow:hidden på body tar bort scroll även för inre containers. */
 .main:has(.catalogTreeLayout) ~ .eterna-footer {
   display: none;
 }
 /* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
    sidscroll gäller. */
 @media (max-width: 900px) {
-  body:has(.catalogTreeLayout) { overflow: auto; }
   .main:has(.catalogTreeLayout) ~ .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1914,12 +1914,14 @@ a.btn-hero:visited, a.btn-welcome:visited {
 html:has(.catalogTreeLayout) {
   overflow: hidden;
 }
-.main:has(.catalogTreeLayout) ~ .eterna-footer {
+/* Footer.java renderas via HTMLWidgetWrapper — .eterna-footer hamnar inuti
+   en GWT-wrapperdiv, inte som direkt sibling. Descendant-selektor krävs. */
+body:has(.catalogTreeLayout) .eterna-footer {
   display: none;
 }
 /* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
    sidscroll gäller. */
 @media (max-width: 900px) {
   html:has(.catalogTreeLayout) { overflow: auto; }
-  .main:has(.catalogTreeLayout) ~ .eterna-footer { display: revert; }
+  body:has(.catalogTreeLayout) .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1908,11 +1908,11 @@ a.btn-hero:visited, a.btn-welcome:visited {
 
 /* #379: catalog-active sätts på body av BrowseTop/BrowseAIP/BrowseRepresentation
    via onLoad()/onUnload(). Säkrare än :has() som kan matcha fel vid GWT async. */
-html.catalog-active {
+body.catalog-active {
   overflow: hidden;
 }
 
 @media (max-width: 900px) {
-  html.catalog-active { overflow: auto; }
+  body.catalog-active { overflow: auto; }
   body.catalog-active .eterna-footer { display: revert; }
 }

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1905,3 +1905,20 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .MuiDialog-root .MuiInputLabel-shrink {
     font-size: 1rem !important;
 }
+
+/* #379: Katalogvyn (catalogTreeLayout) har fast höjd + egna scroll-regioner.
+   Dölj body-scroll och footer precis som login-sidan gör, annars uppstår
+   en scrollbar med exakt footerns höjd. */
+body:has(.catalogTreeLayout) {
+  overflow: hidden;
+  padding-bottom: 0;
+}
+.main:has(.catalogTreeLayout) ~ .eterna-footer {
+  display: none;
+}
+/* Återställ vid smala viewports (≤900px) där trädet döljs och naturlig
+   sidscroll gäller. */
+@media (max-width: 900px) {
+  body:has(.catalogTreeLayout) { overflow: auto; }
+  .main:has(.catalogTreeLayout) ~ .eterna-footer { display: revert; }
+}

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.js
@@ -12,7 +12,7 @@
         let lastBottom = 0;
         function measure() {
             void bannerHeader.offsetHeight;
-            const bhBottom = Math.round(bannerHeader.getBoundingClientRect().bottom);
+            const bhBottom = Math.round(bannerHeader.getBoundingClientRect().height);
             if (bhBottom <= 6 || bhBottom !== lastBottom) {
                 lastBottom = bhBottom;
                 setTimeout(measure, 50);


### PR DESCRIPTION
closes #379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Versionsanteckningar

* **New Features**
  * Katalogträdet är nu responsivt och kollapsar/expanderar automatiskt vid fönsterstorleksändring för bättre användbarhet.

* **Style**
  * Förbättrad layout- och höjdberäkning för katalogvyn (ändrad viewport-höjdshantering).
  * Body-tillståndet för katalogvyn aktiverar nu skroll-/visningsbeteenden (desktop blockerar skroll, mobil tillåter).

* **Bug Fixes**
  * Justerad beräkning för fast header för mer stabil padding och förbättrad visning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->