### PR TITLE
fix: rätta färger i XML-vy för metadata-historik (#367)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DescriptiveMetadataHistory.java
@@ -271,6 +271,7 @@ public class DescriptiveMetadataHistory extends Composite {
           preview.setHTML(html);
           if (inHTML) {
             preview.removeStyleName("code-pre");
+            JavascriptUtils.removeHighlighting(preview.getElement());
           } else {
             preview.addStyleName("code-pre");
             JavascriptUtils.runHighlighterOn(preview.getElement());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
@@ -54,8 +54,8 @@ public class JavascriptUtils {
   }-*/;
 
   public static native void removeHighlighting(JavaScriptObject element) /*-{
-    $wnd.jQuery(element).removeClass("hljs").removeAttr("data-highlighted");
-    $wnd.jQuery(element).find(".hljs").removeClass("hljs").removeAttr("data-highlighted");
+    $wnd.jQuery(element).removeClass('hljs').removeAttr('data-highlighted');
+    $wnd.jQuery(element).find('.hljs').removeClass('hljs').removeAttr('data-highlighted');
   }-*/;
 
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/JavascriptUtils.java
@@ -53,6 +53,12 @@ public class JavascriptUtils {
     });
   }-*/;
 
+  public static native void removeHighlighting(JavaScriptObject element) /*-{
+    $wnd.jQuery(element).removeClass("hljs").removeAttr("data-highlighted");
+    $wnd.jQuery(element).find(".hljs").removeClass("hljs").removeAttr("data-highlighted");
+  }-*/;
+
+
   public static native void runIframeResizer(JavaScriptObject iframe) /*-{
     $wnd.jQuery(iframe).iFrameResize({
       log : false,

--- a/roda-ui/roda-wui/src/main/resources/static/Main.html
+++ b/roda-ui/roda-wui/src/main/resources/static/Main.html
@@ -21,7 +21,7 @@
     <script type="text/javascript" src="webjars/iframe-resizer/js/iframeResizer.min.js"></script>
 
     <!-- Highlighter -->
-    <link rel="stylesheet" href="webjars/highlightjs/styles/tomorrow-night-bright.min.css" type="text/css"/>
+    <link rel="stylesheet" href="webjars/highlightjs/styles/github.min.css" type="text/css"/>
     <script type="text/javascript" src="webjars/highlightjs/highlight.min.js"></script>
 
     <!-- Font awesome -->


### PR DESCRIPTION
## Sammanfattning

Fixar issue #367 — oläsbar text och svart bakgrund i XML-vyn för "Historik av beskrivande metadata".

### Rotorsak

 laddade  — ett mörkt highlight.js-tema med svart bakgrund och ljusgrå text.  applicerade -klassen direkt på preview-elementet, och klassen städades aldrig bort när användaren växlade tillbaka till HTML-vyn.

### Ändringar

- ****: Byter highlight.js-tema från  (mörkt) till  (ljust) — matchar appens ljusa bakgrund
- ****: Ny native-metod  som rensar -klassen och -attributet från DOM-element
- ****: Anropar  i  när användaren växlar tillbaka till HTML-vy

### Testat

- Manuellt verifierat i lokal testmiljö
- Läsbar syntaxfärgad text i XML-vy ✅
- Ingen svart bakgrund vid återgång till HTML-vy ✅
- Syntaxfärgning fungerar vid upprepade vy-byten ✅

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Utgåvor

* **Bug Fixes**
  * Förbättrad rensning av syntaxmarkering vid uppdatering av förhandsvisningar för bättre prestanda och tillförlitlighet.

* **Style**
  * Uppdaterad syntaxmarkeringens färgschema för förbättrad läsbarhet och visuell konsistens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->