### PR TITLE
chore: disable datasource autoconfiguration in default properties

### DIFF
--- a/deploys/standalone/docker-compose-dev.yaml
+++ b/deploys/standalone/docker-compose-dev.yaml
@@ -91,17 +91,17 @@ services:
     volumes:
       - ./ldap/ldif/pbkdf2.ldif:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
 
-  postgres:
-    image: postgres:17
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: roda
-      POSTGRES_DB: roda_core_db
-    ports:
-      - "5432:5432"
-    volumes:
-      - pg_data:/var/lib/postgresql/data
+  # postgres:
+  #   image: postgres:17
+  #   restart: unless-stopped
+  #   environment:
+  #     POSTGRES_USER: admin
+  #     POSTGRES_PASSWORD: roda
+  #     POSTGRES_DB: roda_core_db
+  #   ports:
+  #     - "5432:5432"
+  #   volumes:
+  #     - pg_data:/var/lib/postgresql/data
 
 volumes:
   zookeeper_data:
@@ -109,4 +109,4 @@ volumes:
   solr_data:
   clam_data:
   siegfried_data:
-  pg_data:
+  #pg_data:

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -95,8 +95,8 @@ services:
         condition: service_started
       siegfried:
         condition: service_started
-      postgres:
-        condition: service_started
+      # postgres:
+      #   condition: service_started
       unoserver:
         condition: service_healthy
     volumes:
@@ -121,17 +121,17 @@ services:
       - UNOSERVER_HOST=unoserver
       - UNOSERVER_PORT=2003
 
-  postgres:
-    image: docker.io/postgres:17
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: roda
-      POSTGRES_DB: roda_core_db
-    ports:
-      - "5432:5432"
-    volumes:
-      - pg_data:/var/lib/postgresql/data
+  # postgres:
+  #   image: docker.io/postgres:17
+  #   restart: unless-stopped
+  #   environment:
+  #     POSTGRES_USER: admin
+  #     POSTGRES_PASSWORD: roda
+  #     POSTGRES_DB: roda_core_db
+  #   ports:
+  #     - "5432:5432"
+  #   volumes:
+  #     - pg_data:/var/lib/postgresql/data
 
 
 volumes:
@@ -141,4 +141,4 @@ volumes:
   clam_data:
   siegfried_data:
   roda_data:
-  pg_data:
+  #pg_data:

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -104,6 +104,7 @@ services:
       - ./roda/config/roda-core.properties:/roda/config/roda-core.properties:ro
     environment:
       # Spring configuration
+      # Uncomment when running with the postgres service enabled:
       # - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/roda_core_db
 
       # Solr Cloud configuration

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -104,7 +104,7 @@ services:
       - ./roda/config/roda-core.properties:/roda/config/roda-core.properties:ro
     environment:
       # Spring configuration
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/roda_core_db
+      # - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/roda_core_db
 
       # Solr Cloud configuration
       - RODA_CORE_SOLR_TYPE=CLOUD

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,6 @@ ENV LANG=en_US.UTF-8 \
     LDAP_SERVER_PORT=1389 \
     SIEGFRIED_MODE=server \
     SIEGFRIED_SERVER_URL=http://siegfried:5138 \
-    SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/roda_core_db \
     RODA_USER="roda" \
     RODA_UID="1000" \
     RODA_GROUP="roda" \

--- a/roda-ui/roda-wui/src/main/resources/application.properties
+++ b/roda-ui/roda-wui/src/main/resources/application.properties
@@ -21,20 +21,20 @@ springdoc.api-docs.path=/api/v2/openapi
 springdoc.packagesToScan=org.roda.wui.api.v2
 springdoc.enable-spring-security=false
 
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
-# Transactions database config
-spring.datasource.url=jdbc:postgresql://localhost:5432/roda_core_db
-spring.datasource.username=admin
-spring.datasource.password=roda
-spring.jpa.hibernate.ddl-auto=update
-spring.sql.init.mode=always
+# Transactions database config (disabled — legacy storage mode uses no DB)
+#spring.datasource.url=jdbc:postgresql://localhost:5432/roda_core_db
+#spring.datasource.username=admin
+#spring.datasource.password=roda
+#spring.jpa.hibernate.ddl-auto=update
+#spring.sql.init.mode=always
 
 transactions.cleanup.interval.millis=3600000
 jobs.scheduler.interval.millis=60000
 
 # Metrics and monitoring
-spring.datasource.hikari.metrics-tracking: true
+#spring.datasource.hikari.metrics-tracking: true
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.metrics.enabled=true
 management.endpoint.prometheus.enabled=true

--- a/roda-ui/roda-wui/src/main/resources/application.properties
+++ b/roda-ui/roda-wui/src/main/resources/application.properties
@@ -21,20 +21,25 @@ springdoc.api-docs.path=/api/v2/openapi
 springdoc.packagesToScan=org.roda.wui.api.v2
 springdoc.enable-spring-security=false
 
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 
-# Transactions database config (disabled — legacy storage mode uses no DB)
-#spring.datasource.url=jdbc:postgresql://localhost:5432/roda_core_db
-#spring.datasource.username=admin
-#spring.datasource.password=roda
-#spring.jpa.hibernate.ddl-auto=update
-#spring.sql.init.mode=always
+# Transactions database config
+spring.datasource.url=jdbc:postgresql://localhost:5432/roda_core_db
+spring.datasource.username=admin
+spring.datasource.password=roda
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=always
+# Allow startup without PostgreSQL — connections acquired lazily
+spring.datasource.hikari.initialization-fail-timeout=-1
+spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
+# Explicit dialect so Hibernate doesn't need a connection to auto-detect it
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 transactions.cleanup.interval.millis=3600000
 jobs.scheduler.interval.millis=60000
 
 # Metrics and monitoring
-#spring.datasource.hikari.metrics-tracking: true
+spring.datasource.hikari.metrics-tracking: true
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.metrics.enabled=true
 management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
ETERNA v1 startar inte om man inte har postgres-databas igång.
Iom att vi har disablat transactionmanager så vill vi intne ha postgres igång.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applikationskonfiguration uppdaterad för att förhindra automatisk databasinitiering, begränsa JDBC-metadataåtkomst och ange en explicit databasdialekt.
  * Startsekvens justerad så att tjänsten kan starta även när en lokal databas saknas.
  * Lokala utvecklingskompositioner och containerinställningar ändrade så att den inbyggda PostgreSQL-tjänsten och dess volym är bortkommenterade/avlägsnade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->