### PR TITLE
fix(ui): make asyncdatagrid tables responsive with horizontal scroll

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/JobList.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/JobList.java
@@ -27,7 +27,6 @@ import org.roda.wui.common.client.tools.Humanize.DHMSFormat;
 
 import com.google.gwt.cell.client.SafeHtmlCell;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -221,7 +220,7 @@ public class JobList extends AsyncTableCell<IndexedJob> {
     objectsSkippedCountColumn.setSortable(true);
     progressColumn.setSortable(true);
 
-    addColumn(nameColumn, messages.jobName(), true, false, 100, Style.Unit.PCT);
+    addColumn(nameColumn, messages.jobName(), true, false);
     addColumn(usernameColumn, messages.jobCreator(), true, false, 6);
     addColumn(startDateColumn, messages.jobStartDate(), true, false, 11);
     addColumn(durationColumn, messages.jobDuration(), true, true, 6);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -1456,7 +1456,7 @@ button:after {
 
 .my-asyncdatagrid-main-panel {
     vertical-align: top;
-    overflow: hidden;
+    overflow-x: auto;
 }
 
 .my-asyncdatagrid-main-panel-full {
@@ -1588,8 +1588,9 @@ button:after {
 }
 
 .my-asyncdatagrid-display {
-    width: 100%;
-    table-layout: fixed;
+    width: max-content;
+    min-width: 99%;
+    table-layout: auto;
     margin-top: 0.6rem;
     margin-bottom: 32px;
 }
@@ -4601,6 +4602,11 @@ body.catalogTreeResizing * {
 .searchWrapper {
     display: flex;
     align-items: start;
+}
+
+.searchWrapperMainPanel {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .searchWrapperSearchPanel {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/DisposalConfirmations.ui.xml
@@ -7,7 +7,7 @@
 
 	<g:FlowPanel styleName="wui-disposal-confirmation" addStyleNames="wrapper skip_padding">
 		<g:FlowPanel addStyleNames="row full_width skip_padding">
-			<g:FlowPanel addStyleNames="content" ui:field="contentFlowPanel">
+			<g:FlowPanel addStyleNames="col_12 content" ui:field="contentFlowPanel">
 				<common:TitlePanel text="{messages.disposalConfirmationsTitle}" iconClass="DisposalConfirmations" ui:field="title" />
 				<g:FlowPanel addStyleNames="page-description" ui:field="disposalConfirmationDescription" />
 				<commonsearch:SearchWrapper ui:field="searchWrapper" />


### PR DESCRIPTION
Tables with many fixed-width columns (e.g. JobList with 11 columns) would merge/overflow at viewports below ~1440px because the table container had overflow:hidden and no minimum width constraint.

Changes:
- main.gss: overflow:hidden → overflow-x:auto on my-asyncdatagrid-main-panel
- main.gss: table-layout:fixed + width:100% → table-layout:auto, width:max-content, min-width:100% so columns size to content and the table scrolls only when content genuinely exceeds the container
- main.gss: add .searchWrapperMainPanel { flex:1 1 auto; min-width:0 } so the flex child respects its allocation instead of expanding to content size (which prevented overflow-x from triggering)
- JobList.java: remove erroneous 100% PCT width on nameColumn which collapsed adjacent columns in table-layout:fixed mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Förbättringar**
  * Förbättrad tabell-layout med stöd för horisontell scrollning för bättre visning av bred data.
  * Optimerad tabellstorlekshantering för bättre responsivitet och innehållsanpassning.
  * Små UI-layoutjusteringar som förbättrar panel- och sökkomponenters beteende.

* **Kodförbättringar**
  * Rensning av oanvänd kod och förenkling av kolumndefinitioner för bättre kodkvalitet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->