### PR TITLE
chore: bump commons-ip2 from 2.10.1 to 2.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,7 @@
             <dependency>
                 <groupId>org.roda-community</groupId>
                 <artifactId>commons-ip2</artifactId>
-                <version>2.10.1</version>
+                <version>2.11.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.activation</groupId>


### PR DESCRIPTION
## Summary

- Uppgraderar `commons-ip2` från version `2.10.1` till `2.11.2` (vår fork på ETERNA-earkiv/commons-ip, PR#9 feat/bump-to-2.11.2).

## Motivering

- **Säkerhetsfixar:** Inkluderar jackson-core/databind 2.21.4 som åtgärdar [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq).
- **Beroendeuppgraderingar:** logback, commons-io, commons-lang3, jakarta.xml.bind-api, jaxb-runtime.
- **CLI-tillägg (upstream):** Nya argument för representation-hantering — inga breaking changes för eterna eftersom vi inte anropar CLI-lagret direkt.

## Test plan

- [x] `mvn dependency:resolve` — beroendet löses utan fel
- [x] `mvn compile` — projektet kompilerar utan fel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Utgåvenoteringar

* **Chores**
  * Uppdaterad beroendversion för förbättrad stabilitet och kompatibilitet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->