### PR TITLE
fix(i18n): update stale disposal class names and add missing search labels in Swedish

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -224,10 +224,10 @@ someOfAObject[org.roda.core.data.v2.formats.Format]:format
 someOfAObject[org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent]:bevarandehändelse
 someOfAObject[org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent]:bevarandeaktör
 someOfAObject[org.roda.core.data.v2.Void]:inga indataobjekt
-someOfAObject[org.roda.core.data.v2.ip.disposal.DisposalSchedules]:gallringsscheman
-someOfAObject[org.roda.core.data.v2.ip.disposal.DisposalHolds]:gallringsstopp
-someOfAObject[org.roda.core.data.v2.ip.disposal.DisposalConfirmation]:gallringsbekräftelse
-someOfAObject[org.roda.core.data.v2.ip.disposal.DisposalRules]:gallringsregler
+someOfAObject[org.roda.core.data.v2.disposal.schedule.DisposalSchedules]:gallringsscheman
+someOfAObject[org.roda.core.data.v2.disposal.hold.DisposalHolds]:gallringsstopp
+someOfAObject[org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation]:gallringsbekräftelse
+someOfAObject[org.roda.core.data.v2.disposal.rule.DisposalRules]:gallringsregler
 someOfAObject[org.roda.core.data.v2.synchronization.central.DistributedInstances]:distribuerade instanser
 someOfAObject[org.roda.core.data.v2.accessKey.AccessKeys]:åtkomsttokens
 oneOfAObject:{0}
@@ -257,10 +257,10 @@ oneOfAObject[org.roda.core.data.v2.ip.metadata.PreservationMetadata]:bevarandeme
 oneOfAObject[org.roda.core.data.v2.formats.Format]:format
 oneOfAObject[org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent]:bevarandehändelse
 oneOfAObject[org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent]:bevarandeaktör
-oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalSchedule]:gallringsschema
-oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalHold]:gallringsstopp
-oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalConfirmation]:gallringsbekräftelse
-oneOfAObject[org.roda.core.data.v2.ip.disposal.DisposalRule]:gallringsregler
+oneOfAObject[org.roda.core.data.v2.disposal.schedule.DisposalSchedule]:gallringsschema
+oneOfAObject[org.roda.core.data.v2.disposal.hold.DisposalHold]:gallringsstopp
+oneOfAObject[org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation]:gallringsbekräftelse
+oneOfAObject[org.roda.core.data.v2.disposal.rule.DisposalRule]:gallringsregel
 selected[\=1]:{0,number} {1} vald
 selected:{0,number} {1} vald
 inspectTransferredResource:Inspektera överfört paket
@@ -531,6 +531,8 @@ searchDropdownLabels[org.roda.core.data.v2.user.RODAMember]:användare och grupp
 searchDropdownLabels[org.roda.core.data.v2.ip.metadata.DescriptiveMetadata]:Beskrivande metadata
 searchDropdownLabels[org.roda.core.data.v2.ip.metadata.PreservationMetadata]:Bevarandemetadata
 searchDropdownLabels[org.roda.core.data.v2.formats.Format]:format
+searchDropdownLabels[org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent]:Bevarandehändelser
+searchDropdownLabels[org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation]:Gallringsbekräftelser
 searchDropdownLabels[org.roda.core.data.v2.Void]:Inga indataobjekt
 searchListBoxItems:strukturenheter
 searchListBoxRepresentations:representation


### PR DESCRIPTION
## Summary

- Update `someOfAObject`/`oneOfAObject` keys in `ClientMessages_sv_SE.properties` from old package `org.roda.core.data.v2.ip.disposal.*` to the correct refactored packages (`org.roda.core.data.v2.disposal.confirmation.*`, `.schedule.*`, `.hold.*`, `.rule.*`)
- Add missing `searchDropdownLabels` for `IndexedPreservationEvent` and `DisposalConfirmation`
- Fix singular form: `oneOfAObject[...DisposalRule]` corrected from `gallringsregler` to `gallringsregel`

Closes #586

## Test plan

- [x] Navigate to Gallringsbekräftelser — search bar should show "Gallringsbekräftelser" not the class name
- [x] Empty results message should show "Det gick inte att hitta något gallringsbekräftelse i detta sammanhang."
- [x] Navigate to bevarandehändelser — search bar should show "Bevarandehändelser"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Uppdaterade svenska språköversättningar för gallrings- och dispositionsfunktioner.
  * Uppdaterade svenska etiketter i sökdropdownlistor för förbättrad användarupplevelse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->