### PR TITLE
Chore/update docker compose 1.x

### DIFF
--- a/deploys/distributed/central/docker-compose-dev.yaml
+++ b/deploys/distributed/central/docker-compose-dev.yaml
@@ -58,7 +58,7 @@ services:
       - VALIDATOR_URL=none
 
   mailpit:
-    image: axllent/mailpit:v1.24
+    image: docker.io/axllent/mailpit:v1.24
     restart: unless-stopped
     ports:
       - "1025:1025" # smtp server

--- a/deploys/distributed/central/docker-compose-dev.yaml
+++ b/deploys/distributed/central/docker-compose-dev.yaml
@@ -1,6 +1,6 @@
 services:
   zoo:
-    image: docker.io/zookeeper:3.9-jre-17
+    image: ghcr.io/eterna-earkiv/zookeeper:3.9.5
     restart: unless-stopped
     ports:
       - "2182:2181"
@@ -9,8 +9,9 @@ services:
     volumes:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
+
   solr:
-    image: docker.io/solr:9.6.1
+    image: ghcr.io/eterna-earkiv/solr:9.10.1
     restart: unless-stopped
     ports:
       - "8984:8984"
@@ -24,16 +25,18 @@ services:
       - -c
     volumes:
       - solr_data:/var/solr
+
   clamd:
-    image: docker.io/clamav/clamav:1.2.3
+    image: docker.io/clamav/clamav:stable
     restart: unless-stopped
     ports:
       - "3311:3310"
     volumes:
       - clam_data:/var/lib/clamav
       - $HOME/.roda_central/data/storage:$HOME/.roda_central/data/storage
+
   siegfried:
-    image: ghcr.io/keeps/siegfried:v1.11.0
+    image: ghcr.io/eterna-earkiv/siegfried:v1.11.4
     restart: unless-stopped
     ports:
       - "5139:5138"
@@ -43,8 +46,26 @@ services:
     volumes:
       - siegfried_data:/root/siegfried/
       - $HOME/.roda_central/data/storage:$HOME/.roda_central/data/storage
+
+  swagger:
+    image: docker.io/swaggerapi/swagger-ui:latest
+    restart: on-failure
+    ports:
+      - "8081:8080"
+    environment:
+      - URL=http://localhost:8080/api/openapi.json
+      - DOC_EXPANSION=none
+      - VALIDATOR_URL=none
+
+  mailpit:
+    image: axllent/mailpit:v1.24
+    restart: unless-stopped
+    ports:
+      - "1025:1025" # smtp server
+      - "8025:8025" # web ui
+
   openldap:
-    image: docker.io/bitnami/openldap:2.6.8
+    image: docker.io/bitnamilegacy/openldap:2.6
     user: 1001:root
     ports:
       - "1388:1389"
@@ -58,6 +79,19 @@ services:
       - LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,pbkdf2
     volumes:
       - ldap_data:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
+
+  unoserver:
+    image: ghcr.io/eterna-earkiv/eterna-unoserver:latest
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 2003 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+
+
 volumes:
   zookeeper_data:
   zookeeper_datalog:

--- a/deploys/distributed/local/docker-compose-dev.yaml
+++ b/deploys/distributed/local/docker-compose-dev.yaml
@@ -1,6 +1,6 @@
 services:
   zoo:
-    image: docker.io/zookeeper:3.9-jre-17
+    image: ghcr.io/eterna-earkiv/zookeeper:3.9.5
     restart: unless-stopped
     ports:
       - "2181:2181"
@@ -9,8 +9,9 @@ services:
     volumes:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
+
   solr:
-    image: docker.io/solr:9.6.1
+    image: ghcr.io/eterna-earkiv/solr:9.10.1
     restart: unless-stopped
     ports:
       - "8983:8983"
@@ -24,16 +25,18 @@ services:
       - -c
     volumes:
       - solr_data:/var/solr
+      
   clamd:
-    image: docker.io/clamav/clamav:1.2.3
+    image: docker.io/clamav/clamav:stable
     restart: unless-stopped
     ports:
       - "3310:3310"
     volumes:
       - clam_data:/var/lib/clamav
       - $HOME/.roda_local/data/storage:$HOME/.roda_local/data/storage
+
   siegfried:
-    image: ghcr.io/keeps/siegfried:v1.11.0
+    image: ghcr.io/eterna-earkiv/siegfried:v1.11.4
     restart: unless-stopped
     ports:
       - "5138:5138"
@@ -43,8 +46,26 @@ services:
     volumes:
       - siegfried_data:/root/siegfried/
       - $HOME/.roda_local/data/storage:$HOME/.roda_local/data/storage
+  
+  swagger:
+    image: docker.io/swaggerapi/swagger-ui:latest
+    restart: on-failure
+    ports:
+      - "8081:8080"
+    environment:
+      - URL=http://localhost:8080/api/openapi.json
+      - DOC_EXPANSION=none
+      - VALIDATOR_URL=none
+
+  mailpit:
+    image: axllent/mailpit:v1.24
+    restart: unless-stopped
+    ports:
+      - "1025:1025" # smtp server
+      - "8025:8025" # web ui
+
   openldap:
-    image: docker.io/bitnami/openldap:2.6.8
+    image: docker.io/bitnamilegacy/openldap:2.6
     user: 1001:root
     ports:
       - "1389:1389"
@@ -58,6 +79,7 @@ services:
       - LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,pbkdf2
     volumes:
       - ldap_data:/opt/bitnami/openldap/etc/schema/pbkdf2.ldif
+
 volumes:
   zookeeper_data:
   zookeeper_datalog:

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -1,5 +1,4 @@
 services:
-
   zoo:
     image: ghcr.io/eterna-earkiv/zookeeper:3.9.5
     restart: unless-stopped
@@ -100,7 +99,7 @@ services:
       - CLAMD_TCPADDR=clamd
       - CLAMD_TCPSOCKET=3310
       # SMTP configuration
-      - SMTP_HOST=mailpit
+      - SMTP_HOST=mailserver
       - SMTP_PORT=1025
       - UNOSERVER_HOST=unoserver
       - UNOSERVER_PORT=2003

--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -39,23 +39,6 @@ services:
       - siegfried_data:/root/siegfried/
       - roda_data:/roda/data/
 
-  swagger:
-    image: docker.io/swaggerapi/swagger-ui:v5.13.0
-    restart: on-failure
-    ports:
-      - "8081:8080"
-    environment:
-      - URL=http://localhost:8080/api/openapi.json
-      - DOC_EXPANSION=none
-      - VALIDATOR_URL=none
-
-  mailpit:
-    image: axllent/mailpit:v1.24
-    restart: unless-stopped
-    ports:
-      - "1025:1025" # smtp server
-      - "8025:8025" # web ui
-
   openldap:
     image: docker.io/bitnamilegacy/openldap:2.6
     restart: unless-stopped


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Uppdaterade Docker-bilder för flera tjänster (ZooKeeper, Solr, ClamAV, Siegfried) och bytte OpenLDAP-image till bitnamilegacy.
  * Justerade SMTP-konfiguration så att SMTP_HOST pekar på mailserver i standalone-miljön.
  * Tog bort Swagger och Mailpit från standalone-kompositionen.

* **New Features**
  * Lade till Swagger UI och Mailpit i utvecklingsmiljöer för enklare API- och e-posttestning.
  * Lade till unoserver-tjänst med restart-policy och healthcheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->