### PR TITLE
Fix flickering horizontal scrollbar on data table lists (#605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ETERNA Changelog
 
+## v1.0.1 (unreleased)
+
+#### Bug fixes
+- Fixed flickering horizontal scrollbar on data table list pages (e.g. ingest process); the footer no longer scrolls horizontally with the table [#605](https://github.com/ETERNA-earkiv/ETERNA/issues/605) [#609](https://github.com/ETERNA-earkiv/ETERNA/pull/609)
+
 ## v1.0.0 (2026-06-15)
 
 #### New features

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1635,6 +1635,8 @@ a.btn-hero:visited, a.btn-welcome:visited {
 .my-asyncdatagrid-footer {
     position: sticky;
     left: 0;
+    z-index: 1;
+    background-color: var(--eterna-paper);
 }
 
 /* Representations section */

--- a/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/theme.css
@@ -1627,6 +1627,16 @@ a.btn-hero:visited, a.btn-welcome:visited {
     background: rgba(0,0,0,0.2);
 }
 
+.my-asyncdatagrid-autoupdate-signal {
+    overflow: hidden;
+    position: relative;
+}
+
+.my-asyncdatagrid-footer {
+    position: sticky;
+    left: 0;
+}
+
 /* Representations section */
 
 .representationSection {


### PR DESCRIPTION
Fixes #605.

## Problem
On the "Inleveransprocess" (ingest process) page the horizontal scrollbar under the results table flickers continuously at wider window widths.

## Root cause
The results-table footer (export button, pager, page-size selector and the auto-update signal) lives inside `.my-asyncdatagrid-main-panel`, the element that carries `overflow-x: auto` for horizontally scrollable tables. This caused two problems:

- The auto-update signal renders a continuously spinning Font Awesome icon (`fa-spin`). A rotating element's transformed bounding box contributes to the scroll container's scrollable overflow, so it repeatedly tripped the panel's horizontal scrollbar on and off — a continuous flicker (the behaviour reported in #605).
- When the table was wider than the panel, scrolling it horizontally also scrolled the footer out of view.

## Fix
Three CSS rules in `theme.css`:

- `.my-asyncdatagrid-autoupdate-signal { overflow: hidden; position: relative }` — `overflow: hidden` clips the spinner so its rotation can no longer contribute overflow; `position: relative` makes the signal the containing block for its own absolutely-positioned focus helper input so it stays contained once the footer is sticky.
- `.my-asyncdatagrid-footer { position: sticky; left: 0 }` — pins the footer so only the table scrolls horizontally.

## Notes
These are global styles applied to every `AsyncTableCell` list/table in ETERNA. Verified manually:
- Inleveransprocess: flicker gone, footer stays put on horizontal scroll.
- Arkivbestånd: confirmed no regression scrollbar (an intermediate `position: sticky`-only attempt leaked GWT's hidden focus input; the `position: relative` on the signal resolves that).

Worth a quick look at another list page (Users, Risks, a DIP/representation list) before release, though risk is low.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Minskat flimmer genom förbättrad hantering av auto-uppdateringssignaler i tabellens gränssnitt.
  * Gjort asyncdatagridens sidfot mer stabil vid horisontell scrollning genom “sticky”-positionering, vilket minskar risken för att extra scrollbar/utskick följer med tabellen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->