### PR TITLE
Hide description levels item and file in catalog tree (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.1 (unreleased)
 
 #### Bug fixes
+- Catalog tree no longer shows AIPs at description level `item` or `file` [#604](https://github.com/ETERNA-earkiv/ETERNA/issues/604)
 - Fixed flickering horizontal scrollbar on data table list pages (e.g. ingest process); the footer no longer scrolls horizontally with the table [#605](https://github.com/ETERNA-earkiv/ETERNA/issues/605) [#609](https://github.com/ETERNA-earkiv/ETERNA/pull/609)
 
 ## v1.0.0 (2026-06-15)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreeNode.java
@@ -211,7 +211,8 @@ public class CatalogTreeNode extends Composite {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new SimpleFilterParameter(RodaConstants.AIP_PARENT_ID, aipId),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
@@ -255,7 +256,8 @@ public class CatalogTreeNode extends Composite {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new SimpleFilterParameter(RodaConstants.AIP_ANCESTORS, aipId),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       false)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/CatalogTreePanel.java
@@ -197,7 +197,8 @@ public class CatalogTreePanel extends Composite {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
       new Filter(
         new EmptyKeyFilterParameter(RodaConstants.AIP_PARENT_ID),
-        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
@@ -247,7 +248,9 @@ public class CatalogTreePanel extends Composite {
    */
   private void loadSupplementaryGhostRoots(Set<String> accessibleRootIds, int myGeneration) {
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
-      new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+      new Filter(
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))
@@ -352,7 +355,9 @@ public class CatalogTreePanel extends Composite {
     final int myGeneration = loadGeneration;
     rootsLoading = true;
     FindRequest findRequest = new FindRequest.FindRequestBuilder(
-      new Filter(new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file")),
+      new Filter(
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "file"),
+        new NotSimpleFilterParameter(RodaConstants.AIP_LEVEL, "item")),
       true)
       .withSorter(new Sorter(new SortParameter(RodaConstants.AIP_TITLE_SORT, false)))
       .withSublist(new Sublist(0, TREE_MAX_CHILDREN))


### PR DESCRIPTION
## Summary

The catalog tree ("katalogträdet") displayed AIPs at description levels `item` (**Handling**) and `file` (**Akt**), which should not be visualized in the tree at all.

Every `FindRequest` that populates the tree already excluded level `file`, but none excluded `item` — so item-level nodes still appeared. This adds a second `NotSimpleFilterParameter` excluding `item` alongside the existing `file` exclusion in all five tree-building queries.

Filter parameters are combined with AND in Solr, so both levels are now excluded everywhere the tree is built:

- `CatalogTreeNode` — `loadChildren()`, `loadGhostChildrenFallback()`
- `CatalogTreePanel` — `loadRootNodes()`, `loadSupplementaryGhostRoots()`, `loadFallbackGhostTree()`

## Testing

- `mvn compile` of roda-wui passes.
- Manually verified in the UI: `item`/`file` nodes no longer appear at any level, while higher levels (series, fonds, …) and expansion still work.

Fixes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug fixes**
  * Katalogträdet visar nu inte längre AIP på beskrivningsnivåerna **item** och **file**.
  * Trädets inläsning och kompletterande fallback-hämtning filtrerar bort dessa nivåer mer konsekvent.
  * Detta ger en mer korrekt och renare katalogvy för användare.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->