### PR TITLE
Fix Swedish label 'Start datum' to 'Startdatum' (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.1 (unreleased)
 
 #### Bug fixes
+- Fixed Swedish label "Start datum" → "Startdatum" in the internal actions (job) detail view [#542](https://github.com/ETERNA-earkiv/ETERNA/issues/542)
 - Catalog tree no longer shows AIPs at description level `item` or `file` [#604](https://github.com/ETERNA-earkiv/ETERNA/issues/604)
 - Fixed flickering horizontal scrollbar on data table list pages (e.g. ingest process); the footer no longer scrolls horizontally with the table [#605](https://github.com/ETERNA-earkiv/ETERNA/issues/605) [#609](https://github.com/ETERNA-earkiv/ETERNA/pull/609)
 

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_sv_SE.properties
@@ -773,7 +773,7 @@ jobPriorityLongBadge: {0}
 jobPriorityLongBadge[HIGH]: Hög prioritet
 jobPriorityLongBadge[MEDIUM]: Medium prioritet
 jobPriorityLongBadge[LOW]: Låg prioritet
-jobStartDate: Start datum
+jobStartDate: Startdatum
 jobEndDate: Slutdatum
 jobDuration: Varaktighet
 jobNextScheduledRun: Nästa körning


### PR DESCRIPTION
## Summary

In the internal actions ("Interna åtgärder") job detail view, the Swedish label for the start date was incorrectly split (särskrivning): **"Start datum"** instead of **"Startdatum"**.

Fixed the `jobStartDate` translation in `ClientMessages_sv_SE.properties` to one word, matching the adjacent `jobEndDate` label "Slutdatum".

## Testing

Text-only translation change; no build/logic impact.

Fixes #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Förbättrade svensk översättning i gränssnittet genom att korrigera etiketten från “Start datum” till “Startdatum” för interna jobb.
  * Uppdaterade dokumentationen så att samma språkkorrigering nu är noterad i ändringsloggen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->