### PR TITLE
Hide plugin license button when no license file exists (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.1 (unreleased)
 
 #### Bug fixes
+- License button on built-in plugins (archive maintenance jobs) is now hidden when no license file exists, instead of opening an empty dialog [#366](https://github.com/ETERNA-earkiv/ETERNA/issues/366)
 - Fixed Swedish label "Start datum" → "Startdatum" in the internal actions (job) detail view [#542](https://github.com/ETERNA-earkiv/ETERNA/issues/542)
 - Catalog tree no longer shows AIPs at description level `item` or `file` [#604](https://github.com/ETERNA-earkiv/ETERNA/issues/604)
 - Fixed flickering horizontal scrollbar on data table list pages (e.g. ingest process); the footer no longer scrolls horizontally with the table [#605](https://github.com/ETERNA-earkiv/ETERNA/issues/605) [#609](https://github.com/ETERNA-earkiv/ETERNA/pull/609)

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
@@ -967,8 +967,12 @@ public class PluginManager {
     PluginInfo pluginInfo = getPluginInfo(plugin.getClass().getName());
     pluginInfo.setInstalled(true);
     pluginInfo.setVerified(true);
-    pluginInfo.setHasLicenseFile(true);
-    pluginInfo.setLicenseFilePath(RodaConstants.CORE_LICENSE_MARKDOWN_FILE);
+    // Only advertise a license file when the internal LICENSE.md theme resource actually exists;
+    if (RodaCoreFactory.getConfigurationFile(
+      RodaConstants.CORE_THEME_FOLDER + "/" + RodaConstants.CORE_LICENSE_MARKDOWN_FILE) != null) {
+      pluginInfo.setHasLicenseFile(true);
+      pluginInfo.setLicenseFilePath(RodaConstants.CORE_LICENSE_MARKDOWN_FILE);
+    }
     processAndCachePluginInformation(plugin, pluginInfo);
   }
 


### PR DESCRIPTION
## Summary

Several built-in archive maintenance jobs ("Arkivvårdsjobb") showed a "License" button that opened an **empty** dialog. The button should not appear when no license file exists.

### Root cause

Built-in/internal plugins are registered via the single-arg `PluginManager.processAndCachePluginInformation(Plugin<T>)`, which unconditionally set `hasLicenseFile=true` and `licenseFilePath="LICENSE.md"` — with no existence check. The client renders the license button whenever `hasLicenseFile()` is true and resolves the INTERNAL resource to `theme/LICENSE.md`, which is not shipped, so `ThemeService` serves empty content → empty dialog.

By contrast, `loadPluginResources()` (for JAR plugins) correctly guards the flag with `Files.exists(...)`, and documentation is deliberately not set in the single-arg path — which is why the documentation button behaves correctly but the license button did not.

### Fix

Only set `hasLicenseFile`/`licenseFilePath` when the internal `theme/LICENSE.md` resource actually exists, using the same authoritative lookup `ThemeService` uses (`RodaCoreFactory.getConfigurationFile("theme/LICENSE.md")`). No client change needed — the button is already gated on `hasLicenseFile()`. If an operator later adds `theme/LICENSE.md`, the button reappears for built-in plugins.

## Testing

- `mvn compile` of roda-core passes.
- Manually verified: with no `theme/LICENSE.md`, the license button no longer appears on built-in plugins; documentation button and external market license links are unaffected.

Fixes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Licensknappen för inbyggda plugins visas nu bara när en licensfil faktiskt finns.
  * Tidigare kunde en tom dialog öppnas utan licensfil; detta beteende är nu borttaget.
  * Changelog har uppdaterats med denna rättning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->